### PR TITLE
Support for raw and multi-line strings.

### DIFF
--- a/lib/flexer/src/main/scala/org/enso/flexer/CodeGen.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/CodeGen.scala
@@ -102,7 +102,7 @@ case class CodeGen(dfa: DFA) {
   def generate(i: Int): Tree = {
     def states =
       dfa.links.indices.toList
-        .map(st => (st, TermName(s"group${i}_state$st")))
+        .map(st => (st, TermName(s"state${i}_${st}")))
 
     val cases = states.map {
       case (st, fun) => cq"$st => $fun"
@@ -111,20 +111,8 @@ case class CodeGen(dfa: DFA) {
       case (st, fun) => q"def $fun = {${generateCaseBody(st)}}"
     }
     q"""
-      def ${TermName(s"runGroup$i")}(): Int = {
-        var state: Int = 0
-        matchBuilder.setLength(0)
-        while(state >= 0) {
-          state = ${Match(q"state", cases)}
-          if(state >= 0) {
-            matchBuilder.append(buffer(offset))
-            if (buffer(offset).isHighSurrogate)
-              matchBuilder.append(buffer(offset+1))
-            codePoint = getNextCodePoint()
-          }
-        }
-        state
-      }
+      groups($i) = ${TermName(s"nextState$i")}
+      def ${TermName(s"nextState$i")}(state: Int): Int = ${Match(q"state", cases)}
       ..$bodies
     """
   }

--- a/lib/flexer/src/main/scala/org/enso/flexer/CodeGen.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/CodeGen.scala
@@ -19,24 +19,24 @@ case class CodeGen(dfa: DFA) {
     trgState: Int,
     maybeState: Option[StateDesc],
     rulesOverlap: Boolean
-                   ): Tree = (trgState, maybeState, rulesOverlap) match {
-      case (-1, None, _)            => q"-2"
-      case (-1, Some(state), false) => q"call(${state.rule})"
-      case (-1, Some(state), true) => q"rewindThenCall(${state.rule})"
+  ): Tree = (trgState, maybeState, rulesOverlap) match {
+    case (-1, None, _)            => q"-2"
+    case (-1, Some(state), false) => q"call(${state.rule})"
+    case (-1, Some(state), true)  => q"rewindThenCall(${state.rule})"
 
-      case (targetState, _, _) =>
-        val rulesOverlap_ = maybeState match {
-          case Some(state) if !dfa.endStatePriorityMap.contains(targetState) =>
-            dfa.endStatePriorityMap += targetState -> state
-            stateHasOverlappingRules += targetState -> true
-            true
-          case _ => false
-        }
-        if (rulesOverlap || rulesOverlap_)
-          q"charsToLastRule += charSize; ${Literal(Constant(targetState))}"
-        else
-          q"${Literal(Constant(targetState))}"
-    }
+    case (targetState, _, _) =>
+      val rulesOverlap_ = maybeState match {
+        case Some(state) if !dfa.endStatePriorityMap.contains(targetState) =>
+          dfa.endStatePriorityMap += targetState -> state
+          stateHasOverlappingRules += targetState -> true
+          true
+        case _ => false
+      }
+      if (rulesOverlap || rulesOverlap_)
+        q"charsToLastRule += charSize; ${Literal(Constant(targetState))}"
+      else
+        q"${Literal(Constant(targetState))}"
+  }
 
   def genSwitch(branchs: Seq[Branch]): Seq[CaseDef] = {
     branchs.map {

--- a/lib/flexer/src/main/scala/org/enso/flexer/CodeGen.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/CodeGen.scala
@@ -19,11 +19,10 @@ case class CodeGen(dfa: DFA) {
     trgState: Int,
     maybeState: Option[StateDesc],
     rulesOverlap: Boolean
-  ): Tree = {
-    (trgState, maybeState, rulesOverlap) match {
+                   ): Tree = (trgState, maybeState, rulesOverlap) match {
       case (-1, None, _)            => q"-2"
-      case (-1, Some(state), false) => q"..${state.code}; -1"
-      case (-1, Some(state), true)  => q"rewindToLastRule(); ..${state.code}; -1"
+      case (-1, Some(state), false) => q"call(${state.rule})"
+      case (-1, Some(state), true) => q"rewindThenCall(${state.rule})"
 
       case (targetState, _, _) =>
         val rulesOverlap_ = maybeState match {
@@ -38,7 +37,6 @@ case class CodeGen(dfa: DFA) {
         else
           q"${Literal(Constant(targetState))}"
     }
-  }
 
   def genSwitch(branchs: Seq[Branch]): Seq[CaseDef] = {
     branchs.map {

--- a/lib/flexer/src/main/scala/org/enso/flexer/Group.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/Group.scala
@@ -44,7 +44,7 @@ class Group(val groupIx: Int, val finish: () => Unit) {
   }
 
   def buildRuleAutomata(nfa: NFA, last: Int, ruleIx: Int, rule: Rule): Int = {
-    val end          = buildExprAutomata(nfa, last, rule.expr)
+    val end = buildExprAutomata(nfa, last, rule.expr)
     nfa.state(end).end  = true
     nfa.state(end).rule = ruleName(ruleIx)
     end
@@ -85,15 +85,11 @@ class Group(val groupIx: Int, val finish: () => Unit) {
   def generate(): Tree = {
     val nfa = buildAutomata()
     nfa.computeIsos()
-    val dfa  = nfa.computeDFA()
-    var code = CodeGen(dfa).generate(groupIx)
-
-    code =
-      q"{..$code; groups(${Literal(Constant(groupIx))}) = () => ${TermName(s"runGroup$groupIx")}()}"
-    allRules.zipWithIndex.foreach {
-      case (rule, ruleIx) =>
-        code = q"..$code; def ${ruleName(ruleIx)}() = ${rule.fn}"
+    val dfa   = nfa.computeDFA()
+    val state = CodeGen(dfa).generate(groupIx)
+    val rules = allRules.zipWithIndex.map {
+      case (rule, ruleIx) => q"def ${ruleName(ruleIx)}() = ${rule.fn}"
     }
-    code
+    q"..$state; ..$rules"
   }
 }

--- a/lib/flexer/src/main/scala/org/enso/flexer/Group.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/Group.scala
@@ -45,9 +45,8 @@ class Group(val groupIx: Int, val finish: () => Unit) {
 
   def buildRuleAutomata(nfa: NFA, last: Int, ruleIx: Int, rule: Rule): Int = {
     val end          = buildExprAutomata(nfa, last, rule.expr)
-    val currentMatch = q"currentMatch = matchBuilder.result()"
     nfa.state(end).end  = true
-    nfa.state(end).code = q"{$currentMatch; ${ruleName(ruleIx)}()}"
+    nfa.state(end).rule = ruleName(ruleIx)
     end
   }
 

--- a/lib/flexer/src/main/scala/org/enso/flexer/NFA.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/NFA.scala
@@ -192,7 +192,7 @@ class NFA {
         nfaEndStatePriorityMap.get(iso) match {
           case None =>
           case Some(p) =>
-            dfaEndStatePriorityMap += dfaIx -> StateDesc(p, state(iso).code)
+            dfaEndStatePriorityMap += dfaIx -> StateDesc(p, state(iso).rule)
         }
       }
 

--- a/lib/flexer/src/main/scala/org/enso/flexer/ParserBase.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/ParserBase.scala
@@ -81,6 +81,7 @@ trait ParserBase[T] {
     var state: Int = 0
     matchBuilder.setLength(0)
     while(state >= 0) {
+      logger.log(s"Step: group $group, state $state, code $codePoint, char $currentChar")
       state = nextState(state)
       if(state >= 0) {
         matchBuilder.append(buffer(offset))
@@ -126,8 +127,10 @@ trait ParserBase[T] {
       else String.valueOf(ch)
   }
   def getNextCodePoint(): Int = {
-    if (offset >= bufferLen)
+    if (offset >= bufferLen) {
+      logger.log("Next char ETX.")
       return etxChar.toInt
+    }
     offset += charSize
     if (offset > BUFFERSIZE - UTFCHARSIZE) {
       val keepChars = Math.max(charsToLastRule, currentMatch.length) + UTFCHARSIZE - 1
@@ -143,9 +146,8 @@ trait ParserBase[T] {
     Character.codePointAt(buffer, offset)
   }
 
-  final def rewind(): Unit = logger.trace {
+  final def rewind(): Unit =
     rewind(currentMatch.length)
-  }
 
   final def rewind(i: Int): Unit = logger.trace {
     offset -= i
@@ -164,6 +166,8 @@ trait ParserBase[T] {
     rule()
     -1
   }
+
+  final def currentChar: String = new String(Character.toChars(codePoint))
 
   final def charSize: Int =
     if (offset >= 0 && buffer(offset).isHighSurrogate) 2 else 1

--- a/lib/flexer/src/main/scala/org/enso/flexer/ParserBase.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/ParserBase.scala
@@ -26,7 +26,7 @@ trait ParserBase[T] {
   var matchBuilder = new StringBuilder(64)
   var currentMatch = ""
 
-  val groups: Array[Int=>Int] = new Array(256)
+  val groups: Array[Int => Int] = new Array(256)
 
   val logger = new Logger()
 
@@ -39,8 +39,7 @@ trait ParserBase[T] {
     bufferLen = if (numRead == -1) 1 else numRead + 1
     codePoint = getNextCodePoint()
 
-    var r = -1; while (r == -1)
-      r = runGroup()
+    var r = -1; while (r == -1) r = runGroup()
 
     getResult() match {
       case None => InternalFailure(offset)
@@ -77,16 +76,16 @@ trait ParserBase[T] {
   }
 
   def runGroup(): Int = {
-    val nextState = groups(group)
+    val nextState  = groups(group)
     var state: Int = 0
     matchBuilder.setLength(0)
-    while(state >= 0) {
-      logger.log(s"Step: group $group, state $state, code $codePoint, char $currentChar")
+    while (state >= 0) {
+      logger.log(s"Step: state $group $state, code $codePoint ($currentChar)")
       state = nextState(state)
-      if(state >= 0) {
+      if (state >= 0) {
         matchBuilder.append(buffer(offset))
         if (buffer(offset).isHighSurrogate)
-          matchBuilder.append(buffer(offset+1))
+          matchBuilder.append(buffer(offset + 1))
         codePoint = getNextCodePoint()
       }
     }
@@ -127,10 +126,8 @@ trait ParserBase[T] {
       else String.valueOf(ch)
   }
   def getNextCodePoint(): Int = {
-    if (offset >= bufferLen) {
-      logger.log("Next char ETX.")
+    if (offset >= bufferLen)
       return etxChar.toInt
-    }
     offset += charSize
     if (offset > BUFFERSIZE - UTFCHARSIZE) {
       val keepChars = Math.max(charsToLastRule, currentMatch.length) + UTFCHARSIZE - 1
@@ -142,7 +139,6 @@ trait ParserBase[T] {
       bufferLen = keepChars + numRead
     } else if (offset == bufferLen)
       return eofChar.toInt
-    logger.log(s"Next char '${escapeChar(buffer(offset))}'")
     Character.codePointAt(buffer, offset)
   }
 
@@ -161,7 +157,7 @@ trait ParserBase[T] {
   }
 
   final def call(rule: () => Unit): Int = {
-    currentMatch = matchBuilder.result()
+    currentMatch    = matchBuilder.result()
     charsToLastRule = 0
     rule()
     -1

--- a/lib/flexer/src/main/scala/org/enso/flexer/ParserBase.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/ParserBase.scala
@@ -141,14 +141,21 @@ trait ParserBase[T] {
     codePoint = getNextCodePoint()
   }
 
-  final def rewindToLastRule(): Unit = logger.trace {
-    logger.log(s"RETREAT $charsToLastRule")
-    rewind(charsToLastRule)
+  final def rewindThenCall(rule: () => Unit): Int = {
+    rewind(charsToLastRule + 1)
+    matchBuilder.setLength(matchBuilder.length - charsToLastRule)
+    call(rule)
+  }
+
+  final def call(rule: () => Unit): Int = {
+    currentMatch = matchBuilder.result()
     charsToLastRule = 0
+    rule()
+    -1
   }
 
   final def charSize: Int =
-    if (buffer(offset).isHighSurrogate) 2 else 1
+    if (offset >= 0 && buffer(offset).isHighSurrogate) 2 else 1
 
   def debugGeneratedOutput: Seq[Tree] = groupsx.map(_.generate())
 }

--- a/lib/flexer/src/main/scala/org/enso/flexer/State.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/State.scala
@@ -14,13 +14,13 @@ class State {
 
   var start  = false
   var end    = false
-  var code   = q""
+  var rule = TermName("")
   val links2 = RangeMap[Int, Int, Ordering.Int.type]()
 }
 
 object State {
 
-  case class StateDesc(priority: Int, code: Tree)
+  case class StateDesc(priority: Int, rule: TermName)
 
   trait IsoComputeState
 

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -409,6 +409,9 @@ object AST {
         if (rawSegments.isEmpty) return rawSegments
         var last = rawSegments.head
         for (s <- rawSegments.tail :+ EOL()) yield (last, s) match {
+          case (EOL(_), segment) if indent == 0 =>
+            last = segment
+            EOL()
           case (EOL(_), Plain(txt))
               if txt.takeWhile(_ == ' ').length >= indent =>
             last = Plain(txt.drop(indent))
@@ -466,10 +469,6 @@ object AST {
 
       final case class EOL(validIndent: Boolean = true) extends Raw {
         val repr = "\n"
-      }
-
-      final case class Line(segments: List[Segment]) extends Raw {
-        val repr = R + segments + "\n"
       }
 
       final case class Interpolation(value: Option[AST]) extends Interpolated {

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -367,6 +367,9 @@ object AST {
       val repr     = R + quoteRepr + segments + quoteRepr
       def _dup(quote: Quote, segments: List[Segment]): Interpolated =
         copy(quote, segments)
+
+      def raw: Text.Raw =
+        Raw(quote, segments.map(s => Segment.Plain(s.repr.show())))
     }
 
     final case class Raw(quote: Text.Quote, segments: List[Raw.Segment])
@@ -380,6 +383,12 @@ object AST {
 
     object Raw {
       trait Segment extends Text.Interpolated.Segment
+
+      def apply():                      Raw = Raw(Quote.Single, Nil)
+      def apply(q: Quote):              Raw = Raw(q, Nil)
+      def apply(q: Quote, s: Segment*): Raw = Raw(q, s.to[List])
+      def apply(s: List[Segment]):      Raw = Raw(Quote.Single, s)
+      def apply(s: Segment*):           Raw = Raw(s.to[List])
     }
 
     object Interpolated {
@@ -410,7 +419,7 @@ object AST {
       type Raw          = Text.Raw.Segment
       type Interpolated = Text.Interpolated.Segment
 
-      final case class Plain(value: String) extends Raw {
+      final case class Plain private (value: String) extends Raw {
         val repr = value
       }
 
@@ -421,7 +430,7 @@ object AST {
       trait Escape extends Interpolated
       val Escape = text.Escape
 
-      implicit def fromString(str: String): Segment.Plain = Segment.Plain(str)
+      implicit def fromString(str: String): Plain = Plain(str)
     }
 
     //// Unclosed ////

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -405,16 +405,16 @@ object AST {
 
     object MultiLine {
 
-      def preprocess(indent: Int, rawSegments: List[Segment]): List[Segment] = {
+      def stripOffset(offset: Int, rawSegments: List[Segment]): List[Segment] = {
         if (rawSegments.isEmpty) return rawSegments
         var last = rawSegments.head
         for (s <- rawSegments.tail :+ EOL()) yield (last, s) match {
-          case (EOL(_), segment) if indent == 0 =>
+          case (EOL(_), segment) if offset == 0 =>
             last = segment
             EOL()
           case (EOL(_), Plain(txt))
-              if txt.takeWhile(_ == ' ').length >= indent =>
-            last = Plain(txt.drop(indent))
+              if txt.takeWhile(_ == ' ').length >= offset =>
+            last = Plain(txt.drop(offset))
             EOL()
           case (EOL(_), segment) =>
             last = segment

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/ParserDef.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/ParserDef.scala
@@ -444,12 +444,6 @@ case class ParserDef() extends ParserBase[AST] {
     rewind()
   }
 
-  final def fixme_onTextDoubleQuote(): Unit = logger.trace {
-    currentMatch = "'"
-    onTextQuote(Text.Quote.Single)
-    rewind(1)
-  }
-
   val stringChar    = noneOf("'`\"\n\\")
   val stringSegment = stringChar.many1
   val escape_int    = "\\" >> decimal
@@ -462,12 +456,10 @@ case class ParserDef() extends ParserBase[AST] {
 
   // format: off
   NORMAL rule "'"           run reify { onTextBegin(ast.Text.Quote.Single) }
-  NORMAL rule "''"          run reify { submitEmptyText(ast.Text.Quote.Single) } // FIXME: Remove after fixing DFA Gen
   NORMAL rule "'''"         run reify { onTextBegin(ast.Text.Quote.Triple) }
   NORMAL rule '`'           run reify { onInterpolateEnd() }
   TEXT   rule '`'           run reify { onInterpolateBegin() }
   TEXT   rule "'"           run reify { onTextQuote(ast.Text.Quote.Single) }
-  TEXT   rule "''"          run reify { fixme_onTextDoubleQuote() } // FIXME: Remove after fixing DFA Gen
   TEXT   rule "'''"         run reify { onTextQuote(ast.Text.Quote.Triple) }
   TEXT   rule stringSegment run reify { onPlainTextSegment() }
   TEXT   rule eof           run reify { onTextEOF() }

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/ParserDef.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/ParserDef.scala
@@ -345,7 +345,7 @@ case class ParserDef() extends ParserBase[AST] {
     if (singleLine || currentBlock.firstLine.isDefined || result.isDefined)
       txt
     else {
-      val segs = Text.MultiLine.preprocess(currentBlock.indent, txt.segments)
+      val segs = Text.MultiLine.stripOffset(currentBlock.indent, txt.segments)
       Text.MultiLine(currentBlock.indent, txt.quoteChar, txt.quote, segs)
     }
   }

--- a/syntax/specialization/src/bench/scala/org/enso/syntax/Parser.scala
+++ b/syntax/specialization/src/bench/scala/org/enso/syntax/Parser.scala
@@ -1,7 +1,6 @@
 package org.enso.syntax
 
-import org.enso.flexer.Macro
-import org.enso.syntax.text.ParserDef
+import org.enso.syntax.text.Parser
 import org.scalameter.api._
 
 import scala.math.pow
@@ -24,16 +23,14 @@ object ParserBenchmark extends Bench.OfflineRegressionReport {
                                             | fib  n = fib n-1 + fib n-2
                                             """.stripMargin * i
 
-  val newParser = Macro.compile(ParserDef)
-
   performance of "parser" in {
-    measure method "variable" in (using(variable) in (newParser().run(_)))
-    measure method "text" in (using(text) in (newParser().run(_)))
-    measure method "number" in (using(number) in (newParser().run(_)))
-    measure method "calls" in (using(calls) in (newParser().run(_)))
-    measure method "codeBlock" in (using(codeBlock) in (newParser().run(_)))
-    measure method "openParens" in (using(openParens) in (newParser().run(_)))
-    measure method "clsdParens" in (using(clsdParens) in (newParser().run(_)))
-    measure method "allRules" in (using(allRules) in (newParser().run(_)))
+    measure method "variable" in (using(variable) in (Parser.run(_)))
+    measure method "text" in (using(text) in (Parser.run(_)))
+    measure method "number" in (using(number) in (Parser.run(_)))
+    measure method "calls" in (using(calls) in (Parser.run(_)))
+    measure method "codeBlock" in (using(codeBlock) in (Parser.run(_)))
+    measure method "openParens" in (using(openParens) in (Parser.run(_)))
+    measure method "clsdParens" in (using(clsdParens) in (Parser.run(_)))
+    measure method "allRules" in (using(allRules) in (Parser.run(_)))
   }
 }

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -23,6 +23,8 @@ class Parser {
 object Parser {
   type Result[T] = flexer.Result[T]
   private val newEngine = compile(text.ParserDef)
+
+  def run(input: String): Result[AST.Module] = new Parser().run(input)
 }
 
 //////////////

--- a/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
@@ -10,13 +10,8 @@ import org.enso.syntax.text.AST.Text.Segment.{EOL, Plain}
 
 class ParserSpec extends FlatSpec with Matchers {
 
-  def parse(input: String) = {
-    val parser = new Parser()
-    parser.run(input)
-  }
-
   def assertModule(input: String, result: AST): Assertion = {
-    val tt = parse(input)
+    val tt = Parser.run(input)
     tt match {
       case Flexer.Success(value, offset) =>
         assert(value == result)
@@ -26,7 +21,7 @@ class ParserSpec extends FlatSpec with Matchers {
   }
 
   def assertExpr(input: String, result: AST): Assertion = {
-    val tt = parse(input)
+    val tt = Parser.run(input)
     tt match {
       case Flexer.Success(value, offset) =>
         val module = value.asInstanceOf[Module]
@@ -65,108 +60,108 @@ class ParserSpec extends FlatSpec with Matchers {
   //// Identifiers ////
   /////////////////////
 
-  "_"      ?= "_"
-  "Name"   ?= "Name"
-  "name"   ?= "name"
-  "name'"  ?= "name'"
-  "name''" ?= "name''"
-  "name'a" ?= Ident.InvalidSuffix("name'", "a")
-  "name_"  ?= "name_"
-  "name_'" ?= "name_'"
-  "name'_" ?= Ident.InvalidSuffix("name'", "_")
-  "name`"  ?= "name" $ Unrecognized("`")
-
-  ///////////////////
-  //// Operators ////
-  ///////////////////
-
-  "++"   ?= "++"
-  "="    ?= "="
-  "=="   ?= "=="
-  ":"    ?= ":"
-  ","    ?= ","
-  "."    ?= "."
-  ".."   ?= ".."
-  "..."  ?= "..."
-  ">="   ?= ">="
-  "<="   ?= "<="
-  "/="   ?= "/="
-  "+="   ?= Opr.Mod("+")
-  "-="   ?= Opr.Mod("-")
-  "==="  ?= Ident.InvalidSuffix("==", "=")
-  "...." ?= Ident.InvalidSuffix("...", ".")
-  ">=="  ?= Ident.InvalidSuffix(">=", "=")
-  "+=="  ?= Ident.InvalidSuffix("+", "==")
-
-  /////////////////////
-  //// Expressions ////
-  /////////////////////
-
-  "a b"           ?= ("a" $_ "b")
-  "a +  b"        ?= ("a" $_ "+") $__ "b"
-  "a + b + c"     ?= ("a" $_ "+" $_ "b") $_ "+" $_ "c"
-  "a , b , c"     ?= "a" $_ "," $_ ("b" $_ "," $_ "c")
-  "a + b * c"     ?= "a" $_ "+" $_ ("b" $_ "*" $_ "c")
-  "a * b + c"     ?= ("a" $_ "*" $_ "b") $_ "+" $_ "c"
-  "a+ b"          ?= ("a" $ "+") $$_ "b"
-  "a +b"          ?= "a" $_ ("+" $ "b")
-  "a+ +b"         ?= ("a" $ "+") $$_ ("+" $ "b")
-  "*a+"           ?= ("*" $ "a") $ "+"
-  "+a*"           ?= "+" $ ("a" $ "*")
-  "+ <$> a <*> b" ?= ("+" $_ "<$>" $_ "a") $_ "<*>" $_ "b"
-  "+ * ^"         ?= App.Right("+", 1, App.Right("*", 1, "^"))
-  "+ ^ *"         ?= App.Right("+", 1, App.Left("^", 1, "*"))
-  "^ * +"         ?= App.Left(App.Left("^", 1, "*"), 1, "+")
-  "* ^ +"         ?= App.Left(App.Right("*", 1, "^"), 1, "+")
-  "^ + *"         ?= App.Infix("^", 1, "+", 1, "*")
-  "* + ^"         ?= App.Infix("*", 1, "+", 1, "^")
-
-  //  "a+b"    ?=
-  //  "()"        ?= "(" $ ")" // Group()
-  //  "(())"      ?= "(" $ "(" $ ")" $ ")" // Group(Group())
-  //  "(()"       ?= "(" $ "(" $ ")" // Group.Unclosed(Group())
-  //  "(("        ?= "(" $ "(" // Group.Unclosed(Group.Unclosed())
-  //  "( "        ?= "(" // Group.Unclosed()
-  //  ")"         ?= ")" // Group.UnmatchedClose
-  //  ")("        ?= ")" $ "(" // Group.UnmatchedClose $ Group.Unclosed()
-  //  "a ( b c )" ?= "a" $_ "(" $_ "b" $_ "c" $_ ")" // ("a" $_ Group(1, "b" $_ "c", 1))
-  //  "(a (b c))" ?= "(" $ "a" $_ "(" $ "b" $_ "c" $ ")" $ ")" // Group("a" $_ Group("b" $_ "c"))
-
-  ////////////////
-  //// Layout ////
-  ////////////////
-
-  ""           ?= Module(Block.Line())
-  "\n"         ?= Module(Block.Line(), Block.Line())
-  "  \n "      ?= Module(Block.Line(2), Block.Line(1))
-  "\n\n"       ?= Module(Block.Line(), Block.Line(), Block.Line())
-  " \n  \n   " ?= Module(Block.Line(1), Block.Line(2), Block.Line(3))
-  //  test module "(a)"  ==? GroupBegin  :: Var("a") :: GroupEnd
-  //  test module "[a]"  ==? ListBegin   :: Var("a") :: ListEnd
-  //  test module "{a}"  ==? RecordBegin :: Var("a") :: RecordEnd
-
-  /////////////////
-  //// Numbers ////
-  /////////////////
-
-  "7"     ?= 7
-  "07"    ?= Number("07")
-  "10_7"  ?= Number(10, 7)
-  "16_ff" ?= Number(16, "ff")
-  "16_"   ?= Number.DanglingBase("16")
-  "7.5"   ?= App.Infix(7, 0, Opr("."), 0, 5)
-
-  ////////////////////////
-  //// UTF Surrogates ////
-  ////////////////////////
-
-  "\uD800\uDF1E" ?= Unrecognized("\uD800\uDF1E")
-
-  /////////////////////
-  //// Large Input ////
-  /////////////////////
-
-  "BIG_INPUT_" * ParserBase.BUFFERSIZE ?= "BIG_INPUT_" * ParserBase.BUFFERSIZE
+//  "_"      ?= "_"
+//  "Name"   ?= "Name"
+//  "name"   ?= "name"
+//  "name'"  ?= "name'"
+//  "name''" ?= "name''"
+//  "name'a" ?= Ident.InvalidSuffix("name'", "a")
+//  "name_"  ?= "name_"
+//  "name_'" ?= "name_'"
+//  "name'_" ?= Ident.InvalidSuffix("name'", "_")
+//  "name`"  ?= "name" $ Unrecognized("`")
+//
+//  ///////////////////
+//  //// Operators ////
+//  ///////////////////
+//
+//  "++"   ?= "++"
+//  "="    ?= "="
+//  "=="   ?= "=="
+//  ":"    ?= ":"
+//  ","    ?= ","
+//  "."    ?= "."
+//  ".."   ?= ".."
+//  "..."  ?= "..."
+//  ">="   ?= ">="
+//  "<="   ?= "<="
+//  "/="   ?= "/="
+//  "+="   ?= Opr.Mod("+")
+//  "-="   ?= Opr.Mod("-")
+//  "==="  ?= Ident.InvalidSuffix("==", "=")
+//  "...." ?= Ident.InvalidSuffix("...", ".")
+//  ">=="  ?= Ident.InvalidSuffix(">=", "=")
+//  "+=="  ?= Ident.InvalidSuffix("+", "==")
+//
+//  /////////////////////
+//  //// Expressions ////
+//  /////////////////////
+//
+//  "a b"           ?= ("a" $_ "b")
+//  "a +  b"        ?= ("a" $_ "+") $__ "b"
+//  "a + b + c"     ?= ("a" $_ "+" $_ "b") $_ "+" $_ "c"
+//  "a , b , c"     ?= "a" $_ "," $_ ("b" $_ "," $_ "c")
+//  "a + b * c"     ?= "a" $_ "+" $_ ("b" $_ "*" $_ "c")
+//  "a * b + c"     ?= ("a" $_ "*" $_ "b") $_ "+" $_ "c"
+//  "a+ b"          ?= ("a" $ "+") $$_ "b"
+//  "a +b"          ?= "a" $_ ("+" $ "b")
+//  "a+ +b"         ?= ("a" $ "+") $$_ ("+" $ "b")
+//  "*a+"           ?= ("*" $ "a") $ "+"
+//  "+a*"           ?= "+" $ ("a" $ "*")
+//  "+ <$> a <*> b" ?= ("+" $_ "<$>" $_ "a") $_ "<*>" $_ "b"
+//  "+ * ^"         ?= App.Right("+", 1, App.Right("*", 1, "^"))
+//  "+ ^ *"         ?= App.Right("+", 1, App.Left("^", 1, "*"))
+//  "^ * +"         ?= App.Left(App.Left("^", 1, "*"), 1, "+")
+//  "* ^ +"         ?= App.Left(App.Right("*", 1, "^"), 1, "+")
+//  "^ + *"         ?= App.Infix("^", 1, "+", 1, "*")
+//  "* + ^"         ?= App.Infix("*", 1, "+", 1, "^")
+//
+//  //  "a+b"    ?=
+//  //  "()"        ?= "(" $ ")" // Group()
+//  //  "(())"      ?= "(" $ "(" $ ")" $ ")" // Group(Group())
+//  //  "(()"       ?= "(" $ "(" $ ")" // Group.Unclosed(Group())
+//  //  "(("        ?= "(" $ "(" // Group.Unclosed(Group.Unclosed())
+//  //  "( "        ?= "(" // Group.Unclosed()
+//  //  ")"         ?= ")" // Group.UnmatchedClose
+//  //  ")("        ?= ")" $ "(" // Group.UnmatchedClose $ Group.Unclosed()
+//  //  "a ( b c )" ?= "a" $_ "(" $_ "b" $_ "c" $_ ")" // ("a" $_ Group(1, "b" $_ "c", 1))
+//  //  "(a (b c))" ?= "(" $ "a" $_ "(" $ "b" $_ "c" $ ")" $ ")" // Group("a" $_ Group("b" $_ "c"))
+//
+//  ////////////////
+//  //// Layout ////
+//  ////////////////
+//
+//  ""           ?= Module(Block.Line())
+//  "\n"         ?= Module(Block.Line(), Block.Line())
+//  "  \n "      ?= Module(Block.Line(2), Block.Line(1))
+//  "\n\n"       ?= Module(Block.Line(), Block.Line(), Block.Line())
+//  " \n  \n   " ?= Module(Block.Line(1), Block.Line(2), Block.Line(3))
+//  //  test module "(a)"  ==? GroupBegin  :: Var("a") :: GroupEnd
+//  //  test module "[a]"  ==? ListBegin   :: Var("a") :: ListEnd
+//  //  test module "{a}"  ==? RecordBegin :: Var("a") :: RecordEnd
+//
+//  /////////////////
+//  //// Numbers ////
+//  /////////////////
+//
+//  "7"     ?= 7
+//  "07"    ?= Number("07")
+//  "10_7"  ?= Number(10, 7)
+//  "16_ff" ?= Number(16, "ff")
+//  "16_"   ?= Number.DanglingBase("16")
+//  "7.5"   ?= App.Infix(7, 0, Opr("."), 0, 5)
+//
+//  ////////////////////////
+//  //// UTF Surrogates ////
+//  ////////////////////////
+//
+//  "\uD800\uDF1E" ?= Unrecognized("\uD800\uDF1E")
+//
+//  /////////////////////
+//  //// Large Input ////
+//  /////////////////////
+//
+//  "BIG_INPUT_" * ParserBase.BUFFERSIZE ?= "BIG_INPUT_" * ParserBase.BUFFERSIZE
 
   //////////////
   //// Text ////

--- a/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
@@ -6,6 +6,7 @@ import org.enso.syntax.text.ast.Helpers._
 import org.enso.{flexer => Flexer}
 import org.scalatest._
 import EDSL._
+import org.enso.syntax.text.AST.Text.Segment.{EOL, Plain}
 
 class ParserSpec extends FlatSpec with Matchers {
 
@@ -199,6 +200,9 @@ class ParserSpec extends FlatSpec with Matchers {
   "\"\"\"a\"\"\""  ?= Text.Raw(Text.Quote.Triple, "a")
   "\"\"\"a\""      ?= Text.Unclosed(Text.Raw(Text.Quote.Triple, "a\""))
   "\"\"\"a\"\""    ?= Text.Unclosed(Text.Raw(Text.Quote.Triple, "a\"\""))
+
+
+  "'''\nX\n Y\n'''" ?= Text.MultiLine(0, '\'', Text.Quote.Triple, List(EOL(), Plain("X"), EOL(), Plain(" Y"), EOL()))
 
   //// Escapes ////
 

--- a/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
@@ -60,108 +60,108 @@ class ParserSpec extends FlatSpec with Matchers {
   //// Identifiers ////
   /////////////////////
 
-//  "_"      ?= "_"
-//  "Name"   ?= "Name"
-//  "name"   ?= "name"
-//  "name'"  ?= "name'"
-//  "name''" ?= "name''"
-//  "name'a" ?= Ident.InvalidSuffix("name'", "a")
-//  "name_"  ?= "name_"
-//  "name_'" ?= "name_'"
-//  "name'_" ?= Ident.InvalidSuffix("name'", "_")
-//  "name`"  ?= "name" $ Unrecognized("`")
-//
-//  ///////////////////
-//  //// Operators ////
-//  ///////////////////
-//
-//  "++"   ?= "++"
-//  "="    ?= "="
-//  "=="   ?= "=="
-//  ":"    ?= ":"
-//  ","    ?= ","
-//  "."    ?= "."
-//  ".."   ?= ".."
-//  "..."  ?= "..."
-//  ">="   ?= ">="
-//  "<="   ?= "<="
-//  "/="   ?= "/="
-//  "+="   ?= Opr.Mod("+")
-//  "-="   ?= Opr.Mod("-")
-//  "==="  ?= Ident.InvalidSuffix("==", "=")
-//  "...." ?= Ident.InvalidSuffix("...", ".")
-//  ">=="  ?= Ident.InvalidSuffix(">=", "=")
-//  "+=="  ?= Ident.InvalidSuffix("+", "==")
-//
-//  /////////////////////
-//  //// Expressions ////
-//  /////////////////////
-//
-//  "a b"           ?= ("a" $_ "b")
-//  "a +  b"        ?= ("a" $_ "+") $__ "b"
-//  "a + b + c"     ?= ("a" $_ "+" $_ "b") $_ "+" $_ "c"
-//  "a , b , c"     ?= "a" $_ "," $_ ("b" $_ "," $_ "c")
-//  "a + b * c"     ?= "a" $_ "+" $_ ("b" $_ "*" $_ "c")
-//  "a * b + c"     ?= ("a" $_ "*" $_ "b") $_ "+" $_ "c"
-//  "a+ b"          ?= ("a" $ "+") $$_ "b"
-//  "a +b"          ?= "a" $_ ("+" $ "b")
-//  "a+ +b"         ?= ("a" $ "+") $$_ ("+" $ "b")
-//  "*a+"           ?= ("*" $ "a") $ "+"
-//  "+a*"           ?= "+" $ ("a" $ "*")
-//  "+ <$> a <*> b" ?= ("+" $_ "<$>" $_ "a") $_ "<*>" $_ "b"
-//  "+ * ^"         ?= App.Right("+", 1, App.Right("*", 1, "^"))
-//  "+ ^ *"         ?= App.Right("+", 1, App.Left("^", 1, "*"))
-//  "^ * +"         ?= App.Left(App.Left("^", 1, "*"), 1, "+")
-//  "* ^ +"         ?= App.Left(App.Right("*", 1, "^"), 1, "+")
-//  "^ + *"         ?= App.Infix("^", 1, "+", 1, "*")
-//  "* + ^"         ?= App.Infix("*", 1, "+", 1, "^")
-//
-//  //  "a+b"    ?=
-//  //  "()"        ?= "(" $ ")" // Group()
-//  //  "(())"      ?= "(" $ "(" $ ")" $ ")" // Group(Group())
-//  //  "(()"       ?= "(" $ "(" $ ")" // Group.Unclosed(Group())
-//  //  "(("        ?= "(" $ "(" // Group.Unclosed(Group.Unclosed())
-//  //  "( "        ?= "(" // Group.Unclosed()
-//  //  ")"         ?= ")" // Group.UnmatchedClose
-//  //  ")("        ?= ")" $ "(" // Group.UnmatchedClose $ Group.Unclosed()
-//  //  "a ( b c )" ?= "a" $_ "(" $_ "b" $_ "c" $_ ")" // ("a" $_ Group(1, "b" $_ "c", 1))
-//  //  "(a (b c))" ?= "(" $ "a" $_ "(" $ "b" $_ "c" $ ")" $ ")" // Group("a" $_ Group("b" $_ "c"))
-//
-//  ////////////////
-//  //// Layout ////
-//  ////////////////
-//
-//  ""           ?= Module(Block.Line())
-//  "\n"         ?= Module(Block.Line(), Block.Line())
-//  "  \n "      ?= Module(Block.Line(2), Block.Line(1))
-//  "\n\n"       ?= Module(Block.Line(), Block.Line(), Block.Line())
-//  " \n  \n   " ?= Module(Block.Line(1), Block.Line(2), Block.Line(3))
-//  //  test module "(a)"  ==? GroupBegin  :: Var("a") :: GroupEnd
-//  //  test module "[a]"  ==? ListBegin   :: Var("a") :: ListEnd
-//  //  test module "{a}"  ==? RecordBegin :: Var("a") :: RecordEnd
-//
-//  /////////////////
-//  //// Numbers ////
-//  /////////////////
-//
-//  "7"     ?= 7
-//  "07"    ?= Number("07")
-//  "10_7"  ?= Number(10, 7)
-//  "16_ff" ?= Number(16, "ff")
-//  "16_"   ?= Number.DanglingBase("16")
-//  "7.5"   ?= App.Infix(7, 0, Opr("."), 0, 5)
-//
-//  ////////////////////////
-//  //// UTF Surrogates ////
-//  ////////////////////////
-//
-//  "\uD800\uDF1E" ?= Unrecognized("\uD800\uDF1E")
-//
-//  /////////////////////
-//  //// Large Input ////
-//  /////////////////////
-//
-//  "BIG_INPUT_" * ParserBase.BUFFERSIZE ?= "BIG_INPUT_" * ParserBase.BUFFERSIZE
+  "_"      ?= "_"
+  "Name"   ?= "Name"
+  "name"   ?= "name"
+  "name'"  ?= "name'"
+  "name''" ?= "name''"
+  "name'a" ?= Ident.InvalidSuffix("name'", "a")
+  "name_"  ?= "name_"
+  "name_'" ?= "name_'"
+  "name'_" ?= Ident.InvalidSuffix("name'", "_")
+  "name`"  ?= "name" $ Unrecognized("`")
+
+  ///////////////////
+  //// Operators ////
+  ///////////////////
+
+  "++"   ?= "++"
+  "="    ?= "="
+  "=="   ?= "=="
+  ":"    ?= ":"
+  ","    ?= ","
+  "."    ?= "."
+  ".."   ?= ".."
+  "..."  ?= "..."
+  ">="   ?= ">="
+  "<="   ?= "<="
+  "/="   ?= "/="
+  "+="   ?= Opr.Mod("+")
+  "-="   ?= Opr.Mod("-")
+  "==="  ?= Ident.InvalidSuffix("==", "=")
+  "...." ?= Ident.InvalidSuffix("...", ".")
+  ">=="  ?= Ident.InvalidSuffix(">=", "=")
+  "+=="  ?= Ident.InvalidSuffix("+", "==")
+
+  /////////////////////
+  //// Expressions ////
+  /////////////////////
+
+  "a b"           ?= ("a" $_ "b")
+  "a +  b"        ?= ("a" $_ "+") $__ "b"
+  "a + b + c"     ?= ("a" $_ "+" $_ "b") $_ "+" $_ "c"
+  "a , b , c"     ?= "a" $_ "," $_ ("b" $_ "," $_ "c")
+  "a + b * c"     ?= "a" $_ "+" $_ ("b" $_ "*" $_ "c")
+  "a * b + c"     ?= ("a" $_ "*" $_ "b") $_ "+" $_ "c"
+  "a+ b"          ?= ("a" $ "+") $$_ "b"
+  "a +b"          ?= "a" $_ ("+" $ "b")
+  "a+ +b"         ?= ("a" $ "+") $$_ ("+" $ "b")
+  "*a+"           ?= ("*" $ "a") $ "+"
+  "+a*"           ?= "+" $ ("a" $ "*")
+  "+ <$> a <*> b" ?= ("+" $_ "<$>" $_ "a") $_ "<*>" $_ "b"
+  "+ * ^"         ?= App.Right("+", 1, App.Right("*", 1, "^"))
+  "+ ^ *"         ?= App.Right("+", 1, App.Left("^", 1, "*"))
+  "^ * +"         ?= App.Left(App.Left("^", 1, "*"), 1, "+")
+  "* ^ +"         ?= App.Left(App.Right("*", 1, "^"), 1, "+")
+  "^ + *"         ?= App.Infix("^", 1, "+", 1, "*")
+  "* + ^"         ?= App.Infix("*", 1, "+", 1, "^")
+
+  //  "a+b"    ?=
+  //  "()"        ?= "(" $ ")" // Group()
+  //  "(())"      ?= "(" $ "(" $ ")" $ ")" // Group(Group())
+  //  "(()"       ?= "(" $ "(" $ ")" // Group.Unclosed(Group())
+  //  "(("        ?= "(" $ "(" // Group.Unclosed(Group.Unclosed())
+  //  "( "        ?= "(" // Group.Unclosed()
+  //  ")"         ?= ")" // Group.UnmatchedClose
+  //  ")("        ?= ")" $ "(" // Group.UnmatchedClose $ Group.Unclosed()
+  //  "a ( b c )" ?= "a" $_ "(" $_ "b" $_ "c" $_ ")" // ("a" $_ Group(1, "b" $_ "c", 1))
+  //  "(a (b c))" ?= "(" $ "a" $_ "(" $ "b" $_ "c" $ ")" $ ")" // Group("a" $_ Group("b" $_ "c"))
+
+  ////////////////
+  //// Layout ////
+  ////////////////
+
+  ""           ?= Module(Block.Line())
+  "\n"         ?= Module(Block.Line(), Block.Line())
+  "  \n "      ?= Module(Block.Line(2), Block.Line(1))
+  "\n\n"       ?= Module(Block.Line(), Block.Line(), Block.Line())
+  " \n  \n   " ?= Module(Block.Line(1), Block.Line(2), Block.Line(3))
+  //  test module "(a)"  ==? GroupBegin  :: Var("a") :: GroupEnd
+  //  test module "[a]"  ==? ListBegin   :: Var("a") :: ListEnd
+  //  test module "{a}"  ==? RecordBegin :: Var("a") :: RecordEnd
+
+  /////////////////
+  //// Numbers ////
+  /////////////////
+
+  "7"     ?= 7
+  "07"    ?= Number("07")
+  "10_7"  ?= Number(10, 7)
+  "16_ff" ?= Number(16, "ff")
+  "16_"   ?= Number.DanglingBase("16")
+  "7.5"   ?= App.Infix(7, 0, Opr("."), 0, 5)
+
+  ////////////////////////
+  //// UTF Surrogates ////
+  ////////////////////////
+
+  "\uD800\uDF1E" ?= Unrecognized("\uD800\uDF1E")
+
+  /////////////////////
+  //// Large Input ////
+  /////////////////////
+
+  "BIG_INPUT_" * ParserBase.BUFFERSIZE ?= "BIG_INPUT_" * ParserBase.BUFFERSIZE
 
   //////////////
   //// Text ////

--- a/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
@@ -171,11 +171,11 @@ class ParserSpec extends FlatSpec with Matchers {
   //// Text ////
   //////////////
 
-  "'"    ?= Text.Unclosed(Text())
-  "''"   ?= Text()
-  "'''"  ?= Text.Unclosed(Text(Text.Quote.Triple))
-  "''''" ?= Text.Unclosed(Text(Text.Quote.Triple, "'"))
-  "'''''" ?= Text.Unclosed(Text(Text.Quote.Triple, "''"))
+  "'"       ?= Text.Unclosed(Text())
+  "''"      ?= Text()
+  "'''"     ?= Text.Unclosed(Text(Text.Quote.Triple))
+  "''''"    ?= Text.Unclosed(Text(Text.Quote.Triple, "'"))
+  "'''''"   ?= Text.Unclosed(Text(Text.Quote.Triple, "''"))
   "''''''"  ?= Text(Text.Quote.Triple)
   "'''''''" ?= Text(Text.Quote.Triple) $ Text.Unclosed(Text())
   "'a'"     ?= Text("a")
@@ -183,7 +183,22 @@ class ParserSpec extends FlatSpec with Matchers {
   "'a'''"   ?= Text("a") $ Text()
   "'''a'''" ?= Text(Text.Quote.Triple, "a")
   "'''a'"   ?= Text.Unclosed(Text(Text.Quote.Triple, "a'"))
-  "'''a''" ?= Text.Unclosed(Text(Text.Quote.Triple, "a''"))
+  "'''a''"  ?= Text.Unclosed(Text(Text.Quote.Triple, "a''"))
+
+
+  "\""             ?= Text.Unclosed(Text.Raw())
+  "\"\""           ?= Text.Raw()
+  "\"\"\""         ?= Text.Unclosed(Text.Raw(Text.Quote.Triple))
+  "\"\"\"\""       ?= Text.Unclosed(Text.Raw(Text.Quote.Triple, "\""))
+  "\"\"\"\"\""     ?= Text.Unclosed(Text.Raw(Text.Quote.Triple, "\"\""))
+  "\"\"\"\"\"\""   ?= Text.Raw(Text.Quote.Triple)
+  "\"\"\"\"\"\"\"" ?= Text.Raw(Text.Quote.Triple) $ Text.Unclosed(Text.Raw())
+  "\"a\""          ?= Text.Raw("a")
+  "\"a"            ?= Text.Unclosed(Text.Raw("a"))
+  "\"a\"\"\""      ?= Text.Raw("a") $ Text.Raw()
+  "\"\"\"a\"\"\""  ?= Text.Raw(Text.Quote.Triple, "a")
+  "\"\"\"a\""      ?= Text.Unclosed(Text.Raw(Text.Quote.Triple, "a\""))
+  "\"\"\"a\"\""    ?= Text.Unclosed(Text.Raw(Text.Quote.Triple, "a\"\""))
 
   //// Escapes ////
 

--- a/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
@@ -175,7 +175,7 @@ class ParserSpec extends FlatSpec with Matchers {
   "''"   ?= Text()
   "'''"  ?= Text.Unclosed(Text(Text.Quote.Triple))
   "''''" ?= Text.Unclosed(Text(Text.Quote.Triple, "'"))
-//  "'''''"   ?= Text.Unclosed(Text(Text.Quote.Triple, "''")) // FIXME
+  "'''''" ?= Text.Unclosed(Text(Text.Quote.Triple, "''"))
   "''''''"  ?= Text(Text.Quote.Triple)
   "'''''''" ?= Text(Text.Quote.Triple) $ Text.Unclosed(Text())
   "'a'"     ?= Text("a")
@@ -183,7 +183,7 @@ class ParserSpec extends FlatSpec with Matchers {
   "'a'''"   ?= Text("a") $ Text()
   "'''a'''" ?= Text(Text.Quote.Triple, "a")
   "'''a'"   ?= Text.Unclosed(Text(Text.Quote.Triple, "a'"))
-  //  "'''a''"  ?= Text.Unclosed(Text(Text.Quote.Triple, "a''")) // FIXME
+  "'''a''" ?= Text.Unclosed(Text(Text.Quote.Triple, "a''"))
 
   //// Escapes ////
 


### PR DESCRIPTION
### Pull Request Description
Fixes rewind bug. Adds support for raw and multi-line strings.

### Important Notes
Added `EOL(validIndent: Boolean)`, which signifies end of line. In case of multi line block `validIndent = false` when the next line is wrongly indented. 

### Checklist

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

