### PR TITLE
Parser overlapping rules

### DIFF
--- a/lib/flexer/src/main/scala/org/enso/flexer/CodeGen.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/CodeGen.scala
@@ -1,14 +1,17 @@
 package org.enso.flexer
 
+import org.enso.flexer.State.StateDesc
+
 import scala.annotation.tailrec
+import scala.collection.mutable
 import scala.reflect.runtime.universe._
 
 case class CodeGen(dfa: DFA) {
 
-  var code = q""
+  var code    = q""
+  val offsets = mutable.Map(0 -> 0)
 
-  case class Branch(rangeEnd: Int, target: BranchTarget)
-  case class BranchTarget(state: Int, code: Option[Tree])
+  case class Branch(rangeEnd: Int, targetState: Int)
 
   def cleanBranches(revInput: List[Branch]): List[Branch] = {
     @tailrec def go(rIn: List[Branch], out: List[Branch]): List[Branch] =
@@ -17,40 +20,59 @@ case class CodeGen(dfa: DFA) {
         case i :: is =>
           out match {
             case Nil => go(is, i :: Nil)
-            case o :: os =>
-              if (o.target == i.target) go(is, out)
+            case o :: _ =>
+              if (o.targetState == i.targetState) go(is, out)
               else go(is, i :: out)
           }
       }
     go(revInput, Nil)
   }
 
-  def genBranches(branches: List[Branch]): Tree = {
+  def genBranches(
+    branches: List[Branch],
+    maybeState: Option[StateDesc],
+    offset: Int
+  ): Tree = {
     branches.foldLeft(identity[Tree] _) {
       case (ifBlock, branch) =>
         elseBody =>
-          val body = branch.target match {
-            case BranchTarget(-1, None)        => q"-2"
-            case BranchTarget(-1, Some(block)) => q"{..$block; -1}"
-            case BranchTarget(st, _)           => q"${Literal(Constant(st))}"
+          val body = (branch.targetState, maybeState, offset) match {
+            case (-1, None, _)        => q"-2"
+            case (-1, Some(state), 0) => q"{..${state.code}; -1}"
+            case (-1, Some(state), o) => q"""{
+              offset = offset - ${Literal(Constant(o))}
+              currentChar = buffer(offset) 
+              ..${state.code}
+              -1
+            }"""
+            case (targetState, Some(state), _) =>
+              if (!dfa.endStatePriorityMap.contains(targetState)) {
+                dfa.endStatePriorityMap += targetState -> state
+                offsets += targetState -> (offset + 1)
+              }
+              q"${Literal(Constant(targetState))}"
+            case (targetState, _, _) =>
+              q"${Literal(Constant(targetState))}"
           }
-          ifBlock(q"if (codePoint <= ${branch.rangeEnd}) $body else $elseBody")
+          ifBlock(
+            q"if (codePoint <= ${branch.rangeEnd}) $body else $elseBody"
+          )
     }(q"-2")
   }
 
   def generateStateMatch(): Tree = {
-    val branches = dfa.links.indices.toList.map { state =>
-      var revBranches: List[Branch] = Nil
-      for ((range, vocIx) <- dfa.vocabulary.iter) {
-        val targetState  = dfa.links(state)(vocIx)
-        val p1           = dfa.endStatePriorityMap.get(state)
-        val branchTarget = BranchTarget(targetState, p1.map(_.code))
-        revBranches ::= Branch(range.end, branchTarget)
-      }
+    val branches = dfa.links.indices.toList.map { stateIx =>
+      val state = dfa.endStatePriorityMap.get(stateIx)
+      val revBranches: List[Branch] =
+        dfa.vocabulary.iter.foldLeft(List[Branch]()) {
+          case (list, (range, vocIx)) =>
+            val targetState = dfa.links(stateIx)(vocIx)
+            Branch(range.end, targetState) :: list
+        }
 
       val branches = cleanBranches(revBranches)
 
-      cq"$state => ${genBranches(branches)}"
+      cq"$stateIx => ${genBranches(branches, state, offsets.getOrElse(stateIx, 0))}"
     }
     Match(q"state", branches)
   }

--- a/lib/flexer/src/main/scala/org/enso/flexer/Group.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/Group.scala
@@ -43,24 +43,17 @@ class Group(val groupIx: Int, val finish: () => Unit) {
     nfa
   }
 
-  def buildRuleAutomata(
-    nfa: NFA,
-    previous: Int,
-    ruleIx: Int,
-    rule: Rule
-  ): Int = {
-    val end           = buildExprAutomata(nfa, previous, rule.expr)
-    val resultCompute = q"currentMatch = matchBuilder.result()"
-    val ruleEval      = ruleName(ruleIx)
-    val code          = q"{$resultCompute; $ruleEval()}"
+  def buildRuleAutomata(nfa: NFA, last: Int, ruleIx: Int, rule: Rule): Int = {
+    val end          = buildExprAutomata(nfa, last, rule.expr)
+    val currentMatch = q"currentMatch = matchBuilder.result()"
     nfa.state(end).end  = true
-    nfa.state(end).code = code
+    nfa.state(end).code = q"{$currentMatch; ${ruleName(ruleIx)}()}"
     end
   }
 
-  def buildExprAutomata(nfa: NFA, previous: Int, expr: Pattern): Int = {
+  def buildExprAutomata(nfa: NFA, last: Int, expr: Pattern): Int = {
     val current = nfa.addState()
-    nfa.link(previous, current)
+    nfa.link(last, current)
     expr match {
       case None_ => nfa.addState()
       case Pass  => current

--- a/lib/flexer/src/main/scala/org/enso/flexer/Pattern.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/Pattern.scala
@@ -20,3 +20,21 @@ case class Or(left: Pattern, right: Pattern) extends Pattern
 case class Seq_(first: Pattern, second: Pattern) extends Pattern
 
 case class Many(body: Pattern) extends Pattern
+
+object Pattern {
+  def range(start: Char, end: Char): Pattern = Ran(start, end)
+  def range(start: Int, end: Int):   Pattern = Ran(start, end)
+  def char(c: Char):                 Pattern = range(c, c)
+
+  class ExtendedChar(_this: Char) {
+    final def ||(that: Char): Pattern =
+      Or(char(_this), char(that))
+  }
+
+  implicit def charToExpr(char: Char): Pattern =
+    Ran(char, char)
+  implicit def stringToExpr(s: String): Pattern =
+    s.tail.foldLeft(char(s.head))(_ >> _)
+  implicit def extendChar(i: Char): ExtendedChar =
+    new ExtendedChar(i)
+}

--- a/lib/flexer/src/main/scala/org/enso/flexer/Vocabulary.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/Vocabulary.scala
@@ -12,17 +12,14 @@ class Vocabulary {
     divisions = divisions + (range.end + 1)
   }
 
-  def size(): Int = divisions.size - 1
+  def size: Int = divisions.size - 1
 
   override def toString: String =
     "Vocabulary(" + divisions.toList.map(_.toString).mkString(",") + ")"
 
   def iter[U]: Iterator[(Range, Int)] = {
-    var lastDiv = 0
-    for ((i, ix) <- divisions.iterator.drop(1).zipWithIndex) yield {
-      val r = (Range(lastDiv, i - 1), ix)
-      lastDiv = i
-      r
+    divisions.iterator.zip(divisions.iterator.drop(1)).zipWithIndex.map {
+      case ((start, end), ix) => (Range(start, end - 1), ix)
     }
   }
 }

--- a/syntax/parser/src/main/scala/org/enso/parser/Parser.scala
+++ b/syntax/parser/src/main/scala/org/enso/parser/Parser.scala
@@ -1,6 +1,7 @@
 package org.enso.parser
 
 import org.enso.flexer._
+import org.enso.flexer.Pattern._
 import org.enso.parser.AST.AST
 
 import scala.reflect.runtime.universe._
@@ -9,20 +10,6 @@ import scala.annotation.tailrec
 
 case class Parser() extends ParserBase[AST] {
 
-  implicit final def charToExpr(char: Char): Pattern =
-    Ran(char, char)
-  implicit final def stringToExpr(s: String): Pattern =
-    s.tail.foldLeft(char(s.head))(_ >> _)
-
-  class ExtendedChar(_this: Char) {
-    final def ||(that: Char): Pattern =
-      Or(char(_this), char(that))
-  }
-  implicit final def extendChar(i: Char): ExtendedChar = new ExtendedChar(i)
-  final def char(c: Char):                Pattern      = range(c, c)
-  final def range(start: Char, end: Char): Pattern =
-    Ran(start, end)
-  final def range(start: Int, end: Int): Pattern = Ran(start, end)
   val any: Pattern  = range(5, Int.MaxValue) // FIXME 5 -> 0
   val pass: Pattern = Pass
   val eof: Pattern  = char('\0')

--- a/syntax/runner/src/test/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/runner/src/test/scala/org/enso/syntax/text/Parser.scala
@@ -9,7 +9,7 @@ import org.scalatest._
 
 class LexerSpec extends FlatSpec with Matchers {
 
-  val parserCons = Macro.compile(new Parser())
+  val parserCons = Macro.compile(Parser)
 
   def parse(input: String) = {
     val parser = parserCons()

--- a/syntax/runner/src/test/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/runner/src/test/scala/org/enso/syntax/text/Parser.scala
@@ -9,7 +9,7 @@ import org.scalatest._
 
 class LexerSpec extends FlatSpec with Matchers {
 
-  val parserCons = Macro.compile(Parser)
+  val parserCons = Macro.compile(new Parser())
 
   def parse(input: String) = {
     val parser = parserCons()


### PR DESCRIPTION
### Pull Request Description
Previously, when two rules overlapped - like: `"a"` and `"abc"`, then `"a"` would not get triggered on any input of the form `"ab{not c}"`. This pull request solves this.

The logic sits in `CodeGen`.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] The code has been tested where possible.

