### PR TITLE
Parser: Support Markers.

### DIFF
--- a/lib/flexer/src/main/scala/org/enso/flexer/Parser.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/Parser.scala
@@ -6,10 +6,12 @@ import scala.collection.mutable
 import org.enso.flexer.debug.Escape
 import org.enso.flexer.spec.Macro
 
-trait Parser[T] {
+trait Parser {
   import Parser._
   import java.io.Reader
   import java.io.StringReader
+
+  type T
 
   var reader: Reader      = null
   val buffer: Array[Char] = new Array(BUFFER_SIZE)
@@ -188,8 +190,8 @@ object Parser {
       i >= 0
   }
 
-  def compile[T](p: Macro.In[T]): Macro.Out[T] =
-    macro Macro.compileImpl[T]
+  def compile[P <: Parser](p: () => P): () => P =
+    macro Macro.compileImpl[P]
 
   case class Result[T](offset: Int, value: Result.Value[T]) {
     def map[S](fn: T => S): Result[S] = copy(value = value.map(fn))

--- a/lib/flexer/src/main/scala/org/enso/flexer/Parser.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/Parser.scala
@@ -1,17 +1,16 @@
 package org.enso.flexer
 
 import org.enso.Logger
-
-import scala.collection.mutable
 import org.enso.flexer.debug.Escape
 import org.enso.flexer.spec.Macro
 
-trait Parser {
-  import Parser._
+import scala.collection.mutable
+
+trait Parser[T] {
   import java.io.Reader
   import java.io.StringReader
 
-  type T
+  import Parser._
 
   var reader: Reader      = null
   val buffer: Array[Char] = new Array(BUFFER_SIZE)
@@ -190,8 +189,8 @@ object Parser {
       i >= 0
   }
 
-  def compile[P <: Parser](p: () => P): () => P =
-    macro Macro.compileImpl[P]
+  def compile[T, P](p: () => P)(implicit ev: P <:< Parser[T]): () => P =
+    macro Macro.compileImpl[T, P]
 
   case class Result[T](offset: Int, value: Result.Value[T]) {
     def map[S](fn: T => S): Result[S] = copy(value = value.map(fn))

--- a/lib/flexer/src/main/scala/org/enso/flexer/spec/Macro.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/spec/Macro.scala
@@ -8,20 +8,13 @@ import scala.reflect.runtime.universe
 // FIXME: Needs to be refactored. Contains deprecated API usage
 object Macro {
 
-  type Base[T] = Parser[T]
-  type In[T]   = () => Base[T]
-  type Out[T]  = () => Base[T]
-
-  def compile[T](p: In[T]): Out[T] =
-    macro compileImpl[T]
-
-  def compileImpl[T: c.WeakTypeTag](
+  def compileImpl[P <: Parser](
     c: Context
-  )(p: c.Expr[In[T]]): c.Expr[Out[T]] = {
+  )(p: c.Expr[() => P]): c.Expr[() => P] = {
     import c.universe._
     val tree   = p.tree
     val expr   = q"$tree()"
-    val parser = c.eval(c.Expr[Base[T]](c.untypecheck(expr.duplicate)))
+    val parser = c.eval(c.Expr[P](c.untypecheck(expr.duplicate)))
     val groups = c.internal
       .createImporter(universe)
       .importTree(universe.Block(parser.state.registry.map(_.generate()): _*))
@@ -57,7 +50,7 @@ object Macro {
 
     val clsDef = c.parse(s"final class __Parser__ extends $tree")
     val tgtDef = addGroupDefs.transform(clsDef)
-    c.Expr[Out[T]](q"$tgtDef; () => { new __Parser__ () }")
+    c.Expr[() => P](q"$tgtDef; () => { new __Parser__ () }")
   }
 
 }

--- a/lib/flexer/src/main/scala/org/enso/flexer/spec/Macro.scala
+++ b/lib/flexer/src/main/scala/org/enso/flexer/spec/Macro.scala
@@ -8,13 +8,13 @@ import scala.reflect.runtime.universe
 // FIXME: Needs to be refactored. Contains deprecated API usage
 object Macro {
 
-  def compileImpl[P <: Parser](
+  def compileImpl[T: c.WeakTypeTag, P: c.WeakTypeTag](
     c: Context
-  )(p: c.Expr[() => P]): c.Expr[() => P] = {
+  )(p: c.Expr[() => P])(ev: c.Expr[P <:< Parser[T]]): c.Expr[() => P] = {
     import c.universe._
     val tree   = p.tree
     val expr   = q"$tree()"
-    val parser = c.eval(c.Expr[P](c.untypecheck(expr.duplicate)))
+    val parser = c.eval(c.Expr[Parser[T]](c.untypecheck(expr.duplicate)))
     val groups = c.internal
       .createImporter(universe)
       .importTree(universe.Block(parser.state.registry.map(_.generate()): _*))

--- a/syntax/definition/src/main/scala/org/enso/data/VectorMap.scala
+++ b/syntax/definition/src/main/scala/org/enso/data/VectorMap.scala
@@ -1,6 +1,14 @@
 package org.enso.data
 
-class VectorMap[K: Ordering, V](values: Seq[(K, V)]) {
+/** Read only zipper-like map.
+ *
+ *  Sparse, sorted, vector based map
+ *  with O(1) access, when accessing adjacent keys
+ *  with O(N) access, when accessing random keys
+ *  this is achieved by remembering the index of
+ *  last accessed key in local variable `index`
+ */
+final class VectorMap[K: Ordering, V](values: Seq[(K, V)]) {
   private var index  = 0
   private val ord    = Ordering[K]
   private val vector = values.toVector.sortBy(_._1)

--- a/syntax/definition/src/main/scala/org/enso/data/VectorMap.scala
+++ b/syntax/definition/src/main/scala/org/enso/data/VectorMap.scala
@@ -1,0 +1,34 @@
+package org.enso.data
+
+class VectorMap[K: Ordering, V](values: Seq[(K, V)]) {
+  private var index  = 0
+  private val ord    = Ordering[K]
+  private val vector = values.toVector.sortBy(_._1)
+
+  private def key:   K = vector(index)._1
+  private def value: V = vector(index)._2
+
+  def get(k: K): Option[V] = {
+    while (index < vector.length && ord.lteq(key, k)) {
+      if (ord.equiv(key, k))
+        return Some(value)
+      index += 1
+    }
+    index -= 1
+    while (index >= 0 && ord.gteq(key, k)) {
+      if (ord.equiv(key, k))
+        return Some(value)
+      index -= 1
+    }
+    index += 1
+    None
+  }
+}
+
+object VectorMap {
+
+  def apply[K: Ordering, V](): VectorMap[K, V] = new VectorMap(Vector[(K, V)]())
+  def apply[K: Ordering, V](values: Seq[(K, V)]): VectorMap[K, V] =
+    new VectorMap(values)
+
+}

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -58,6 +58,17 @@ object AST {
     else Opr(str)
   }
 
+
+  ////////////////
+  //// Marker ////
+  ////////////////
+
+  final case class Marker(id: Int)
+
+  final case class Marked(ast: AST, marker: Marker) extends AST {
+    val repr = ast.repr
+  }
+
   /////////////////
   //// Invalid ////
   /////////////////

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -65,7 +65,7 @@ object AST {
 
   final case class Marker(id: Int)
 
-  final case class Marked(ast: AST, marker: Marker) extends AST {
+  final case class Marked(marker: Marker, ast: AST) extends AST {
     val repr = ast.repr
   }
 

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/ParserDef.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/ParserDef.scala
@@ -1,13 +1,17 @@
 package org.enso.syntax.text
 
+import org.enso.data.VectorMap
 import org.enso.flexer._
 import org.enso.flexer.automata.Pattern
 import org.enso.flexer.automata.Pattern._
+import org.enso.syntax.text.AST.Marker
 import org.enso.syntax.text.AST.Text.Segment.EOL
 
 import scala.reflect.runtime.universe.reify
 
-case class ParserDef() extends Parser[AST] {
+case class ParserDef() extends Parser {
+
+  type T = AST
 
   final def unwrap[T](opt: Option[T]): T = opt match {
     case None    => throw new Error("Internal Error")
@@ -18,7 +22,12 @@ case class ParserDef() extends Parser[AST] {
   //// API ////
   /////////////
 
-  override def run(input: String) = {
+  def run(input: String, markerSeq: scala.Seq[(Int, Marker)]): Parser.Result[AST] = {
+    result.markers = VectorMap(markerSeq)
+    run(input)
+  }
+
+  override def run(input: String): Parser.Result[AST] = {
     block.onBegin(0)
     state.begin(block.FIRSTCHAR)
     super.run(input)
@@ -44,8 +53,11 @@ case class ParserDef() extends Parser[AST] {
   override def getResult() = result.current
 
   final object result {
-    var current: Option[AST]     = None
-    var stack: List[Option[AST]] = Nil
+    import AST.Marked
+
+    var markers: VectorMap[Int, Marker] = VectorMap()
+    var current: Option[AST]            = None
+    var stack: List[Option[AST]]        = Nil
 
     def push(): Unit = logger.trace {
       logger.log(s"Pushed: $current")
@@ -62,10 +74,14 @@ case class ParserDef() extends Parser[AST] {
     def app(fn: String => AST): Unit =
       app(fn(currentMatch))
 
-    def app(t: AST): Unit = logger.trace {
+    def app(ast: AST): Unit = logger.trace {
+      val marked = markers.get(offset - ast.span - 1) match {
+        case None         => ast
+        case Some(marker) => Marked(ast, marker)
+      }
       current = Some(current match {
-        case None    => t
-        case Some(r) => AST.App(r, off.use(), t)
+        case None    => marked
+        case Some(r) => AST.App(r, off.use(), marked)
       })
     }
   }
@@ -108,6 +124,8 @@ case class ParserDef() extends Parser[AST] {
   ////////////////////
 
   final object ident {
+    import AST.Ident._
+
     var current: Option[AST.Ident] = None
 
     def on(cons: String => AST.Ident): Unit = logger.trace_ {
@@ -125,7 +143,7 @@ case class ParserDef() extends Parser[AST] {
     }
 
     def onErrSfx(): Unit = logger.trace {
-      val ast = AST.Ident.InvalidSuffix(unwrap(current), currentMatch)
+      val ast = InvalidSuffix(unwrap(current), currentMatch)
       result.app(ast)
       current = None
       state.end()
@@ -161,6 +179,7 @@ case class ParserDef() extends Parser[AST] {
   //////////////////
 
   final object opr {
+
     def on(cons: String => AST.Ident): Unit = logger.trace {
       on(cons(currentMatch))
     }
@@ -496,7 +515,6 @@ case class ParserDef() extends Parser[AST] {
         unwrap(current.firstLine),
         current.lines.reverse
       )
-
     }
 
     def submit(): Unit = logger.trace {

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/ParserDef.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/ParserDef.scala
@@ -179,7 +179,6 @@ case class ParserDef() extends Parser {
   //////////////////
 
   final object opr {
-
     def on(cons: String => AST.Ident): Unit = logger.trace {
       on(cons(currentMatch))
     }

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/ParserDef.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/ParserDef.scala
@@ -4,14 +4,11 @@ import org.enso.data.VectorMap
 import org.enso.flexer._
 import org.enso.flexer.automata.Pattern
 import org.enso.flexer.automata.Pattern._
-import org.enso.syntax.text.AST.Marker
 import org.enso.syntax.text.AST.Text.Segment.EOL
 
 import scala.reflect.runtime.universe.reify
 
-case class ParserDef() extends Parser {
-
-  type T = AST
+case class ParserDef() extends Parser[AST] {
 
   final def unwrap[T](opt: Option[T]): T = opt match {
     case None    => throw new Error("Internal Error")
@@ -22,7 +19,10 @@ case class ParserDef() extends Parser {
   //// API ////
   /////////////
 
-  def run(input: String, markerSeq: scala.Seq[(Int, Marker)]): Parser.Result[AST] = {
+  def run(
+    input: String,
+    markerSeq: scala.Seq[(Int, AST.Marker)]
+  ): Parser.Result[AST] = {
     result.markers = VectorMap(markerSeq)
     run(input)
   }
@@ -53,11 +53,10 @@ case class ParserDef() extends Parser {
   override def getResult() = result.current
 
   final object result {
-    import AST.Marked
 
-    var markers: VectorMap[Int, Marker] = VectorMap()
-    var current: Option[AST]            = None
-    var stack: List[Option[AST]]        = Nil
+    var markers: VectorMap[Int, AST.Marker] = VectorMap()
+    var current: Option[AST]                = None
+    var stack: List[Option[AST]]            = Nil
 
     def push(): Unit = logger.trace {
       logger.log(s"Pushed: $current")
@@ -77,7 +76,7 @@ case class ParserDef() extends Parser {
     def app(ast: AST): Unit = logger.trace {
       val marked = markers.get(offset - ast.span - 1) match {
         case None         => ast
-        case Some(marker) => Marked(ast, marker)
+        case Some(marker) => AST.Marked(marker, ast)
       }
       current = Some(current match {
         case None    => marked

--- a/syntax/specialization/src/bench/scala/org/enso/syntax/Parser.scala
+++ b/syntax/specialization/src/bench/scala/org/enso/syntax/Parser.scala
@@ -24,13 +24,13 @@ object ParserBenchmark extends Bench.OfflineRegressionReport {
                                             """.stripMargin * i
 
   performance of "parser" in {
-    measure method "variable" in (using(variable) in (Parser.run(_)))
-    measure method "text" in (using(text) in (Parser.run(_)))
-    measure method "number" in (using(number) in (Parser.run(_)))
-    measure method "calls" in (using(calls) in (Parser.run(_)))
-    measure method "codeBlock" in (using(codeBlock) in (Parser.run(_)))
-    measure method "openParens" in (using(openParens) in (Parser.run(_)))
-    measure method "clsdParens" in (using(clsdParens) in (Parser.run(_)))
-    measure method "allRules" in (using(allRules) in (Parser.run(_)))
+    measure method "variable" in (using(variable) in (Parser().run(_)))
+    measure method "text" in (using(text) in (Parser().run(_)))
+    measure method "number" in (using(number) in (Parser().run(_)))
+    measure method "calls" in (using(calls) in (Parser().run(_)))
+    measure method "codeBlock" in (using(codeBlock) in (Parser().run(_)))
+    measure method "openParens" in (using(openParens) in (Parser().run(_)))
+    measure method "clsdParens" in (using(clsdParens) in (Parser().run(_)))
+    measure method "allRules" in (using(allRules) in (Parser().run(_)))
   }
 }

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -2,6 +2,7 @@ package org.enso.syntax.text
 
 import org.enso.flexer
 import org.enso.syntax.text
+import org.enso.syntax.text.AST.Marker
 import org.enso.syntax.text.precedence.Template
 
 ////////////////
@@ -12,10 +13,11 @@ class Parser {
   import Parser._
   private val engine = newEngine()
 
-  def run(input: String): Result[AST.Module] = engine.run(input).map { module =>
-    val module2 = module.asInstanceOf[AST.Module] // FIXME
-    Template.run(module2)
-  }
+  def run(input: String, mrkr: Seq[(Int, Marker)] = Seq()): Result[AST.Module] =
+    engine.run(input, mrkr).map { module: AST =>
+      val module2 = module.asInstanceOf[AST.Module] // FIXME
+      Template.run(module2)
+    }
 
 }
 
@@ -23,7 +25,7 @@ object Parser {
   type Result[T] = flexer.Parser.Result[T]
   private val newEngine = flexer.Parser.compile(text.ParserDef)
 
-  def run(input: String): Result[AST.Module] = new Parser().run(input)
+  def apply(): Parser = new Parser()
 }
 
 //////////////
@@ -35,8 +37,7 @@ object Main extends App {
   val p2 = new Parser()
 
   val inp = "import Std.Math"
-  val out = p1.run(inp)
-
+  val out = p1.run(inp, Seq())
   pprint.pprintln(out, width = 50, height = 10000)
 
   out match {

--- a/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
@@ -14,8 +14,10 @@ import org.enso.syntax.text.AST.Text.Segment.Plain
 
 class ParserSpec extends FlatSpec with Matchers {
 
-  def assertModule(input: String, result: AST): Assertion = {
-    val output = Parser.run(input)
+  type Markers = Seq[(Int, Marker)]
+
+  def assertModule(input: String, result: AST, markers: Markers): Assertion = {
+    val output = Parser().run(input, markers)
     output match {
       case Result(offset, Result.Success(value)) =>
         assert(value == result)
@@ -24,8 +26,8 @@ class ParserSpec extends FlatSpec with Matchers {
     }
   }
 
-  def assertExpr(input: String, result: AST): Assertion = {
-    val output = Parser.run(input)
+  def assertExpr(input: String, result: AST, markers: Markers): Assertion = {
+    val output = Parser().run(input, markers)
     output match {
       case Result(offset, Result.Success(value)) =>
         val module = value.asInstanceOf[Module]
@@ -44,7 +46,7 @@ class ParserSpec extends FlatSpec with Matchers {
   }
 
   def assertIdentity(input: String): Assertion = {
-    val output = Parser.run(input)
+    val output = Parser().run(input)
     output match {
       case Result(offset, Result.Success(value)) =>
         assert(value.show() == input)
@@ -66,10 +68,13 @@ class ParserSpec extends FlatSpec with Matchers {
 
     private val testBase = it should parseTitle(input)
 
-    def ?=(out: AST)    = testBase in { assertExpr(input, out) }
-    def ?=(out: Module) = testBase in { assertModule(input, out) }
+    def ?=(out: AST)    = testBase in { assertExpr(input, out, Seq()) }
+    def ?=(out: Module) = testBase in { assertModule(input, out, Seq()) }
+    def ?#=(out: AST) = testBase in { assertExpr(input, out, markers) }
     def testIdentity = testBase in { assertIdentity(input) }
   }
+
+  val markers = 0 to 100 map ( offset => offset -> Marker(offset))
 
   /////////////////////
   //// Identifiers ////
@@ -236,6 +241,19 @@ class ParserSpec extends FlatSpec with Matchers {
   //  // Disabled
   //  expr("a #= b"         , Var("a") :: DisabledAssignment :: Var("b"))
   //
+
+
+  /////////////////
+  //// Markers ////
+  /////////////////
+
+  "marked" ?#= Marked(Var("marked"), Marker(0))
+  "Marked" ?#= Marked(Cons("Marked"), Marker(0))
+  "111111" ?#= Marked(Number(111111), Marker(0))
+  "'    '" ?#= Marked(Text("    "), Marker(0))
+  "++++++" ?#= Marked(Opr("++++++"), Marker(0))
+  "+++++=" ?#= Marked(Opr.Mod("+++++"), Marker(0))
+  "a b  c" ?#= Marked(Var("a"), Marker(0)) $_ Marked(Var("b"), Marker(2)) $__ Marked(Var("c"), Marker(5))
 
   //////////////////
   //// Mixfixes ////

--- a/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
@@ -247,13 +247,13 @@ class ParserSpec extends FlatSpec with Matchers {
   //// Markers ////
   /////////////////
 
-  "marked" ?#= Marked(Var("marked"), Marker(0))
-  "Marked" ?#= Marked(Cons("Marked"), Marker(0))
-  "111111" ?#= Marked(Number(111111), Marker(0))
-  "'    '" ?#= Marked(Text("    "), Marker(0))
-  "++++++" ?#= Marked(Opr("++++++"), Marker(0))
-  "+++++=" ?#= Marked(Opr.Mod("+++++"), Marker(0))
-  "a b  c" ?#= Marked(Var("a"), Marker(0)) $_ Marked(Var("b"), Marker(2)) $__ Marked(Var("c"), Marker(5))
+  "marked" ?#= Marked(Marker(0), Var("marked"))
+  "Marked" ?#= Marked(Marker(0), Cons("Marked"))
+  "111111" ?#= Marked(Marker(0), Number(111111))
+  "'    '" ?#= Marked(Marker(0), Text("    "))
+  "++++++" ?#= Marked(Marker(0), Opr("++++++"))
+  "+++++=" ?#= Marked(Marker(0), Opr.Mod("+++++"))
+  "a b  c" ?#= Marked(Marker(0), Var("a")) $_ Marked(Marker(2), Var("b")) $__ Marked(Marker(5), Var("c"))
 
   //////////////////
   //// Mixfixes ////


### PR DESCRIPTION
### Summary

parser.run now takes `Seq([Int, Marker])` as additional input. During parsing if some AST token starts at offset associated with marker, it will be decorated as `Marked(token, marker)`.

Currently `Marker` only holds `Int` to make it testable.
VectorMap is a zipper-like vector for fast marker access.


### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

