### PR TITLE
Temporarily disable the shaky test.

### DIFF
--- a/FileManager/src/test/scala/org/enso/filemanager/WatchTests.scala
+++ b/FileManager/src/test/scala/org/enso/filemanager/WatchTests.scala
@@ -60,16 +60,14 @@ class WatchTests
   def matchesEvent(
     path: Path,
     eventType: DirectoryChangeEvent.EventType
-  )(message: FileSystemEvent
-  ): Boolean = {
+  )(message: FileSystemEvent): Boolean = {
     message.path == path && message.eventType == eventType
   }
 
   def expectEventFor(
     eventType: DirectoryChangeEvent.EventType,
     events: Seq[FileSystemEvent]
-  )(path: Path
-  ): Unit = {
+  )(path: Path): Unit = {
     assert(
       events.exists(matchesEvent(path, eventType)),
       s"not received message about $path"
@@ -107,25 +105,28 @@ class WatchTests
     Await.result(futureResponse, timeout.duration).get
   }
 
-  test("Watcher: observe subtree creation and deletion") {
-    val subtree = createSubtree()
-    val events  = testProbe.receiveMessages(subtree.elements.size)
-    subtree.elements.foreach(
-      expectEventFor(DirectoryChangeEvent.EventType.CREATE, events)
-    )
-
-    FileUtils.deleteDirectory(subtree.root.toFile)
-
-    val deletionEvents = testProbe.receiveMessages(subtree.elements.size)
-    subtree.elements.foreach(
-      expectEventFor(
-        DirectoryChangeEvent.EventType.DELETE,
-        deletionEvents
-      )
-    )
-
-    testProbe.expectNoMessage(50.millis)
-  }
+  // FIXME [MWU]
+  //  This test has been temporarily disabled because it was failing from time
+  //  to time on CI runs: https://github.com/luna/enso/issues/73
+//  test("Watcher: observe subtree creation and deletion") {
+//    val subtree = createSubtree()
+//    val events  = testProbe.receiveMessages(subtree.elements.size)
+//    subtree.elements.foreach(
+//      expectEventFor(DirectoryChangeEvent.EventType.CREATE, events)
+//    )
+//
+//    FileUtils.deleteDirectory(subtree.root.toFile)
+//
+//    val deletionEvents = testProbe.receiveMessages(subtree.elements.size)
+//    subtree.elements.foreach(
+//      expectEventFor(
+//        DirectoryChangeEvent.EventType.DELETE,
+//        deletionEvents
+//      )
+//    )
+//
+//    testProbe.expectNoMessage(50.millis)
+//  }
 
   test("Watcher: observe file modification") {
     val dir10 = tempDir.resolve("dir10")


### PR DESCRIPTION
### Pull Request Description
Having shaky test is worse that not having test at all.
Disable the test, until it is properly investigated and either fixed or removed.

### Important Notes
If accepted, I will rename the https://github.com/luna/enso/issues/73 issue.

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [ ] All code has been tested where possible.

