### PR TITLE
Documentation Parser Extended Integration with Parser

### DIFF
--- a/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Doc.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Doc.scala
@@ -62,22 +62,10 @@ object Doc {
     *
     * It extends Repr.Provider, so it also contain repr method, as well as
     * span and show values. In addition to that it specifies html method for
-    * extending tokens and renderHTML method for creating ready-to-deploy HTML
-    * file from documentation
+    * extending tokens and getting HTML file out of Doc Parser
     */
   sealed trait Symbol extends Repr.Provider {
     def html: HTML
-    def renderHTML(cssLink: String): HTMLTag = {
-      val metaEquiv = HTML.httpEquiv := "Content-Type"
-      val metaCont  = HTML.content := "text/html"
-      val metaChar  = HTML.charset := "UTF-8"
-      val meta      = HTML.meta(metaEquiv)(metaCont)(metaChar)
-      val cssRel    = HTML.rel := "stylesheet"
-      val cssHref   = HTML.href := cssLink
-      val css       = HTML.link(cssRel)(cssHref)
-      HTML.html(HTML.head(meta, css), HTML.body(html))
-    }
-
     def htmlCls(): generic.AttrPair[Builder, String] =
       HTML.`class` := getClass.toString.split('$').last.split('.').last
   }

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Documented.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Documented.scala
@@ -39,7 +39,7 @@ sealed trait Doc extends Repr.Provider with Comment {
   */
 final case class Documentation(title: Option[String], documented: Documented)
     extends Doc {
-  val repr: Repr                 = R + title + documented
+  val repr: Repr                 = R + title + Documented.Elem.Newline + documented
   val titleHTML: Documented.HTML = Seq(HTML.div(HTML.`class` := "Title")(title))
   val html: Documented.HTML = Seq(
     HTML.div(htmlCls())(titleHTML)(documented.html)

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
@@ -4,18 +4,18 @@ import org.enso.flexer._
 import org.enso.flexer.automata.Pattern
 import org.enso.flexer.automata.Pattern._
 import org.enso.data.List1
-import org.enso.syntax.text.ast.Doc._
-import org.enso.syntax.text.ast.Doc
+import org.enso.syntax.text.ast.Documented._
+import org.enso.syntax.text.ast.Documented
 
 import scala.reflect.runtime.universe.reify
 
-case class DocParserDef() extends Parser[Doc] {
+case class DocParserDef() extends Parser[Documented] {
 
   //////////////////////////////////////////////////////////////////////////////
   //// Result //////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  override def getResult(): Option[Doc] = result.doc
+  override def getResult(): Option[Documented] = result.doc
 
   /** result - used to manage result from Doc Parser
     *
@@ -24,9 +24,9 @@ case class DocParserDef() extends Parser[Doc] {
     * stack - used to hold stack of elems
     */
   final object result {
-    var current: Option[Elem] = None
-    var doc: Option[Doc]      = None
-    var stack: List[Elem]     = Nil
+    var current: Option[Elem]   = None
+    var doc: Option[Documented] = None
+    var stack: List[Elem]       = Nil
 
     def push(): Unit = logger.trace {
       if (current.isDefined) {
@@ -764,7 +764,7 @@ case class DocParserDef() extends Parser[Doc] {
       val tags: Option[Tags]         = createTags()
       val synopsis: Option[Synopsis] = createSynopsis()
       val body: Option[Body]         = createBody()
-      result.doc = Some(Doc(tags, synopsis, body))
+      result.doc = Some(Documented(tags, synopsis, body))
     }
 
     def createTags(): Option[Tags] = logger.trace {

--- a/syntax/specialization/src/bench/scala/org/enso/syntax/DocParserBench.scala
+++ b/syntax/specialization/src/bench/scala/org/enso/syntax/DocParserBench.scala
@@ -2,7 +2,7 @@ package org.enso.syntax
 
 import org.enso.syntax.text.DocParser
 import org.enso.syntax.text.DocParser.Result
-import org.enso.syntax.text.ast.Doc
+import org.enso.syntax.text.ast.Documented
 import org.scalameter.api._
 
 import scala.math.pow
@@ -47,7 +47,7 @@ object DocParserBench extends Bench.LocalTime {
     )
   )
 
-  def run(str: String): Result[Doc] = DocParser.run(str)
+  def run(str: String): Result[Documented] = DocParser.run(str)
   performance of "DocParser" in {
     tests.foreach {
       case (name, gen) => measure method name in (using(gen) in run)

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
@@ -89,8 +89,8 @@ object DocParserRunner {
     val preparedDocs = createdDocs match {
       case mod: AST.Module => reformatDocumentation(mod, ast)
     }
-    /* NOTE : Commented out just for ease of debugging procedures */
-//    generateHTMLForEveryDocumentation(preparedDocs)
+    /* NOTE : Comment out for ease of debugging procedures */
+    generateHTMLForEveryDocumentation(preparedDocs)
     preparedDocs
   }
 

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
@@ -85,8 +85,10 @@ object DocParserRunner {
     * @return - AST with possible documentation
     */
   def create(ast: AST.Module): AST = {
-    val createdDocs  = createDocs(ast).asInstanceOf[AST.Module]
-    val preparedDocs = reformatDocumentation(createdDocs, ast)
+    val createdDocs = createDocs(ast)
+    val preparedDocs = createdDocs match {
+      case mod: AST.Module => reformatDocumentation(mod, ast)
+    }
     /* NOTE : Commented out just for ease of debugging procedures */
 //    generateHTMLForEveryDocumentation(preparedDocs)
     preparedDocs
@@ -113,11 +115,30 @@ object DocParserRunner {
               }
             case _ => v
           }
+        // FIXME - THIS IS UUUUGLY, still, next PR
 //        case v: AST.Def =>
 //          /* NOTE - Only create title if def is right under Doc */
 //          previousElement match {
-//            case documented: Documented => defAction(v, documented)
-//            case _                      => v
+//            case documented: Documented =>
+//              v.body match {
+//                case Some(b) =>
+//                  b match {
+//                    case c: AST.Block =>
+//                      AST.Module(
+//                        AST.Block
+//                          ._Line(Some(defAction(v, documented)), c.indent),
+//                        AST.Block._Line(Some(createDocs(v)), c.indent)
+//                      )
+//                    case _ =>
+//                      AST.Module(
+//                        AST.Block
+//                          ._Line(Some(defAction(v, documented)), 0),
+//                        AST.Block._Line(Some(createDocs(v)), 0)
+//                      )
+//                  }
+//                case None => defAction(v, documented)
+//              }
+//            case _ => v
 //          }
         case v => createDocs(v)
       }
@@ -195,6 +216,8 @@ object DocParserRunner {
           val updatedWithInfix = updatedWithDoc.updated(elem._2, infix)
 
           astDoc = AST.Module(List1(updatedWithInfix).get)
+//        case v: AST.Def => //FIXME - Loop through Def's
+//          reformatDocumentation(astWithDoc.lines.toList(elem._2), astBeginning.lines.toList(elem._2))
         case _ =>
       }
     }

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
@@ -6,6 +6,7 @@ import java.io.PrintWriter
 import org.enso.flexer
 import org.enso.flexer.Reader
 import org.enso.syntax.text.ast.Doc
+import org.enso.syntax.text.ast.meta.Builtin
 import org.enso.syntax.text.spec.DocParserDef
 import scalatags.Text.TypedTag
 
@@ -19,12 +20,14 @@ class DocParser {
   import DocParser._
   private val engine = newEngine()
 
-  def parserRun(input: String): AST = run(input) match {
+  def runner(input: String, renderHTML: Boolean): AST = run(input) match {
     case flexer.Parser.Result(_, flexer.Parser.Result.Success(v)) =>
-      println(v.renderHTML("style.css"))
-      val path =
-        "syntax/specialization/src/main/scala/org/enso/syntax/text/DocParserHTMLOut/"
-      saveHTMLCodeToLocalFile(path, v.renderHTML("style.css"))
+      if (renderHTML) {
+        println(v.renderHTML("style.css"))
+        val path =
+          "syntax/specialization/src/main/scala/org/enso/syntax/text/DocParserHTMLOut/"
+        saveHTMLCodeToLocalFile(path, v.renderHTML("style.css"))
+      }
       v
     case _ => Doc()
   }
@@ -36,8 +39,11 @@ object DocParser {
   type Result[T] = flexer.Parser.Result[T]
   private val newEngine = flexer.Parser.compile(DocParserDef())
 
-  def parserRun(input: String): AST         = new DocParser().parserRun(input)
-  def run(input: String):       Result[Doc] = new DocParser().run(input)
+  def runnerWithHTMLRendering(input: String): AST =
+    new DocParser().runner(input, renderHTML = true)
+  def runner(input: String): AST =
+    new DocParser().runner(input, renderHTML = false)
+  def run(input: String): Result[Doc] = new DocParser().run(input)
 
   def saveHTMLCodeToLocalFile(path: String, code: TypedTag[String]): Unit = {
     val writer = new PrintWriter(
@@ -47,5 +53,99 @@ object DocParser {
     )
     writer.write(code.toString)
     writer.close()
+  }
+}
+
+object DocParserRunner {
+  /* TODO [MM] - CreateDocumentation - walk through parsed data and look in
+               Infix for title of function under documentation, then create
+               true documented body */
+
+  /** createDocumentation - function for invoking DocParser in right places
+    * and creating documentation from parsed comments
+    *
+    * @param ast - parsed data
+    * @return - AST with possible documentation
+    */
+  def create(ast: AST): AST = {
+    ast match {
+      case v: AST.Macro.Match        => macroMatchAction(v)
+      case v: AST.Comment.MultiLine  => MultilineAction(v)
+      case v: AST.Comment.SingleLine => SinglelineAction(v)
+      case v: AST.App._Infix         => infixAction(v)
+      case v                         => defaultAction(v)
+    }
+  }
+
+  def SinglelineAction(ast: AST.Comment.SingleLine): AST = {
+    println("\n--- FOUND SINGLE LINE COMMENT ---\n")
+    pprint.pprintln(ast, width = 50, height = 10000)
+    val in = ast.text
+    DocParser.runner(in)
+  }
+
+  def MultilineAction(ast: AST.Comment.MultiLine): AST = {
+    println("\n--- FOUND MULTI LINE COMMENT ---\n")
+    pprint.pprintln(ast, width = 50, height = 10000)
+    val in = ast.lines.mkString("\n")
+    DocParser.runner(in)
+  }
+
+  def infixAction(ast: AST.App._Infix): AST = {
+    println("\n--- FOUND INFIX ---\n")
+    pprint.pprintln(ast, width = 50, height = 10000)
+    println("--- L ARG: " + ast.larg)
+    println("--- L OFF: " + ast.loff)
+    println("--- OPR  : " + ast.opr)
+    println("--- R ARG: " + ast.rarg)
+    println("--- R OFF: " + ast.roff)
+    ast.larg match {
+      case _: AST._App =>
+        ast.opr match {
+          case AST.Opr("=") => createTitleFromInfix(ast)
+          case _            => infixActionNoTitleFound(ast)
+        }
+      case _ => infixActionNoTitleFound(ast)
+    }
+  }
+
+  def createTitleFromInfix(ast: AST): AST = {
+    println("\n--- FOUND LAMBDA DEFINITION ---\n")
+    infixActionNoTitleFound(ast) //TODO - CREATE DOC TITLE/HEADER?
+  }
+
+  def infixActionNoTitleFound(ast: AST): AST = {
+    println("\n--- NO TITLE FOUND ---\n")
+    ast.map({ elem =>
+      println("\n--- --- --- TRYING WITH ELEM (INFIX): ---\n")
+      pprint.pprintln(elem, width = 50, height = 10000)
+      create(elem)
+    })
+  }
+
+  def macroMatchAction(ast: AST.Macro.Match): AST = {
+    Builtin.registry.get(ast.path()) match {
+      case None => throw new Error("Macro definition not found")
+      case Some(spec) =>
+        println("\n--- --- --- MATCH FOUND: ---\n")
+        pprint.pprintln(spec, width = 50, height = 10000)
+        println("\n--- --- --- MATCH FINALIZERS: ---\n")
+        pprint.pprintln(
+          spec.fin(ast.pfx, ast.segs.toList().map(_.el)),
+          width  = 50,
+          height = 10000
+        )
+        create(spec.fin(ast.pfx, ast.segs.toList().map(_.el)))
+    }
+  }
+
+  def defaultAction(ast: AST): AST = {
+    println("\n--- NO COMMENT FOUND IN THIS ELEMENT ---\n")
+    pprint.pprintln(ast, width = 50, height = 10000)
+    ast.map({ elem =>
+      println("\n--- --- --- TRY FROM ELEM (DEFAULT): ---\n")
+      pprint.pprintln(elem, width = 50, height = 10000)
+      create(elem)
+    })
   }
 }

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
@@ -136,7 +136,7 @@ object DocParserRunner {
     val doc        = Doc(Doc.Synopsis(Doc.Section.Raw(docHeader)))
     pprint.pprintln(doc)
     println(doc.show())
-    previousElement = doc
+    previousElement = ast
     findCommentsAndTitles(doc)
   }
 

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
@@ -115,31 +115,6 @@ object DocParserRunner {
               }
             case _ => v
           }
-        // FIXME - THIS IS UUUUGLY, still, next PR
-//        case v: AST.Def =>
-//          /* NOTE - Only create title if def is right under Doc */
-//          previousElement match {
-//            case documented: Documented =>
-//              v.body match {
-//                case Some(b) =>
-//                  b match {
-//                    case c: AST.Block =>
-//                      AST.Module(
-//                        AST.Block
-//                          ._Line(Some(defAction(v, documented)), c.indent),
-//                        AST.Block._Line(Some(createDocs(v)), c.indent)
-//                      )
-//                    case _ =>
-//                      AST.Module(
-//                        AST.Block
-//                          ._Line(Some(defAction(v, documented)), 0),
-//                        AST.Block._Line(Some(createDocs(v)), 0)
-//                      )
-//                  }
-//                case None => defAction(v, documented)
-//              }
-//            case _ => v
-//          }
         case v => createDocs(v)
       }
       previousElement
@@ -216,80 +191,11 @@ object DocParserRunner {
           val updatedWithInfix = updatedWithDoc.updated(elem._2, infix)
 
           astDoc = AST.Module(List1(updatedWithInfix).get)
-//        case v: AST.Def => //FIXME - Loop through Def's
-//          if (astBeginning.lines.toList.length <= elem._2) {
-//            astBeginning.lines.toList(elem._2).elem match {
-//              case Some(value) =>
-//                value match {
-//                  case d: AST.Def =>
-//                    d.body match {
-//                      case Some(value2) =>
-//                        value2 match {
-//                          case b: AST.Block =>
-//                            reformatBlock(v.body.get.asInstanceOf[AST.Block], b)
-//                          case _ =>
-//                        }
-//                      case None =>
-//                    }
-//                  case _ =>
-//                }
-//              case None =>
-//            }
-//          }
         case _ =>
       }
     }
     astDoc
   }
-
-//  def reformatBlock(
-//    astWithDoc: AST.Block,
-//    astBeginning: AST.Block
-//  ): AST.Block = {
-//    var astDoc = astWithDoc
-//    astWithDoc.lines.zipWithIndex.map { elem =>
-//      elem._1.elem.map {
-//        case v: Documentation =>
-//          // NOTE : Documented(before comment) -> Documentation
-//          val DocToLine = AST.Block._Line(Some(v), 0)
-//          val updatedWithDoc =
-//            astDoc.lines.updated(elem._2 - 1, DocToLine)
-//          // NOTE : Documentation -> Infix (to get back func. def)
-//          val infix            = astBeginning.lines(elem._2)
-//          val updatedWithInfix = updatedWithDoc.updated(elem._2, infix)
-//
-//          astDoc = AST._Block(
-//            AST.Block.Continuous,
-//            astWithDoc.indent,
-//            astWithDoc.emptyLines,
-//            updatedWithInfix.head.asInstanceOf[AST.Block.Line.NonEmpty],
-//            updatedWithInfix.tail
-//          )
-//        case v: AST.Def => //FIXME - Loop through Def's
-//          if (astBeginning.lines.length <= elem._2) {
-//            astBeginning.lines(elem._2).elem match {
-//              case Some(value) =>
-//                value match {
-//                  case d: AST.Def =>
-//                    d.body match {
-//                      case Some(value2) =>
-//                        value2 match {
-//                          case b: AST.Block =>
-//                            reformatBlock(v.body.get.asInstanceOf[AST.Block], b)
-//                          case _ =>
-//                        }
-//                      case None =>
-//                    }
-//                  case _ =>
-//                }
-//              case None =>
-//            }
-//          }
-//        case _ =>
-//      }
-//    }
-//    astDoc
-//  }
 
   /** generateHTMLForEveryDocumentation - this method is used for generation of
     * HTML files from parsed and reformatted Documentation(s) and/or Documented(s)

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
@@ -217,12 +217,79 @@ object DocParserRunner {
 
           astDoc = AST.Module(List1(updatedWithInfix).get)
 //        case v: AST.Def => //FIXME - Loop through Def's
-//          reformatDocumentation(astWithDoc.lines.toList(elem._2), astBeginning.lines.toList(elem._2))
+//          if (astBeginning.lines.toList.length <= elem._2) {
+//            astBeginning.lines.toList(elem._2).elem match {
+//              case Some(value) =>
+//                value match {
+//                  case d: AST.Def =>
+//                    d.body match {
+//                      case Some(value2) =>
+//                        value2 match {
+//                          case b: AST.Block =>
+//                            reformatBlock(v.body.get.asInstanceOf[AST.Block], b)
+//                          case _ =>
+//                        }
+//                      case None =>
+//                    }
+//                  case _ =>
+//                }
+//              case None =>
+//            }
+//          }
         case _ =>
       }
     }
     astDoc
   }
+
+//  def reformatBlock(
+//    astWithDoc: AST.Block,
+//    astBeginning: AST.Block
+//  ): AST.Block = {
+//    var astDoc = astWithDoc
+//    astWithDoc.lines.zipWithIndex.map { elem =>
+//      elem._1.elem.map {
+//        case v: Documentation =>
+//          // NOTE : Documented(before comment) -> Documentation
+//          val DocToLine = AST.Block._Line(Some(v), 0)
+//          val updatedWithDoc =
+//            astDoc.lines.updated(elem._2 - 1, DocToLine)
+//          // NOTE : Documentation -> Infix (to get back func. def)
+//          val infix            = astBeginning.lines(elem._2)
+//          val updatedWithInfix = updatedWithDoc.updated(elem._2, infix)
+//
+//          astDoc = AST._Block(
+//            AST.Block.Continuous,
+//            astWithDoc.indent,
+//            astWithDoc.emptyLines,
+//            updatedWithInfix.head.asInstanceOf[AST.Block.Line.NonEmpty],
+//            updatedWithInfix.tail
+//          )
+//        case v: AST.Def => //FIXME - Loop through Def's
+//          if (astBeginning.lines.length <= elem._2) {
+//            astBeginning.lines(elem._2).elem match {
+//              case Some(value) =>
+//                value match {
+//                  case d: AST.Def =>
+//                    d.body match {
+//                      case Some(value2) =>
+//                        value2 match {
+//                          case b: AST.Block =>
+//                            reformatBlock(v.body.get.asInstanceOf[AST.Block], b)
+//                          case _ =>
+//                        }
+//                      case None =>
+//                    }
+//                  case _ =>
+//                }
+//              case None =>
+//            }
+//          }
+//        case _ =>
+//      }
+//    }
+//    astDoc
+//  }
 
   /** generateHTMLForEveryDocumentation - this method is used for generation of
     * HTML files from parsed and reformatted Documentation(s) and/or Documented(s)

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
@@ -75,9 +75,6 @@ object DocParser {
 ////////////////////////////////////////////////////////////////////////////////
 
 object DocParserRunner {
-  /* TODO [MM] - CreateDocumentation - walk through parsed data and look in
-               Infix for title of function under documentation, then create
-               true documented body */
   var previousElement: AST = AST.Blank
 
   /** create - function for invoking DocParser in right places

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
@@ -87,7 +87,8 @@ object DocParserRunner {
   def create(ast: AST.Module): AST = {
     val createdDocs  = createDocs(ast)
     val preparedDocs = reformatDocumentation(createdDocs, ast)
-    generateHTMLForEveryDocumentation(preparedDocs)
+    /* NOTE : Commented out just for ease of debugging procedures */
+//    generateHTMLForEveryDocumentation(preparedDocs)
     preparedDocs
   }
 
@@ -99,7 +100,6 @@ object DocParserRunner {
     */
   def createDocs(ast: AST.Module): AST.Module = {
     ast.map { elem =>
-      println("ELEM OF AST : " + elem)
       previousElement = elem match {
         case v: AST.Comment.MultiLine  => multiLineAction(v)
         case v: AST.Comment.SingleLine => singleLineAction(v)
@@ -127,8 +127,6 @@ object DocParserRunner {
     * @return - Documentation from single line comment
     */
   def singleLineAction(ast: AST.Comment.SingleLine): Documented = {
-    println("\n--- FOUND SINGLE LINE COMMENT ---\n")
-    pprint.pprintln(ast, width = 50, height = 10000)
     val in = ast.text
     DocParser.runMatched(in)
   }
@@ -139,8 +137,6 @@ object DocParserRunner {
     * @return - Documentation from multi line comment
     */
   def multiLineAction(ast: AST.Comment.MultiLine): Documented = {
-    println("\n--- FOUND MULTI LINE COMMENT ---\n")
-    pprint.pprintln(ast, width = 50, height = 10000)
     val in = ast.lines.mkString("\n")
     DocParser.runMatched(in)
   }
@@ -154,8 +150,6 @@ object DocParserRunner {
     ast: AST.App._Infix,
     doc: Documented
   ): Option[Documentation] = {
-    println("\n--- FOUND INFIX ---\n")
-    pprint.pprintln(ast, width = 50, height = 10000)
     ast.larg match {
       case v: AST._App => Some(Documentation(Some(v.show()), doc))
       case _           => None
@@ -191,6 +185,11 @@ object DocParserRunner {
     astDoc
   }
 
+  /** generateHTMLForEveryDocumentation - this method is used for generation of
+    * HTML files from parsed and reformated Documetation(s) and/or Documented(s)
+    *
+    * @param ast - parsed AST.Module and reformatted using Doc Parser
+    */
   def generateHTMLForEveryDocumentation(ast: AST.Module): Unit = {
     ast.map { elem =>
       elem match {

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
@@ -66,7 +66,7 @@ object DocParserRunner {
                true documented body */
 
   var previousElement: AST = AST.Blank
-  var prevDoc: Doc         = Doc()
+//  var prevDoc: Doc         = Doc()
 
   /** create- function for invoking DocParser in right places
     * and creating documentation from parsed comments
@@ -75,33 +75,35 @@ object DocParserRunner {
     * @return - AST with possible documentation
     */
   def create(ast: AST): AST = {
-    var astParsed = findCommentsAndTitles(ast)
-    astParsed = loopToOrientDocs(astParsed)
-    astParsed
+//    var astParsed = findCommentsAndTitles(ast)
+//    astParsed = loopToOrientDocs(astParsed)
+//    astParsed
+    findCommentsAndTitles(ast)
   }
 
-  def loopToOrientDocs(ast: AST): AST = {
-    ast match {
-      case v: Doc =>
-        println("DOC FOUND! : " + v + "\n")
-        if (prevDoc == Doc()) {
-          prevDoc = v
-          Doc()
-        } else {
-          val head = AST.Block._Line(Some(v), 0)
-          val body = AST.Block._Line(Some(prevDoc), 0)
-          prevDoc = Doc()
-
-          AST.Module(head, body)
-        }
-      case v =>
-        println("NO DOC : " + v + "\n")
-        v.map({ elem =>
-          println("LOOPING : " + elem + "\n")
-          loopToOrientDocs(elem)
-        })
-    }
-  }
+//  def loopToOrientDocs(ast: AST): AST = {
+//    ast match {
+//      case v: Doc =>
+//        if (prevDoc == Doc()) {
+//          println("DOC FOUND! : " + v + "\n")
+//          prevDoc = v
+//          AST.Module(AST.Block._Line(Some(v), 0))
+//        } else {
+//          println("DOC CREATED! : " + v + "\n")
+//          val head = AST.Block._Line(Some(v), 0)
+//          val body = AST.Block._Line(Some(prevDoc), 0)
+//          prevDoc = Doc()
+//
+//          AST.Module(head, body)
+//        }
+//      case v =>
+//        println("NO DOC : " + v + "\n")
+//        v.map({ elem =>
+//          println("LOOPING : " + elem + "\n")
+//          loopToOrientDocs(elem)
+//        })
+//    }
+//  }
 
   def findCommentsAndTitles(ast: AST): AST = {
     println("PREVIOUS ELEMENT: " + previousElement + "--- --- --- --- --- ---")
@@ -119,6 +121,10 @@ object DocParserRunner {
     pprint.pprintln(ast, width = 50, height = 10000)
     val in = ast.text
     previousElement = DocParser.runner(in)
+//    AST.Module(
+//      AST.Block._Line(Some(AST.Comment.SingleLine("")), 0),
+//      AST.Block._Line(Some(previousElement), 0)
+//    )
     previousElement
   }
 
@@ -127,6 +133,10 @@ object DocParserRunner {
     pprint.pprintln(ast, width = 50, height = 10000)
     val in = ast.lines.mkString("\n")
     previousElement = DocParser.runner(in)
+//    AST.Module(
+//      AST.Block._Line(Some(AST.Comment.MultiLine(0, List(""))), 0),
+//      AST.Block._Line(Some(previousElement), 0)
+//    )
     previousElement
   }
 

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParserHTMLOut/style.css
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParserHTMLOut/style.css
@@ -142,7 +142,7 @@ h2 {
 //// Tags ////
 ////////////*/
 
-.Doc .Tags {
+ .Tags {
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 20px;
@@ -151,17 +151,17 @@ h2 {
     background-color: #fafafa;
 }
 
-.Doc .ExtForTagDetails {
+ .ExtForTagDetails {
     margin: 0 3px;
     color: #999999;
 }
 
-.Doc .Tags .DEPRECATED,
-.Doc .Tags .MODIFIED,
-.Doc .Tags .ADDED,
-.Doc .Tags .UPCOMING,
-.Doc .Tags .REMOVED,
-.Doc .Tags .UNRECOGNIZED {
+ .Tags .DEPRECATED,
+ .Tags .MODIFIED,
+ .Tags .ADDED,
+ .Tags .UPCOMING,
+ .Tags .REMOVED,
+ .Tags .UNRECOGNIZED {
     line-height: 1.5;
     font-weight: 400;
     border-radius: 3px;
@@ -175,29 +175,29 @@ h2 {
     background: transparent;
 }
 
-.Doc .Tags .DEPRECATED {
+ .Tags .DEPRECATED {
     border-color: #c35400;
     color: #c35400;
 }
 
-.Doc .Tags .MODIFIED {
+ .Tags .MODIFIED {
     border-color: #8A82CF;
     color: #8A82CF;
 }
 
-.Doc .Tags .ADDED {
+ .Tags .ADDED {
     border-color: #79A129;
     color: #79A129;
 }
 
-.Doc .Tags .UPCOMING,
-.Doc .Tags .REMOVED,
-.Doc .Tags .UNRECOGNIZED {
+ .Tags .UPCOMING,
+ .Tags .REMOVED,
+ .Tags .UNRECOGNIZED {
     border-color: #888888;
     color: #666666;
 }
 
-.creator .Doc .Tags .UNRECOGNIZED {
+.creator  .Tags .UNRECOGNIZED {
     border: 2px solid;
     color: orangered;
 }
@@ -291,7 +291,12 @@ h2 {
     border-bottom: 1px solid #d6d6d6
 }
 
-.Doc {
+.Documentation .Title {
+    
+}
+
+
+.Documentation .Documented {
     margin: 0;
     width: 100%;
     background-color: #ffffff;

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParserHTMLOut/style.css
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParserHTMLOut/style.css
@@ -1,8 +1,3 @@
-/*//////////////////////////////////////////////////////////////////////////////
-////                           UNDER CONSTRUCTION                           ////
-//////////////////////////////////////////////////////////////////////////////*/
-
-
 /*///////////
 //// DOM ////
 ///////////*/
@@ -146,9 +141,11 @@ h2 {
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 20px;
-    padding: 15px 0;
+    padding: 15px 10px;
     text-align: center;
     background-color: #fafafa;
+    border-radius: 8px;
+
 }
 
  .ExtForTagDetails {
@@ -292,7 +289,13 @@ h2 {
 }
 
 .Documentation .Title {
-    
+    margin: 20 auto;
+    padding: 5px;
+    text-align: left;
+    font-size: 40px;
+    line-height: 1.05;
+    font-weight: 500;
+    letter-spacing: 0.008em;
 }
 
 
@@ -304,35 +307,45 @@ h2 {
 
 @media (min-width: 300px) {
     .Synopsis, 
-    .Body {
+    .Body,
+    .Tags,
+    .Documentation .Title {
         width: 380px
     }
 }
 
 @media (min-width: 500px) {
     .Synopsis, 
-    .Body {
+    .Body,
+    .Tags,
+    .Documentation .Title {
         width: 440px
     }
 }
 
 @media (min-width: 600px) {
     .Synopsis, 
-    .Body {
+    .Body,
+    .Tags,
+    .Documentation .Title {
         width: 490px
     }
 }
 
 @media (min-width: 900px) {
     .Synopsis, 
-    .Body {
+    .Body,
+    .Tags,
+    .Documentation .Title {
         width: 670px
     }
 }
 
 @media (min-width: 1300px) {
     .Synopsis,
-    .Body  {
+    .Body,
+    .Tags,
+    .Documentation .Title  {
         width: 780px
     }
 }

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -196,6 +196,24 @@ object Main extends App {
 //  val inp = "a = b -> c d"
 //  val inp = "x = skip (a.b)"
 //  val inp = "x(x[a))"
+//  val inp = """## Foo bar baz
+//             |def Maybe a
+//             |    ## Foo bo fo
+//             |    def Just val:a
+//             |    def Nothing
+//             |
+//             |def Maybe b
+//             |    ## Foo bo fo
+//             |    def Just val:b
+//             |    def Nothing
+//             |
+//             |def Foo
+//             |    ##
+//             |     this function takes parameters *x* and *y*
+//             |     and returns x added to y
+//             |    foo x y = x + y
+//             |    bar a b = a - b
+//             |    def Baz""".stripMargin
 
   val inp =
     """##
@@ -232,28 +250,9 @@ object Main extends App {
       |baz x y = x * y
       |## foo bar""".stripMargin
 
-  val inp2 = """## Foo bar baz
-               |def Maybe a
-               |    ## Foo bo fo 
-               |    def Just val:a
-               |    def Nothing
-               |    
-               |def Maybe b
-               |    ## Foo bo fo 
-               |    def Just val:b
-               |    def Nothing
-               |
-               |def Foo
-               |    ##
-               |     this function takes parameters *x* and *y*
-               |     and returns x added to y
-               |    foo x y = x + y
-               |    bar a b = a - b
-               |    def Baz""".stripMargin
-
   val parser = new Parser()
-  val out    = parser.run(new Reader(inp2), Seq())
-  ParserRunner.resultMatcher(parser, inp2, out)
+  val out    = parser.run(new Reader(inp), Seq())
+  ParserRunner.resultMatcher(parser, inp, out)
 }
 
 object ParserRunner {

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -213,7 +213,7 @@ object Main extends App {
       | ALAMAKOTA a kot ma Ale
       | Construct and manage a graphical, event-driven user interface for your
       | iOS or tvOS app.
-      | 
+      |
       | The UIKit framework provides the required infrastructure for your iOS or
       | tvOS apps. It provides the window and view architecture for implementing
       | your interface, the event handling infrastructure for delivering Multi-
@@ -221,9 +221,9 @@ object Main extends App {
       | to manage interactions among the user, the system, and your app. Other
       | features offered by the framework include animation support, document
       | support, drawing and printing support, information about the current
-      | device, text management and display, search support, accessibility  
+      | device, text management and display, search support, accessibility
       | support, app extension support, and resource management.
-      | 
+      |
       | ! Important
       |   Use UIKit classes only from your app’s main thread or main dispatch
       |   queue, unless otherwise indicated. This restriction particularly
@@ -232,9 +232,20 @@ object Main extends App {
       |baz x y = x * y
       |## foo bar""".stripMargin
 
+  val inp2 = """## Foo bar baz
+               |def Maybe a
+               |    ## Foo bo fo 
+               |    def Just val:a
+               |    def Nothing
+               |    
+               |def Maybe b
+               |    ## Foo bo fo 
+               |    def Just val:b
+               |    def Nothing""".stripMargin
+
   val parser = new Parser()
-  val out    = parser.run(new Reader(inp), Seq())
-  ParserRunner.resultMatcher(parser, inp, out)
+  val out    = parser.run(new Reader(inp2), Seq())
+  ParserRunner.resultMatcher(parser, inp2, out)
 }
 
 object ParserRunner {

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -249,9 +249,14 @@ object Main extends App {
 //  val inp = "x(x[a))"
 
   val inp =
-    """## this function adds parameter *x* to parameter *y*
+    """##
+      | this function takes parameters *x* and *y*
+      | and returns x added to y
       |foo x y = x + y
-      |foo2 x y = x + y
+      |##
+      | this function takes parameters *x* and *y*
+      | and returns x multiplied by y
+      |foo2 x y = x * y
       |## foo bar""".stripMargin
   /* NOTE
    * Now 1st comment -> Doc

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -251,11 +251,13 @@ object Main extends App {
   val inp =
     """## this function adds parameter *x* to parameter *y*
       |foo x y = x + y
-      |foo2 x y = x + y""".stripMargin
+      |foo2 x y = x + y
+      |## foo bar""".stripMargin
   /* NOTE
    * Now 1st comment -> Doc
    * func def -> Doc.Header TODO Doc.Header + func def
    * func 2 def Stays
+   * comment 2 doesnt have any function
    *
    * TODO organize docs:
    *  Doc.Header -> Doc -> func def -> ...

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -282,20 +282,21 @@ object Main extends App {
       println(
         "\n--- --- --- --- BEGIN `DocParserRunner.create` --- --- --- ---\n"
       )
-      val documentation = DocParserRunner.create(mod)
+      println("\n--- --- DOC IS USING DATA WITH RESOLVED MACROS  --- ---\n")
+      val documentation = DocParserRunner.create(rmod)
       println(
         "\n--- --- --- --- ENF OF `DocParserRunner.create` --- --- --- ---\n"
       )
-      if (mod != rmod) {
-        println("\n-- RESOLVED MACROS ARE DIFFERENT FROM MODULE --\n")
-        pprint.pprintln(rmod, width = 50, height = 10000)
-      }
+//      if (mod != rmod) {
+//        println("\n-- RESOLVED MACROS ARE DIFFERENT FROM MODULE --\n")
+//        pprint.pprintln(rmod, width = 50, height = 10000)
+//      }
       println("\n--- DOC PARSED  ---\n")
       pprint.pprintln(documentation, width = 50, height = 10000)
-      println("\n-- IN == MOD?  --\n")
-      println(mod.show() == inp)
-      println("\n----- INPUT -----\n")
-      println(inp)
+//      println("\n-- IN == MOD?  --\n")
+//      println(mod.show() == inp)
+//      println("\n----- INPUT -----\n")
+//      println(inp)
       println("\n-- MODULE SHOW --\n")
       println(mod.show())
       println("\n--- DOC SHOW  ---\n")

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -254,9 +254,32 @@ object Main extends App {
       | and returns x added to y
       |foo x y = x + y
       |bar a b = a - b
+      |
       |##
-      | this function takes parameters *x* and *y*
-      | and returns x multiplied by y
+      | DEPRECATED
+      | REMOVED - replaced by SwiftUI
+      | ADDED
+      | MODIFIED
+      | UPCOMING
+      | ALAMAKOTA a kot ma Ale
+      | Construct and manage a graphical, event-driven user interface for your
+      | iOS or tvOS app.
+      | 
+      | The UIKit framework provides the required infrastructure for your iOS or
+      | tvOS apps. It provides the window and view architecture for implementing
+      | your interface, the event handling infrastructure for delivering Multi-
+      | Touch and other types of input to your app, and the main run loop needed
+      | to manage interactions among the user, the system, and your app. Other
+      | features offered by the framework include animation support, document
+      | support, drawing and printing support, information about the current
+      | device, text management and display, search support, accessibility  
+      | support, app extension support, and resource management.
+      | 
+      | ! Important
+      |   Use UIKit classes only from your app’s main thread or main dispatch
+      |   queue, unless otherwise indicated. This restriction particularly
+      |   applies to classes derived from UIResponder or that involve
+      |   manipulating your app’s user interface in any way.
       |baz x y = x * y
       |## foo bar""".stripMargin
 

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -250,7 +250,16 @@ object Main extends App {
 
   val inp =
     """## this function adds parameter *x* to parameter *y*
-      |foo x y = x + y""".stripMargin
+      |foo x y = x + y
+      |foo2 x y = x + y""".stripMargin
+  /* NOTE
+   * Now 1st comment -> Doc
+   * func def -> Doc.Header TODO Doc.Header + func def
+   * func 2 def Stays
+   *
+   * TODO organize docs:
+   *  Doc.Header -> Doc -> func def -> ...
+   */
 
   val parser = new Parser()
   val out    = parser.run(new Reader(inp), Seq())

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -253,20 +253,12 @@ object Main extends App {
       | this function takes parameters *x* and *y*
       | and returns x added to y
       |foo x y = x + y
+      |bar a b = a - b
       |##
       | this function takes parameters *x* and *y*
       | and returns x multiplied by y
-      |foo2 x y = x * y
+      |baz x y = x * y
       |## foo bar""".stripMargin
-  /* NOTE
-   * Now 1st comment -> Doc
-   * func def -> Doc.Header TODO Doc.Header + func def
-   * func 2 def Stays
-   * comment 2 doesnt have any function
-   *
-   * TODO organize docs:
-   *  Doc.Header -> Doc -> func def -> ...
-   */
 
   val parser = new Parser()
   val out    = parser.run(new Reader(inp), Seq())

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -241,7 +241,15 @@ object Main extends App {
                |def Maybe b
                |    ## Foo bo fo 
                |    def Just val:b
-               |    def Nothing""".stripMargin
+               |    def Nothing
+               |
+               |def Foo
+               |    ##
+               |     this function takes parameters *x* and *y*
+               |     and returns x added to y
+               |    foo x y = x + y
+               |    bar a b = a - b
+               |    def Baz""".stripMargin
 
   val parser = new Parser()
   val out    = parser.run(new Reader(inp2), Seq())

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -249,8 +249,8 @@ object Main extends App {
 //  val inp = "x(x[a))"
 
   val inp =
-    """## foo bar baz
-      |foo x = x + 1""".stripMargin
+    """## this function adds parameter *x* to parameter *y*
+      |foo x y = x + y""".stripMargin
 
   val parser = new Parser()
   val out    = parser.run(new Reader(inp), Seq())

--- a/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -286,38 +286,29 @@ object Main extends App {
   val parser = new Parser()
   val out    = parser.run(new Reader(inp), Seq())
 
-  println("\n-- RESULT --\n")
   pprint.pprintln(out, width = 50, height = 10000)
+  println("------")
 
   out match {
     case flexer.Parser.Result(_, flexer.Parser.Result.Success(mod)) =>
-      println("\n-- PARSED MODULE --\n")
       pprint.pprintln(mod, width = 50, height = 10000)
-      val rmod = parser.resolveMacros(mod)
-      println(
-        "\n--- --- --- --- BEGIN `DocParserRunner.create` --- --- --- ---\n"
-      )
-      println("\n--- --- DOC IS USING DATA WITH RESOLVED MACROS  --- ---\n")
+      println("------")
+      val rmod          = parser.resolveMacros(mod)
       val documentation = DocParserRunner.create(rmod)
-      println(
-        "\n--- --- --- --- ENF OF `DocParserRunner.create` --- --- --- ---\n"
-      )
-//      if (mod != rmod) {
-//        println("\n-- RESOLVED MACROS ARE DIFFERENT FROM MODULE --\n")
-//        pprint.pprintln(rmod, width = 50, height = 10000)
-//      }
-      println("\n--- DOC PARSED  ---\n")
+      if (mod != rmod) {
+        pprint.pprintln(rmod, width = 50, height = 10000)
+        println("------")
+      }
       pprint.pprintln(documentation, width = 50, height = 10000)
-//      println("\n-- IN == MOD?  --\n")
-//      println(mod.show() == inp)
-//      println("\n----- INPUT -----\n")
-//      println(inp)
-      println("\n-- MODULE SHOW --\n")
+      println("------")
+      println(mod.show() == inp)
+      println("------")
+      println(inp)
+      println("------")
       println(mod.show())
-      println("\n--- DOC SHOW  ---\n")
+      println("------")
       println(documentation.show())
-      println("\n-----------------")
-
+      println("------")
   }
   println()
 }

--- a/syntax/specialization/src/test/scala/org/enso/syntax/text/DocParserTests.scala
+++ b/syntax/specialization/src/test/scala/org/enso/syntax/text/DocParserTests.scala
@@ -1,8 +1,8 @@
 package org.enso.syntax.text
 
-import org.enso.syntax.text.ast.Doc
-import org.enso.syntax.text.ast.Doc._
-import org.enso.syntax.text.ast.Doc.Elem._
+import org.enso.syntax.text.ast.Documented
+import org.enso.syntax.text.ast.Documented._
+import org.enso.syntax.text.ast.Documented.Elem._
 import org.enso.Logger
 import org.enso.flexer.Parser.Result
 import org.scalatest.FlatSpec
@@ -12,7 +12,7 @@ import org.scalatest.Assertion
 class DocParserTests extends FlatSpec with Matchers {
   val logger = new Logger()
 
-  def assertExpr(input: String, result: Doc): Assertion = {
+  def assertExpr(input: String, result: Documented): Assertion = {
     val output = DocParser.run(input)
     output match {
       case Result(_, Result.Success(value)) =>
@@ -31,7 +31,7 @@ class DocParserTests extends FlatSpec with Matchers {
 
     private val testBase = it should parseDocumentation(input)
 
-    def ?=(out: Doc): Unit = testBase in {
+    def ?=(out: Documented): Unit = testBase in {
       assertExpr(input, out)
     }
   }
@@ -44,55 +44,59 @@ class DocParserTests extends FlatSpec with Matchers {
   //// Formatters //////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  "*Foo*" ?= Doc(Synopsis(Section.Raw(Formatter(Formatter.Bold, "Foo"))))
-  "_Foo_" ?= Doc(Synopsis(Section.Raw(Formatter(Formatter.Italic, "Foo"))))
-  "~Foo~" ?= Doc(
+  "*Foo*" ?= Documented(
+    Synopsis(Section.Raw(Formatter(Formatter.Bold, "Foo")))
+  )
+  "_Foo_" ?= Documented(
+    Synopsis(Section.Raw(Formatter(Formatter.Italic, "Foo")))
+  )
+  "~Foo~" ?= Documented(
     Synopsis(Section.Raw(Formatter(Formatter.Strikeout, "Foo")))
   )
-  "`Foo`" ?= Doc(Synopsis(Section.Raw(CodeBlock.Inline("Foo"))))
-  "~*Foo*~" ?= Doc(
+  "`Foo`" ?= Documented(Synopsis(Section.Raw(CodeBlock.Inline("Foo"))))
+  "~*Foo*~" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter(Formatter.Strikeout, Formatter(Formatter.Bold, "Foo"))
       )
     )
   )
-  "~_Foo_~" ?= Doc(
+  "~_Foo_~" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter(Formatter.Strikeout, Formatter(Formatter.Italic, "Foo"))
       )
     )
   )
-  "_~Foo~_" ?= Doc(
+  "_~Foo~_" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter(Formatter.Italic, Formatter(Formatter.Strikeout, "Foo"))
       )
     )
   )
-  "_*Foo*_" ?= Doc(
+  "_*Foo*_" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter(Formatter.Italic, Formatter(Formatter.Bold, "Foo"))
       )
     )
   )
-  "*_Foo_*" ?= Doc(
+  "*_Foo_*" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter(Formatter.Bold, Formatter(Formatter.Italic, "Foo"))
       )
     )
   )
-  "*~Foo~*" ?= Doc(
+  "*~Foo~*" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter(Formatter.Bold, Formatter(Formatter.Strikeout, "Foo"))
       )
     )
   )
-  "_~*Foo*~_" ?= Doc(
+  "_~*Foo*~_" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter(
@@ -102,7 +106,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "`import foo`" ?= Doc(
+  "`import foo`" ?= Documented(
     Synopsis(
       Section.Raw(CodeBlock.Inline("import foo"))
     )
@@ -112,14 +116,14 @@ class DocParserTests extends FlatSpec with Matchers {
   //// Unclosed formatters /////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  "_*Foo*" ?= Doc(
+  "_*Foo*" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter.Unclosed(Formatter.Italic, Formatter(Formatter.Bold, "Foo"))
       )
     )
   )
-  "~*Foo*" ?= Doc(
+  "~*Foo*" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter
@@ -127,7 +131,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "***Foo" ?= Doc(
+  "***Foo" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter(Formatter.Bold),
@@ -135,14 +139,14 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "*_Foo_" ?= Doc(
+  "*_Foo_" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter.Unclosed(Formatter.Bold, Formatter(Formatter.Italic, "Foo"))
       )
     )
   )
-  "~_Foo_" ?= Doc(
+  "~_Foo_" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter
@@ -150,7 +154,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "___Foo" ?= Doc(
+  "___Foo" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter(Formatter.Italic),
@@ -158,7 +162,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "*~Foo~" ?= Doc(
+  "*~Foo~" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter
@@ -166,7 +170,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "_~Foo~" ?= Doc(
+  "_~Foo~" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter
@@ -174,7 +178,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "~~~Foo" ?= Doc(
+  "~~~Foo" ?= Documented(
     Synopsis(
       Section.Raw(
         Formatter(Formatter.Strikeout),
@@ -182,7 +186,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  " foo *bar* _baz *bo*_" ?= Doc(
+  " foo *bar* _baz *bo*_" ?= Documented(
     Synopsis(
       Section.Raw(
         1,
@@ -194,12 +198,12 @@ class DocParserTests extends FlatSpec with Matchers {
     )
   )
   """foo *bar
-    |*""".stripMargin ?= Doc(
+    |*""".stripMargin ?= Documented(
     Synopsis(Section.Raw("foo ", Formatter(Formatter.Bold, "bar", Newline)))
   )
 
   """foo _foo
-    |_foo2""".stripMargin ?= Doc(
+    |_foo2""".stripMargin ?= Documented(
     Synopsis(
       Section
         .Raw("foo ", Formatter(Formatter.Italic, "foo", Newline), "foo2")
@@ -207,7 +211,7 @@ class DocParserTests extends FlatSpec with Matchers {
   )
 
   """foo *foo
-    |*foo2""".stripMargin ?= Doc(
+    |*foo2""".stripMargin ?= Documented(
     Synopsis(
       Section
         .Raw("foo ", Formatter(Formatter.Bold, "foo", Newline), "foo2")
@@ -215,7 +219,7 @@ class DocParserTests extends FlatSpec with Matchers {
   )
 
   """foo ~foo
-    |~foo2""".stripMargin ?= Doc(
+    |~foo2""".stripMargin ?= Documented(
     Synopsis(
       Section
         .Raw("foo ", Formatter(Formatter.Strikeout, "foo", Newline), "foo2")
@@ -226,40 +230,40 @@ class DocParserTests extends FlatSpec with Matchers {
   //// Segments ////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  "!Important" ?= Doc(
+  "!Important" ?= Documented(
     Synopsis(
       Section.Marked(Section.Marked.Important, Section.Header("Important"))
     )
   )
-  " ! Important" ?= Doc(
+  " ! Important" ?= Documented(
     Synopsis(
       Section
         .Marked(1, 1, Section.Marked.Important, Section.Header("Important"))
     )
   )
-  "   ! Important" ?= Doc(
+  "   ! Important" ?= Documented(
     Synopsis(
       Section
         .Marked(3, 1, Section.Marked.Important, Section.Header("Important"))
     )
   )
-  " !    Important" ?= Doc(
+  " !    Important" ?= Documented(
     Synopsis(
       Section
         .Marked(1, 4, Section.Marked.Important, Section.Header("Important"))
     )
   )
-  "?Info" ?= Doc(
+  "?Info" ?= Documented(
     Synopsis(Section.Marked(Section.Marked.Info, Section.Header("Info")))
   )
-  ">Example" ?= Doc(
+  ">Example" ?= Documented(
     Synopsis(
       Section.Marked(Section.Marked.Example, Section.Header("Example"))
     )
   )
   """?Info
     |
-    |!Important""".stripMargin ?= Doc(
+    |!Important""".stripMargin ?= Documented(
     Synopsis(
       Section.Marked(Section.Marked.Info, Section.Header("Info"), Newline)
     ),
@@ -271,7 +275,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |
     |!Important
     |
-    |>Example""".stripMargin ?= Doc(
+    |>Example""".stripMargin ?= Documented(
     Synopsis(
       Section.Marked(Section.Marked.Info, Section.Header("Info"), Newline)
     ),
@@ -293,7 +297,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |
     |?info
     |
-    |>Example""".stripMargin ?= Doc(
+    |>Example""".stripMargin ?= Documented(
     Synopsis(
       Section.Raw(
         "Foo ",
@@ -325,7 +329,7 @@ class DocParserTests extends FlatSpec with Matchers {
   //// Lists ///////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  "ul:\n  - Foo\n  - Bar" ?= Doc(
+  "ul:\n  - Foo\n  - Bar" ?= Documented(
     Synopsis(
       Section.Raw(
         "ul:",
@@ -334,7 +338,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "ol:\n  * Foo\n  * Bar" ?= Doc(
+  "ol:\n  * Foo\n  * Bar" ?= Documented(
     Synopsis(
       Section.Raw(
         "ol:",
@@ -348,7 +352,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |  - Second unordered item
     |    * First ordered sub item
     |    * Second ordered sub item
-    |  - Third unordered item""".stripMargin ?= Doc(
+    |  - Third unordered item""".stripMargin ?= Documented(
     Synopsis(
       Section.Raw(
         "List",
@@ -374,7 +378,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |  - Second unordered item
     |    * First ordered sub item
     |    *    Second ordered sub item
-    |  - Third unordered item""".stripMargin ?= Doc(
+    |  - Third unordered item""".stripMargin ?= Documented(
     Synopsis(
       Section.Raw(
         "List",
@@ -406,7 +410,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |      - First unordered sub item
     |      - Second unordered sub item
     |    * Third ordered sub item
-    |  - Fourth unordered item""".stripMargin ?= Doc(
+    |  - Fourth unordered item""".stripMargin ?= Documented(
     Synopsis(
       Section.Raw(
         "List",
@@ -458,7 +462,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |      - Second unordered sub item
     |    * Third ordered sub item
     |   * Wrong Indent Item
-    |  - Fourth unordered item""".stripMargin ?= Doc(
+    |  - Fourth unordered item""".stripMargin ?= Documented(
     Synopsis(
       Section.Raw(
         "List",
@@ -499,7 +503,7 @@ class DocParserTests extends FlatSpec with Matchers {
   //// Links ///////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  "[Hello](Http://Google.com)" ?= Doc(
+  "[Hello](Http://Google.com)" ?= Documented(
     Synopsis(
       Section.Raw(
         Link.URL(
@@ -509,7 +513,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "![Media](http://foo.com)" ?= Doc(
+  "![Media](http://foo.com)" ?= Documented(
     Synopsis(
       Section.Raw(
         Link.Image(
@@ -519,7 +523,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "![foo)" ?= Doc(
+  "![foo)" ?= Documented(
     Synopsis(
       Section.Raw(
         Link.Invalid(
@@ -528,7 +532,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "[foo)" ?= Doc(
+  "[foo)" ?= Documented(
     Synopsis(
       Section.Raw(
         Link.Invalid(
@@ -537,7 +541,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "[foo]bo)" ?= Doc(
+  "[foo]bo)" ?= Documented(
     Synopsis(
       Section.Raw(
         Link.Invalid(
@@ -546,7 +550,7 @@ class DocParserTests extends FlatSpec with Matchers {
       )
     )
   )
-  "![foo]google" ?= Doc(
+  "![foo]google" ?= Documented(
     Synopsis(
       Section.Raw(
         Link.Invalid(
@@ -556,7 +560,7 @@ class DocParserTests extends FlatSpec with Matchers {
     )
   )
 
-  "[foo]google" ?= Doc(
+  "[foo]google" ?= Documented(
     Synopsis(
       Section.Raw(
         Link.Invalid(
@@ -567,7 +571,7 @@ class DocParserTests extends FlatSpec with Matchers {
   )
 
   """[foo]bo)
-    |basdbasd""".stripMargin ?= Doc(
+    |basdbasd""".stripMargin ?= Documented(
     Synopsis(
       Section.Raw(
         Link.Invalid(
@@ -587,16 +591,16 @@ class DocParserTests extends FlatSpec with Matchers {
 
   allPossibleTags.foreach(
     t =>
-      s"${t.toString.toUpperCase()}\nFoo" ?= Doc(
+      s"${t.toString.toUpperCase()}\nFoo" ?= Documented(
         Tags(Tags.Tag(t)),
         Synopsis(Section.Raw("Foo"))
       )
   )
-  "DEPRECATED in 1.0\nFoo" ?= Doc(
+  "DEPRECATED in 1.0\nFoo" ?= Documented(
     Tags(Tags.Tag(Tags.Tag.Type.Deprecated, " in 1.0")),
     Synopsis(Section.Raw("Foo"))
   )
-  "DEPRECATED in 1.0\nMODIFIED\nFoo" ?= Doc(
+  "DEPRECATED in 1.0\nMODIFIED\nFoo" ?= Documented(
     Tags(
       Tags.Tag(Tags.Tag.Type.Deprecated, " in 1.0"),
       Tags.Tag(Tags.Tag.Type.Modified)
@@ -604,7 +608,7 @@ class DocParserTests extends FlatSpec with Matchers {
     Synopsis(Section.Raw("Foo"))
   )
   """   ALAMAKOTA a kot ma ale
-    | foo bar""".stripMargin ?= Doc(
+    | foo bar""".stripMargin ?= Documented(
     Tags(Tags.Tag(3, Tags.Tag.Unrecognized, "ALAMAKOTA a kot ma ale")),
     Synopsis(Section.Raw(1, "foo bar"))
   )
@@ -616,7 +620,7 @@ class DocParserTests extends FlatSpec with Matchers {
   """afsfasfsfjanfjanfa
     |jfnajnfjadnbfjabnf
     |   siafjaifhjiasjf
-    |   fasfknfanfijnf""".stripMargin ?= Doc(
+    |   fasfknfanfijnf""".stripMargin ?= Documented(
     Synopsis(
       Section.Raw(
         "afsfasfsfjanfjanfa",
@@ -634,7 +638,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |jfnajnfjadnbfjabnf
     |   siafjaifhjiasjf
     |     fasfknfanfijnf
-    |   fasfknfanfijnf""".stripMargin ?= Doc(
+    |   fasfknfanfijnf""".stripMargin ?= Documented(
     Synopsis(
       Section.Raw(
         "afsfasfsfjanfjanfa",
@@ -655,7 +659,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |     fasfknfanfijnf
     |          fasfknfanfijnf
     |     fasfknfanfijnf
-    |   fasfknfanfijnf""".stripMargin ?= Doc(
+    |   fasfknfanfijnf""".stripMargin ?= Documented(
     Synopsis(
       Section.Raw(
         "afsfasfsfjanfjanfa",
@@ -678,7 +682,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |     fasfknfanfijnf
     |  fasfknfanfijnf
     |     fasfknfanfijnf
-    |   fasfknfanfijnf""".stripMargin ?= Doc(
+    |   fasfknfanfijnf""".stripMargin ?= Documented(
     Synopsis(
       Section.Raw(
         "afsfasfsfjanfjanfa",
@@ -703,7 +707,7 @@ class DocParserTests extends FlatSpec with Matchers {
   """
     | - bar
     | baz
-    |""".stripMargin ?= Doc(
+    |""".stripMargin ?= Documented(
     Synopsis(
       Section.Raw(
         Newline,
@@ -720,7 +724,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |Construct and manage a graphical, event-driven user interface for your iOS or
     |tvOS app.
     |
-    | foo *foo*""".stripMargin ?= Doc(
+    | foo *foo*""".stripMargin ?= Documented(
     Tags(
       Tags.Tag(3, Tags.Tag.Type.Deprecated, " das sfa asf"),
       Tags.Tag(0, Tags.Tag.Type.Removed, " fdsdf")
@@ -741,7 +745,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |Construct and manage a graphical, event-driven user interface for your iOS or
     |tvOS app.
     |
-    | foo *foo""".stripMargin ?= Doc(
+    | foo *foo""".stripMargin ?= Documented(
     Tags(
       Tags.Tag(3, Tags.Tag.Type.Deprecated, " das sfa asf"),
       Tags.Tag(0, Tags.Tag.Type.Removed, " fdsdf")
@@ -759,7 +763,7 @@ class DocParserTests extends FlatSpec with Matchers {
 
   """    DEPRECATED das sfa asf
     |  REMOVED
-    | Foo""".stripMargin ?= Doc(
+    | Foo""".stripMargin ?= Documented(
     Tags(
       Tags.Tag(4, Tags.Tag.Type.Deprecated, " das sfa asf"),
       Tags.Tag(2, Tags.Tag.Type.Removed)
@@ -775,7 +779,7 @@ class DocParserTests extends FlatSpec with Matchers {
     |   fooo bar baz
     |   dsadasfsaf asfasfas
     |   asfasfa sf
-    |   asfas fasf """.stripMargin ?= Doc(
+    |   asfas fasf """.stripMargin ?= Documented(
     Tags(
       Tags.Tag(3, Tags.Tag.Type.Deprecated, " das sfa asf"),
       Tags.Tag(0, Tags.Tag.Type.Removed, " fdsdf")

--- a/syntax/specialization/src/test/scala/org/enso/syntax/text/DocParserTests.scala
+++ b/syntax/specialization/src/test/scala/org/enso/syntax/text/DocParserTests.scala
@@ -5,6 +5,7 @@ import org.enso.syntax.text.ast.Documented._
 import org.enso.syntax.text.ast.Documented.Elem._
 import org.enso.Logger
 import org.enso.flexer.Parser.Result
+import org.enso.syntax.text.ast.Documented.Tags.Tag
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.Assertion
@@ -587,7 +588,8 @@ class DocParserTests extends FlatSpec with Matchers {
   //// Tags ////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  val allPossibleTags = Tags.Tag.Type.codes.-(Tags.Tag.Unrecognized)
+  val allPossibleTags: Set[Tag.Type] =
+    Tags.Tag.Type.codes.-(Tags.Tag.Unrecognized)
 
   allPossibleTags.foreach(
     t =>


### PR DESCRIPTION
### Pull Request Description
#### For reference - (#121)
This is a small PR (as we discussed with Wojciech to open many small PR's) but it is really important, as it deeply integrates together DocParser with Parser. Now if you have some code like that:
```
## This function adds together x and y
foo x y = x + y
```
it will output to you:
```
Documentation(Title(foo x y),Documented(This function adds together x and y)
```
and that will display as
```
foo x y
This function adds together x and y
foo x y = x + y
```

In short words - it combines together parser output with docParser output in a better way, creates titles for documentation out of function names.

Also I've upgraded HTML generator with CSS to reflect changes, here's example output:
<img width="1224" alt="Zrzut ekranu 2019-08-30 o 17 46 47" src="https://user-images.githubusercontent.com/26655166/64034495-119f0580-cb4f-11e9-9836-d24c9dac9136.png">


### Important Notes
- As it is a small PR it can only create title from function name, some methods may be generalised in future

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

