### PR TITLE
Text literals for cata parser

### DIFF
--- a/syntax/definition/src/main/scala/org/enso/syntax/text/AST2.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/AST2.scala
@@ -6,6 +6,7 @@ import cats.Functor
 import cats.derived._
 import cats.implicits._
 import org.enso.data.List1._
+import org.enso.data.ADT
 import org.enso.data.List1
 import org.enso.data.Shifted
 import org.enso.data.Tree
@@ -601,8 +602,6 @@ object AST {
       sealed trait Segment[T]
       object Segment {
 
-        val Escape = ast.text.Escape
-
         // FIXME: Compatibility mode
 
         //// Definition ////
@@ -616,12 +615,17 @@ object AST {
         type Expr  = _Expr[AST]
         case class _Plain[T](value: String)   extends _Raw[T] with Phantom
         case class _Expr[T](value: Option[T]) extends _Fmt[T]
-        trait Escape[T]                       extends Phantom // FIXME with _Fmt[T] // this makes compilation fail on out of memory!
+        sealed trait Escape[T]                extends Phantom // FIXME with _Fmt[T] // this makes compilation fail on out of memory!
 
         //// Instances ////
 
         object implicits extends implicits
         trait implicits {
+
+          implicit def ftorEscape:          Functor[Escape]      = semi.functor
+          implicit def reprEscape[T: Repr]: Repr[Escape[T]]      = ???
+          implicit def offzipEscape[T]:     OffsetZip[Escape, T] = ???
+
           implicit def reprPlain[T]: Repr[_Plain[T]] = _.value
           implicit def reprExpr[T: Repr]: Repr[_Expr[T]] =
             R + '`' + _.value + '`'
@@ -661,6 +665,180 @@ object AST {
           case t: _Fmt[T] => OffsetZip(t)
         }
       }
+
+      object Escape {
+
+        type Escape[T] = Segment.Escape[T]
+
+        type Number  = ASTOf[NumberOf]
+        type Invalid = ASTOf[InvalidOf]
+
+        case class NumberOf[T](int: Int) extends Escape[T]
+        object Number {
+          def apply[T](int: Int):    NumberOf[T]            = NumberOf(int)
+          implicit def functor:      Functor[NumberOf]      = semi.functor
+          implicit def offsetZip[T]: OffsetZip[NumberOf, T] = t => t.coerce
+          implicit def repr[T]:      Repr[NumberOf[T]]      = R + '\\' + _.int.toString
+        }
+        case class InvalidOf[T](str: String)
+            extends Escape[T]
+            with AST.InvalidOf[T]
+        object Invalid {
+          def apply[T](str: String): InvalidOf[T]       = InvalidOf(str)
+          implicit def repr[T]:      Repr[InvalidOf[T]] = R + '\\' + _.str
+        }
+
+        // Reference: https://en.wikipedia.org/wiki/String_literal
+        sealed trait Unicode[T] extends Escape[T]
+        object Unicode {
+
+          type U          = ASTOf[UFO]
+          type U16        = ASTOf[UFO16]
+          type U32        = ASTOf[UFO32]
+          type U21        = ASTOf[UFO21]
+          type InvalidU16 = ASTOf[InvalidUFO16]
+          type InvalidU32 = ASTOf[InvalidUFO32]
+          type InvalidU21 = ASTOf[InvalidUFO21]
+
+          abstract class UFO[T](val pfx: String, val sfx: String)
+              extends Unicode[T] {
+            val digits: String
+          }
+          object UFO {
+            implicit def repr[T]: Repr[UFO[T]] =
+              t => R + "\\" + t.pfx + t.digits + t.sfx
+          }
+
+          final case class UFO16[T] private (digits: String)
+              extends UFO[T]("u", "")
+          final case class UFO32[T] private (digits: String)
+              extends UFO[T]("U", "")
+          final case class UFO21[T] private (digits: String)
+              extends UFO[T]("u{", "}")
+
+          final case class InvalidUFO16[T] private (digits: String)
+              extends UFO[T]("u", "")
+              with AST.InvalidOf[T]
+
+          final case class InvalidUFO32[T] private (digits: String)
+              extends UFO[T]("U", "")
+              with AST.InvalidOf[T]
+
+          final case class InvalidUFO21[T] private (digits: String)
+              extends UFO[T]("u{", "}")
+              with AST.InvalidOf[T]
+
+          object Validator {
+            val hexChars = (('a' to 'f') ++ ('A' to 'F') ++ ('0' to '9')).toSet
+            def isHexChar(char: Char) =
+              hexChars.contains(char)
+          }
+
+          object U16 {
+            def apply[T](digits: String): Unicode[T] =
+              if (validate(digits)) UFO16(digits) else InvalidUFO16(digits)
+            def validate(digits: String) = {
+              import Validator._
+              val validLength = digits.length == 4
+              val validChars  = digits.forall(isHexChar(_))
+              validLength && validChars
+            }
+          }
+          object U32 {
+            def apply[T](digits: String): Unicode[T] =
+              if (validate(digits)) UFO32(digits) else InvalidUFO32(digits)
+            def validate(digits: String) = {
+              import Validator._
+              val validLength = digits.length == 8
+              val validPrefix = digits.startsWith("00")
+              val validChars  = digits.forall(isHexChar(_))
+              validLength && validPrefix && validChars
+            }
+          }
+          object U21 {
+            def apply[T](digits: String): Unicode[T] =
+              if (validate(digits)) UFO21(digits) else InvalidUFO21(digits)
+            def validate(digits: String) = {
+              import Validator._
+              val validLength = digits.length >= 1 && digits.length <= 6
+              val validChars  = digits.forall(isHexChar(_))
+              validLength && validChars
+            }
+          }
+        }
+
+        type Simple = ASTOf[SimpleOf]
+
+        case class SimpleOf[T](char: CharCode) extends Escape[T]
+        object SimpleOf {
+          implicit def repr[T]: Repr[SimpleOf[T]] = R + _.char.repr
+        }
+
+        abstract class CharCode(val code: Int) {
+          def name = toString
+          def repr = R + '\\' + name
+        }
+
+        case object Slash extends CharCode('\\') { override def repr = "\\\\" }
+        case object Quote extends CharCode('\'') { override def repr = "\\'"  }
+        case object RawQuote extends CharCode('"') {
+          override def repr = "\\\""
+        }
+
+        // Reference: https://en.wikipedia.org/wiki/String_literal
+        sealed trait Character extends CharCode
+        object Character {
+          case object a extends CharCode('\u0007') with Character
+          case object b extends CharCode('\u0008') with Character
+          case object f extends CharCode('\u000C') with Character
+          case object n extends CharCode('\n') with Character
+          case object r extends CharCode('\r') with Character
+          case object t extends CharCode('\u0009') with Character
+          case object v extends CharCode('\u000B') with Character
+          case object e extends CharCode('\u001B') with Character
+          val codes = ADT.constructors[Character]
+        }
+
+        // Reference: https://en.wikipedia.org/wiki/Control_character
+        sealed trait Control extends CharCode
+        object Control {
+          case object NUL extends CharCode(0x00) with Control
+          case object SOH extends CharCode(0x01) with Control
+          case object STX extends CharCode(0x02) with Control
+          case object ETX extends CharCode(0x03) with Control
+          case object EOT extends CharCode(0x04) with Control
+          case object ENQ extends CharCode(0x05) with Control
+          case object ACK extends CharCode(0x06) with Control
+          case object BEL extends CharCode(0x07) with Control
+          case object BS  extends CharCode(0x08) with Control
+          case object TAB extends CharCode(0x09) with Control
+          case object LF  extends CharCode(0x0A) with Control
+          case object VT  extends CharCode(0x0B) with Control
+          case object FF  extends CharCode(0x0C) with Control
+          case object CR  extends CharCode(0x0D) with Control
+          case object SO  extends CharCode(0x0E) with Control
+          case object SI  extends CharCode(0x0F) with Control
+          case object DLE extends CharCode(0x10) with Control
+          case object DC1 extends CharCode(0x11) with Control
+          case object DC2 extends CharCode(0x12) with Control
+          case object DC3 extends CharCode(0x13) with Control
+          case object DC4 extends CharCode(0x14) with Control
+          case object NAK extends CharCode(0x15) with Control
+          case object SYN extends CharCode(0x16) with Control
+          case object ETB extends CharCode(0x17) with Control
+          case object CAN extends CharCode(0x18) with Control
+          case object EM  extends CharCode(0x19) with Control
+          case object SUB extends CharCode(0x1A) with Control
+          case object ESC extends CharCode(0x1B) with Control
+          case object FS  extends CharCode(0x1C) with Control
+          case object GS  extends CharCode(0x1D) with Control
+          case object RS  extends CharCode(0x1E) with Control
+          case object US  extends CharCode(0x1F) with Control
+          case object DEL extends CharCode(0x7F) with Control
+          val codes = ADT.constructors[Control]
+        }
+      }
+
     }
   }
 

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/ast/text/Escape.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/ast/text/Escape.scala
@@ -1,142 +1,175 @@
 package org.enso.syntax.text.ast.text
 
+import cats.Functor
+import cats.derived.semi
 import org.enso.data.ADT
 import org.enso.syntax.text.AST
 import org.enso.syntax.text.AST.Text.Segment
+import org.enso.syntax.text.AST.{ASTOf, OffsetZip}
+import org.enso.syntax.text.ast.Repr
 import org.enso.syntax.text.ast.Repr.R
 
-//object Escape {
-//  type Escape = Segment.Escape
-//  case object Slash           extends Escape { val repr = "\\\\" }
-//  case object Quote           extends Escape { val repr = "\\'" }
-//  case object RawQuote        extends Escape { val repr = "\\\"" }
-//  case class Number(int: Int) extends Escape { val repr = '\\' + int.toString }
-//  case class Invalid(str: String) extends Escape with AST.Invalid {
-//    val repr               = '\\' + str
-//    def map(f: AST => AST) = this
-//  }
-//
-//  // Reference: https://en.wikipedia.org/wiki/String_literal
-//  sealed trait Unicode extends Escape
-//  object Unicode {
-//    abstract class U(val pfx: String, val sfx: String) extends Unicode {
-//      val digits: String
-//      val repr = R + "\\" + pfx + digits + sfx
-//
-//    }
-//    final case class U16 private (digits: String) extends U("u", "")
-//    final case class U32 private (digits: String) extends U("U", "")
-//    final case class U21 private (digits: String) extends U("u{", "}")
-//    final case class InvalidU16 private (digits: String)
-//        extends U("u", "")
-//        with AST.Invalid {
-//      def map(f: AST => AST) = this
-//    }
-//    final case class InvalidU32 private (digits: String)
-//        extends U("U", "")
-//        with AST.Invalid {
-//      def map(f: AST => AST) = this
-//    }
-//    final case class InvalidU21 private (digits: String)
-//        extends U("u{", "}")
-//        with AST.Invalid {
-//      def map(f: AST => AST) = this
-//    }
-//
-//    object Validator {
-//      val hexChars = (('a' to 'f') ++ ('A' to 'F') ++ ('0' to '9')).toSet
-//      def isHexChar(char: Char) =
-//        hexChars.contains(char)
-//    }
-//
-//    object U16 {
-//      def apply(digits: String): Unicode =
-//        if (validate(digits)) new U16(digits) else InvalidU16(digits)
-//      def validate(digits: String) = {
-//        import Validator._
-//        val validLength = digits.length == 4
-//        val validChars  = digits.map(isHexChar).forall(identity)
-//        validLength && validChars
-//      }
-//    }
-//    object U32 {
-//      def apply(digits: String): Unicode =
-//        if (validate(digits)) new U32(digits) else InvalidU32(digits)
-//      def validate(digits: String) = {
-//        import Validator._
-//        val validLength = digits.length == 8
-//        val validPrefix = digits.startsWith("00")
-//        val validChars  = digits.map(isHexChar).forall(identity)
-//        validLength && validPrefix && validChars
-//      }
-//    }
-//    object U21 {
-//      def apply(digits: String): Unicode =
-//        if (validate(digits)) new U21(digits) else InvalidU21(digits)
-//      def validate(digits: String) = {
-//        import Validator._
-//        val validLength = digits.length >= 1 && digits.length <= 6
-//        val validChars  = digits.map(isHexChar).forall(identity)
-//        validLength && validChars
-//      }
-//    }
-//  }
-//
-//  abstract class Simple(val code: Int) extends Escape {
-//    val name = toString()
-//    val repr = '\\' + name
-//  }
-//
-//  // Reference: https://en.wikipedia.org/wiki/String_literal
-//  sealed trait Character extends Escape
-//  object Character {
-//    case object a extends Simple('\u0007') with Character
-//    case object b extends Simple('\u0008') with Character
-//    case object f extends Simple('\u000C') with Character
-//    case object n extends Simple('\n') with Character
-//    case object r extends Simple('\r') with Character
-//    case object t extends Simple('\u0009') with Character
-//    case object v extends Simple('\u000B') with Character
-//    case object e extends Simple('\u001B') with Character
-//    val codes = ADT.constructors[Character]
-//  }
-//
-//  // Reference: https://en.wikipedia.org/wiki/Control_character
-//  sealed trait Control extends Escape
-//  object Control {
-//    case object NUL extends Simple(0x00) with Control
-//    case object SOH extends Simple(0x01) with Control
-//    case object STX extends Simple(0x02) with Control
-//    case object ETX extends Simple(0x03) with Control
-//    case object EOT extends Simple(0x04) with Control
-//    case object ENQ extends Simple(0x05) with Control
-//    case object ACK extends Simple(0x06) with Control
-//    case object BEL extends Simple(0x07) with Control
-//    case object BS  extends Simple(0x08) with Control
-//    case object TAB extends Simple(0x09) with Control
-//    case object LF  extends Simple(0x0A) with Control
-//    case object VT  extends Simple(0x0B) with Control
-//    case object FF  extends Simple(0x0C) with Control
-//    case object CR  extends Simple(0x0D) with Control
-//    case object SO  extends Simple(0x0E) with Control
-//    case object SI  extends Simple(0x0F) with Control
-//    case object DLE extends Simple(0x10) with Control
-//    case object DC1 extends Simple(0x11) with Control
-//    case object DC2 extends Simple(0x12) with Control
-//    case object DC3 extends Simple(0x13) with Control
-//    case object DC4 extends Simple(0x14) with Control
-//    case object NAK extends Simple(0x15) with Control
-//    case object SYN extends Simple(0x16) with Control
-//    case object ETB extends Simple(0x17) with Control
-//    case object CAN extends Simple(0x18) with Control
-//    case object EM  extends Simple(0x19) with Control
-//    case object SUB extends Simple(0x1A) with Control
-//    case object ESC extends Simple(0x1B) with Control
-//    case object FS  extends Simple(0x1C) with Control
-//    case object GS  extends Simple(0x1D) with Control
-//    case object RS  extends Simple(0x1E) with Control
-//    case object US  extends Simple(0x1F) with Control
-//    case object DEL extends Simple(0x7F) with Control
-//    val codes = ADT.constructors[Control]
-//  }
-//}
+object Escape {
+
+  type Escape[T] = Segment.Escape[T]
+
+  type Number  = ASTOf[NumberOf]
+  type Invalid = ASTOf[InvalidOf]
+
+  case class NumberOf[T](int: Int) extends Escape[T]
+  object Number {
+    def apply[T](int: Int):    NumberOf[T]            = NumberOf(int)
+    implicit def functor:      Functor[NumberOf]      = semi.functor
+    implicit def offsetZip[T]: OffsetZip[NumberOf, T] = t => t.coerce
+    implicit def repr[T]:      Repr[NumberOf[T]]      = R + '\\' + _.int.toString
+  }
+  case class InvalidOf[T](str: String) extends Escape[T] //with AST.InvalidOf[T] FIXME if we unseal InvalidOf, we won't be able to derive functor for it
+  object Invalid {
+    def apply[T](str: String): InvalidOf[T]       = InvalidOf(str)
+    implicit def repr[T]:      Repr[InvalidOf[T]] = R + '\\' + _.str
+  }
+
+  // Reference: https://en.wikipedia.org/wiki/String_literal
+  sealed trait Unicode[T] extends Escape[T]
+  object Unicode {
+
+    type U          = ASTOf[UFO]
+    type U16        = ASTOf[UFO16]
+    type U32        = ASTOf[UFO32]
+    type U21        = ASTOf[UFO21]
+    type InvalidU16 = ASTOf[InvalidUFO16]
+    type InvalidU32 = ASTOf[InvalidUFO32]
+    type InvalidU21 = ASTOf[InvalidUFO21]
+
+    abstract class UFO[T](val pfx: String, val sfx: String) extends Unicode[T] {
+      val digits: String
+    }
+    object UFO {
+      implicit def repr[T]: Repr[UFO[T]] =
+        t => R + "\\" + t.pfx + t.digits + t.sfx
+    }
+
+    final case class UFO16[T] private (digits: String) extends UFO[T]("u", "")
+    final case class UFO32[T] private (digits: String) extends UFO[T]("U", "")
+    final case class UFO21[T] private (digits: String) extends UFO[T]("u{", "}")
+
+    final case class InvalidUFO16[T] private (digits: String)
+        extends UFO[T]("u", "")
+//        with AST.InvalidOf[T]
+
+    final case class InvalidUFO32[T] private (digits: String)
+        extends UFO[T]("U", "")
+//        with AST.InvalidOf[T]
+
+    final case class InvalidUFO21[T] private (digits: String)
+        extends UFO[T]("u{", "}")
+//        with AST.InvalidOf[T]
+
+    object Validator {
+      val hexChars = (('a' to 'f') ++ ('A' to 'F') ++ ('0' to '9')).toSet
+      def isHexChar(char: Char) =
+        hexChars.contains(char)
+    }
+
+    object U16 {
+      def apply[T](digits: String): Unicode[T] =
+        if (validate(digits)) UFO16(digits) else InvalidUFO16(digits)
+      def validate(digits: String) = {
+        import Validator._
+        val validLength = digits.length == 4
+        val validChars  = digits.map(isHexChar).forall(identity)
+        validLength && validChars
+      }
+    }
+    object U32 {
+      def apply[T](digits: String): Unicode[T] =
+        if (validate(digits)) UFO32(digits) else InvalidUFO32(digits)
+      def validate(digits: String) = {
+        import Validator._
+        val validLength = digits.length == 8
+        val validPrefix = digits.startsWith("00")
+        val validChars  = digits.map(isHexChar).forall(identity)
+        validLength && validPrefix && validChars
+      }
+    }
+    object U21 {
+      def apply[T](digits: String): Unicode[T] =
+        if (validate(digits)) UFO21(digits) else InvalidUFO21(digits)
+      def validate(digits: String) = {
+        import Validator._
+        val validLength = digits.length >= 1 && digits.length <= 6
+        val validChars  = digits.map(isHexChar).forall(identity)
+        validLength && validChars
+      }
+    }
+  }
+
+  type Simple = ASTOf[SimpleOf]
+
+  case class SimpleOf[T](char: CharCode) extends Escape[T]
+  object SimpleOf {
+    implicit def repr[T]: Repr[SimpleOf[T]] = R + _.char.repr
+  }
+
+  abstract class CharCode(val code: Int) {
+    def name = toString
+    def repr = R + '\\' + name
+  }
+
+  case object Slash    extends CharCode('\\') { override def repr = "\\\\" }
+  case object Quote    extends CharCode('\'') { override def repr = "\\'"  }
+  case object RawQuote extends CharCode('"')  { override def repr = "\\\"" }
+
+  // Reference: https://en.wikipedia.org/wiki/String_literal
+  sealed trait Character extends CharCode
+  object Character {
+    case object a extends CharCode('\u0007') with Character
+    case object b extends CharCode('\u0008') with Character
+    case object f extends CharCode('\u000C') with Character
+    case object n extends CharCode('\n') with Character
+    case object r extends CharCode('\r') with Character
+    case object t extends CharCode('\u0009') with Character
+    case object v extends CharCode('\u000B') with Character
+    case object e extends CharCode('\u001B') with Character
+    val codes = ADT.constructors[Character]
+  }
+
+  // Reference: https://en.wikipedia.org/wiki/Control_character
+  sealed trait Control extends CharCode
+  object Control {
+    case object NUL extends CharCode(0x00) with Control
+    case object SOH extends CharCode(0x01) with Control
+    case object STX extends CharCode(0x02) with Control
+    case object ETX extends CharCode(0x03) with Control
+    case object EOT extends CharCode(0x04) with Control
+    case object ENQ extends CharCode(0x05) with Control
+    case object ACK extends CharCode(0x06) with Control
+    case object BEL extends CharCode(0x07) with Control
+    case object BS  extends CharCode(0x08) with Control
+    case object TAB extends CharCode(0x09) with Control
+    case object LF  extends CharCode(0x0A) with Control
+    case object VT  extends CharCode(0x0B) with Control
+    case object FF  extends CharCode(0x0C) with Control
+    case object CR  extends CharCode(0x0D) with Control
+    case object SO  extends CharCode(0x0E) with Control
+    case object SI  extends CharCode(0x0F) with Control
+    case object DLE extends CharCode(0x10) with Control
+    case object DC1 extends CharCode(0x11) with Control
+    case object DC2 extends CharCode(0x12) with Control
+    case object DC3 extends CharCode(0x13) with Control
+    case object DC4 extends CharCode(0x14) with Control
+    case object NAK extends CharCode(0x15) with Control
+    case object SYN extends CharCode(0x16) with Control
+    case object ETB extends CharCode(0x17) with Control
+    case object CAN extends CharCode(0x18) with Control
+    case object EM  extends CharCode(0x19) with Control
+    case object SUB extends CharCode(0x1A) with Control
+    case object ESC extends CharCode(0x1B) with Control
+    case object FS  extends CharCode(0x1C) with Control
+    case object GS  extends CharCode(0x1D) with Control
+    case object RS  extends CharCode(0x1E) with Control
+    case object US  extends CharCode(0x1F) with Control
+    case object DEL extends CharCode(0x7F) with Control
+    val codes = ADT.constructors[Control]
+  }
+}

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/ast/text/Escape.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/ast/text/Escape.scala
@@ -1,175 +1,175 @@
-package org.enso.syntax.text.ast.text
-
-import cats.Functor
-import cats.derived.semi
-import org.enso.data.ADT
-import org.enso.syntax.text.AST
-import org.enso.syntax.text.AST.Text.Segment
-import org.enso.syntax.text.AST.{ASTOf, OffsetZip}
-import org.enso.syntax.text.ast.Repr
-import org.enso.syntax.text.ast.Repr.R
-
-object Escape {
-
-  type Escape[T] = Segment.Escape[T]
-
-  type Number  = ASTOf[NumberOf]
-  type Invalid = ASTOf[InvalidOf]
-
-  case class NumberOf[T](int: Int) extends Escape[T]
-  object Number {
-    def apply[T](int: Int):    NumberOf[T]            = NumberOf(int)
-    implicit def functor:      Functor[NumberOf]      = semi.functor
-    implicit def offsetZip[T]: OffsetZip[NumberOf, T] = t => t.coerce
-    implicit def repr[T]:      Repr[NumberOf[T]]      = R + '\\' + _.int.toString
-  }
-  case class InvalidOf[T](str: String) extends Escape[T] //with AST.InvalidOf[T] FIXME if we unseal InvalidOf, we won't be able to derive functor for it
-  object Invalid {
-    def apply[T](str: String): InvalidOf[T]       = InvalidOf(str)
-    implicit def repr[T]:      Repr[InvalidOf[T]] = R + '\\' + _.str
-  }
-
-  // Reference: https://en.wikipedia.org/wiki/String_literal
-  sealed trait Unicode[T] extends Escape[T]
-  object Unicode {
-
-    type U          = ASTOf[UFO]
-    type U16        = ASTOf[UFO16]
-    type U32        = ASTOf[UFO32]
-    type U21        = ASTOf[UFO21]
-    type InvalidU16 = ASTOf[InvalidUFO16]
-    type InvalidU32 = ASTOf[InvalidUFO32]
-    type InvalidU21 = ASTOf[InvalidUFO21]
-
-    abstract class UFO[T](val pfx: String, val sfx: String) extends Unicode[T] {
-      val digits: String
-    }
-    object UFO {
-      implicit def repr[T]: Repr[UFO[T]] =
-        t => R + "\\" + t.pfx + t.digits + t.sfx
-    }
-
-    final case class UFO16[T] private (digits: String) extends UFO[T]("u", "")
-    final case class UFO32[T] private (digits: String) extends UFO[T]("U", "")
-    final case class UFO21[T] private (digits: String) extends UFO[T]("u{", "}")
-
-    final case class InvalidUFO16[T] private (digits: String)
-        extends UFO[T]("u", "")
-//        with AST.InvalidOf[T]
-
-    final case class InvalidUFO32[T] private (digits: String)
-        extends UFO[T]("U", "")
-//        with AST.InvalidOf[T]
-
-    final case class InvalidUFO21[T] private (digits: String)
-        extends UFO[T]("u{", "}")
-//        with AST.InvalidOf[T]
-
-    object Validator {
-      val hexChars = (('a' to 'f') ++ ('A' to 'F') ++ ('0' to '9')).toSet
-      def isHexChar(char: Char) =
-        hexChars.contains(char)
-    }
-
-    object U16 {
-      def apply[T](digits: String): Unicode[T] =
-        if (validate(digits)) UFO16(digits) else InvalidUFO16(digits)
-      def validate(digits: String) = {
-        import Validator._
-        val validLength = digits.length == 4
-        val validChars  = digits.map(isHexChar).forall(identity)
-        validLength && validChars
-      }
-    }
-    object U32 {
-      def apply[T](digits: String): Unicode[T] =
-        if (validate(digits)) UFO32(digits) else InvalidUFO32(digits)
-      def validate(digits: String) = {
-        import Validator._
-        val validLength = digits.length == 8
-        val validPrefix = digits.startsWith("00")
-        val validChars  = digits.map(isHexChar).forall(identity)
-        validLength && validPrefix && validChars
-      }
-    }
-    object U21 {
-      def apply[T](digits: String): Unicode[T] =
-        if (validate(digits)) UFO21(digits) else InvalidUFO21(digits)
-      def validate(digits: String) = {
-        import Validator._
-        val validLength = digits.length >= 1 && digits.length <= 6
-        val validChars  = digits.map(isHexChar).forall(identity)
-        validLength && validChars
-      }
-    }
-  }
-
-  type Simple = ASTOf[SimpleOf]
-
-  case class SimpleOf[T](char: CharCode) extends Escape[T]
-  object SimpleOf {
-    implicit def repr[T]: Repr[SimpleOf[T]] = R + _.char.repr
-  }
-
-  abstract class CharCode(val code: Int) {
-    def name = toString
-    def repr = R + '\\' + name
-  }
-
-  case object Slash    extends CharCode('\\') { override def repr = "\\\\" }
-  case object Quote    extends CharCode('\'') { override def repr = "\\'"  }
-  case object RawQuote extends CharCode('"')  { override def repr = "\\\"" }
-
-  // Reference: https://en.wikipedia.org/wiki/String_literal
-  sealed trait Character extends CharCode
-  object Character {
-    case object a extends CharCode('\u0007') with Character
-    case object b extends CharCode('\u0008') with Character
-    case object f extends CharCode('\u000C') with Character
-    case object n extends CharCode('\n') with Character
-    case object r extends CharCode('\r') with Character
-    case object t extends CharCode('\u0009') with Character
-    case object v extends CharCode('\u000B') with Character
-    case object e extends CharCode('\u001B') with Character
-    val codes = ADT.constructors[Character]
-  }
-
-  // Reference: https://en.wikipedia.org/wiki/Control_character
-  sealed trait Control extends CharCode
-  object Control {
-    case object NUL extends CharCode(0x00) with Control
-    case object SOH extends CharCode(0x01) with Control
-    case object STX extends CharCode(0x02) with Control
-    case object ETX extends CharCode(0x03) with Control
-    case object EOT extends CharCode(0x04) with Control
-    case object ENQ extends CharCode(0x05) with Control
-    case object ACK extends CharCode(0x06) with Control
-    case object BEL extends CharCode(0x07) with Control
-    case object BS  extends CharCode(0x08) with Control
-    case object TAB extends CharCode(0x09) with Control
-    case object LF  extends CharCode(0x0A) with Control
-    case object VT  extends CharCode(0x0B) with Control
-    case object FF  extends CharCode(0x0C) with Control
-    case object CR  extends CharCode(0x0D) with Control
-    case object SO  extends CharCode(0x0E) with Control
-    case object SI  extends CharCode(0x0F) with Control
-    case object DLE extends CharCode(0x10) with Control
-    case object DC1 extends CharCode(0x11) with Control
-    case object DC2 extends CharCode(0x12) with Control
-    case object DC3 extends CharCode(0x13) with Control
-    case object DC4 extends CharCode(0x14) with Control
-    case object NAK extends CharCode(0x15) with Control
-    case object SYN extends CharCode(0x16) with Control
-    case object ETB extends CharCode(0x17) with Control
-    case object CAN extends CharCode(0x18) with Control
-    case object EM  extends CharCode(0x19) with Control
-    case object SUB extends CharCode(0x1A) with Control
-    case object ESC extends CharCode(0x1B) with Control
-    case object FS  extends CharCode(0x1C) with Control
-    case object GS  extends CharCode(0x1D) with Control
-    case object RS  extends CharCode(0x1E) with Control
-    case object US  extends CharCode(0x1F) with Control
-    case object DEL extends CharCode(0x7F) with Control
-    val codes = ADT.constructors[Control]
-  }
-}
+//package org.enso.syntax.text.ast.text
+//
+//import cats.Functor
+//import cats.derived.semi
+//import org.enso.data.ADT
+//import org.enso.syntax.text.AST
+//import org.enso.syntax.text.AST.Text.Segment
+//import org.enso.syntax.text.AST.{ASTOf, OffsetZip}
+//import org.enso.syntax.text.ast.Repr
+//import org.enso.syntax.text.ast.Repr.R
+//
+//object Escape {
+//
+//  type Escape[T] = Segment.Escape[T]
+//
+//  type Number  = ASTOf[NumberOf]
+//  type Invalid = ASTOf[InvalidOf]
+//
+//  case class NumberOf[T](int: Int) extends Escape[T]
+//  object Number {
+//    def apply[T](int: Int):    NumberOf[T]            = NumberOf(int)
+//    implicit def functor:      Functor[NumberOf]      = semi.functor
+//    implicit def offsetZip[T]: OffsetZip[NumberOf, T] = t => t.coerce
+//    implicit def repr[T]:      Repr[NumberOf[T]]      = R + '\\' + _.int.toString
+//  }
+//  case class InvalidOf[T](str: String) extends Escape[T] //with AST.InvalidOf[T] FIXME if we unseal InvalidOf, we won't be able to derive functor for it
+//  object Invalid {
+//    def apply[T](str: String): InvalidOf[T]       = InvalidOf(str)
+//    implicit def repr[T]:      Repr[InvalidOf[T]] = R + '\\' + _.str
+//  }
+//
+//  // Reference: https://en.wikipedia.org/wiki/String_literal
+//  sealed trait Unicode[T] extends Escape[T]
+//  object Unicode {
+//
+//    type U          = ASTOf[UFO]
+//    type U16        = ASTOf[UFO16]
+//    type U32        = ASTOf[UFO32]
+//    type U21        = ASTOf[UFO21]
+//    type InvalidU16 = ASTOf[InvalidUFO16]
+//    type InvalidU32 = ASTOf[InvalidUFO32]
+//    type InvalidU21 = ASTOf[InvalidUFO21]
+//
+//    abstract class UFO[T](val pfx: String, val sfx: String) extends Unicode[T] {
+//      val digits: String
+//    }
+//    object UFO {
+//      implicit def repr[T]: Repr[UFO[T]] =
+//        t => R + "\\" + t.pfx + t.digits + t.sfx
+//    }
+//
+//    final case class UFO16[T] private (digits: String) extends UFO[T]("u", "")
+//    final case class UFO32[T] private (digits: String) extends UFO[T]("U", "")
+//    final case class UFO21[T] private (digits: String) extends UFO[T]("u{", "}")
+//
+//    final case class InvalidUFO16[T] private (digits: String)
+//        extends UFO[T]("u", "")
+////        with AST.InvalidOf[T]
+//
+//    final case class InvalidUFO32[T] private (digits: String)
+//        extends UFO[T]("U", "")
+////        with AST.InvalidOf[T]
+//
+//    final case class InvalidUFO21[T] private (digits: String)
+//        extends UFO[T]("u{", "}")
+////        with AST.InvalidOf[T]
+//
+//    object Validator {
+//      val hexChars = (('a' to 'f') ++ ('A' to 'F') ++ ('0' to '9')).toSet
+//      def isHexChar(char: Char) =
+//        hexChars.contains(char)
+//    }
+//
+//    object U16 {
+//      def apply[T](digits: String): Unicode[T] =
+//        if (validate(digits)) UFO16(digits) else InvalidUFO16(digits)
+//      def validate(digits: String) = {
+//        import Validator._
+//        val validLength = digits.length == 4
+//        val validChars  = digits.map(isHexChar).forall(identity)
+//        validLength && validChars
+//      }
+//    }
+//    object U32 {
+//      def apply[T](digits: String): Unicode[T] =
+//        if (validate(digits)) UFO32(digits) else InvalidUFO32(digits)
+//      def validate(digits: String) = {
+//        import Validator._
+//        val validLength = digits.length == 8
+//        val validPrefix = digits.startsWith("00")
+//        val validChars  = digits.map(isHexChar).forall(identity)
+//        validLength && validPrefix && validChars
+//      }
+//    }
+//    object U21 {
+//      def apply[T](digits: String): Unicode[T] =
+//        if (validate(digits)) UFO21(digits) else InvalidUFO21(digits)
+//      def validate(digits: String) = {
+//        import Validator._
+//        val validLength = digits.length >= 1 && digits.length <= 6
+//        val validChars  = digits.map(isHexChar).forall(identity)
+//        validLength && validChars
+//      }
+//    }
+//  }
+//
+//  type Simple = ASTOf[SimpleOf]
+//
+//  case class SimpleOf[T](char: CharCode) extends Escape[T]
+//  object SimpleOf {
+//    implicit def repr[T]: Repr[SimpleOf[T]] = R + _.char.repr
+//  }
+//
+//  abstract class CharCode(val code: Int) {
+//    def name = toString
+//    def repr = R + '\\' + name
+//  }
+//
+//  case object Slash    extends CharCode('\\') { override def repr = "\\\\" }
+//  case object Quote    extends CharCode('\'') { override def repr = "\\'"  }
+//  case object RawQuote extends CharCode('"')  { override def repr = "\\\"" }
+//
+//  // Reference: https://en.wikipedia.org/wiki/String_literal
+//  sealed trait Character extends CharCode
+//  object Character {
+//    case object a extends CharCode('\u0007') with Character
+//    case object b extends CharCode('\u0008') with Character
+//    case object f extends CharCode('\u000C') with Character
+//    case object n extends CharCode('\n') with Character
+//    case object r extends CharCode('\r') with Character
+//    case object t extends CharCode('\u0009') with Character
+//    case object v extends CharCode('\u000B') with Character
+//    case object e extends CharCode('\u001B') with Character
+//    val codes = ADT.constructors[Character]
+//  }
+//
+//  // Reference: https://en.wikipedia.org/wiki/Control_character
+//  sealed trait Control extends CharCode
+//  object Control {
+//    case object NUL extends CharCode(0x00) with Control
+//    case object SOH extends CharCode(0x01) with Control
+//    case object STX extends CharCode(0x02) with Control
+//    case object ETX extends CharCode(0x03) with Control
+//    case object EOT extends CharCode(0x04) with Control
+//    case object ENQ extends CharCode(0x05) with Control
+//    case object ACK extends CharCode(0x06) with Control
+//    case object BEL extends CharCode(0x07) with Control
+//    case object BS  extends CharCode(0x08) with Control
+//    case object TAB extends CharCode(0x09) with Control
+//    case object LF  extends CharCode(0x0A) with Control
+//    case object VT  extends CharCode(0x0B) with Control
+//    case object FF  extends CharCode(0x0C) with Control
+//    case object CR  extends CharCode(0x0D) with Control
+//    case object SO  extends CharCode(0x0E) with Control
+//    case object SI  extends CharCode(0x0F) with Control
+//    case object DLE extends CharCode(0x10) with Control
+//    case object DC1 extends CharCode(0x11) with Control
+//    case object DC2 extends CharCode(0x12) with Control
+//    case object DC3 extends CharCode(0x13) with Control
+//    case object DC4 extends CharCode(0x14) with Control
+//    case object NAK extends CharCode(0x15) with Control
+//    case object SYN extends CharCode(0x16) with Control
+//    case object ETB extends CharCode(0x17) with Control
+//    case object CAN extends CharCode(0x18) with Control
+//    case object EM  extends CharCode(0x19) with Control
+//    case object SUB extends CharCode(0x1A) with Control
+//    case object ESC extends CharCode(0x1B) with Control
+//    case object FS  extends CharCode(0x1C) with Control
+//    case object GS  extends CharCode(0x1D) with Control
+//    case object RS  extends CharCode(0x1E) with Control
+//    case object US  extends CharCode(0x1F) with Control
+//    case object DEL extends CharCode(0x7F) with Control
+//    val codes = ADT.constructors[Control]
+//  }
+//}

--- a/syntax/definition/src/main/scala/org/enso/syntax/text/spec/ParserDef.scala
+++ b/syntax/definition/src/main/scala/org/enso/syntax/text/spec/ParserDef.scala
@@ -2,6 +2,7 @@ package org.enso.syntax.text.spec
 
 import java.io.DataInputStream
 
+import org.enso.data.List1
 import org.enso.data.VectorMap
 import org.enso.flexer
 import org.enso.flexer.Reader
@@ -10,7 +11,6 @@ import org.enso.flexer.automata.Pattern
 import org.enso.flexer.automata.Pattern._
 import org.enso.syntax.text.AST
 import org.enso.syntax.text.AST.implicits._
-import org.enso.syntax.text.AST.Text.Segment.EOL
 
 import scala.annotation.tailrec
 import scala.reflect.runtime.universe.reify
@@ -288,201 +288,213 @@ case class ParserDef() extends flexer.Parser[AST.Module] {
 
   import AST.Text.Quote
 
-//  final object text {
-//    var stack: List[AST.Text.Interpolated] = Nil
-//
-//    def current = stack.head
-//
-//    def withCurrent(f: AST.Text.Interpolated => AST.Text.Interpolated) =
-//      stack = f(stack.head) :: stack.tail
-//
-//    def push(quoteSize: Quote): Unit = logger.trace {
-//      stack +:= AST.Text.Interpolated(quoteSize)
-//    }
-//
-//    def pop(): Unit = logger.trace {
-//      stack = stack.tail
-//    }
-//
-//    def submitEmpty(groupIx: State, quoteNum: Quote): Unit =
-//      logger.trace {
-//        if (groupIx == RAW)
-//          result.app(AST.Text.Raw(quoteNum))
-//        else
-//          result.app(AST.Text.Interpolated(quoteNum))
-//      }
-//
-//    def finishCurrent(): AST.Text.Class[_] = logger.trace {
-//      withCurrent(t => t.copy(segments = t.segments.reverse))
-//      val txt = if (state.current == RAW) current.raw else current
-//      pop()
-//      state.end()
-//      val singleLine = !txt.segments.contains(EOL())
-//      if (singleLine || block.current.firstLine.isDefined || result.current.isDefined)
-//        txt
-//      else {
-//        val segs =
-//          AST.Text.MultiLine.stripOffset(block.current.indent, txt.segments)
-//        AST.Text.MultiLine(block.current.indent, txt.quoteChar, txt.quote, segs)
-//      }
-//    }
-//
-//    def submit(): Unit = logger.trace {
-//      result.app(finishCurrent())
-//    }
-//
-//    def submit(segment: AST.Text.Interpolated.Segment): Unit =
-//      logger.trace {
-//        withCurrent(_.prepend(segment))
-//      }
-//
-//    def submitUnclosed(): Unit = logger.trace {
-//      result.app(AST.Text.Unclosed(finishCurrent()))
-//    }
-//
-//    def onBegin(grp: State, quoteSize: Quote): Unit = logger.trace {
-//      push(quoteSize)
-//      state.begin(grp)
-//    }
-//
-//    def submitPlainSegment(
-//      segment: AST.Text.Interpolated.Segment
-//    ): Unit =
-//      logger.trace {
-//        withCurrent(_.prependMergeReversed(segment))
-//      }
-//
-//    def onPlainSegment(): Unit = logger.trace {
-//      submitPlainSegment(AST.Text.Segment.Plain(currentMatch))
-//    }
-//
-//    def onQuote(quoteSize: Quote): Unit = logger.trace {
-//      if (current.quote == Quote.Triple
-//          && quoteSize == Quote.Single) onPlainSegment()
-//      else if (current.quote == Quote.Single
-//               && quoteSize == Quote.Triple) {
-//        val groupIx = state.current
-//        submit()
-//        submitEmpty(groupIx, Quote.Single)
-//      } else
-//        submit()
-//    }
-//
-//    def onEscape(code: AST.Text.Segment.Escape): Unit = logger.trace {
-//      submit(code)
-//    }
-//
-//    def onEscapeU16(): Unit = logger.trace {
-//      val code = currentMatch.drop(2)
-//      submit(AST.Text.Segment.Escape.Unicode.U16(code))
-//    }
-//
-//    def onEscapeU32(): Unit = logger.trace {
-//      val code = currentMatch.drop(2)
-//      submit(AST.Text.Segment.Escape.Unicode.U32(code))
-//    }
-//
-//    def onEscapeInt(): Unit = logger.trace {
-//      val int = currentMatch.drop(1).toInt
-//      submit(AST.Text.Segment.Escape.Number(int))
-//    }
-//
-//    def onInvalidEscape(): Unit = logger.trace {
-//      val str = currentMatch.drop(1)
-//      submit(AST.Text.Segment.Escape.Invalid(str))
-//    }
-//
-//    def onEscapeSlash(): Unit = logger.trace {
-//      submit(AST.Text.Segment.Escape.Slash)
-//    }
-//
-//    def onEscapeQuote(): Unit = logger.trace {
-//      submit(AST.Text.Segment.Escape.Quote)
-//    }
-//
-//    def onEscapeRawQuote(): Unit = logger.trace {
-//      submit(AST.Text.Segment.Escape.RawQuote)
-//    }
-//
-//    def onInterpolateBegin(): Unit = logger.trace {
-//      result.push()
-//      off.push()
-//      state.begin(INTERPOLATE)
-//    }
-//
-//    def onInterpolateEnd(): Unit = logger.trace {
-//      if (state.isInside(INTERPOLATE)) {
-//        state.endTill(INTERPOLATE)
-//        submit(AST.Text.Segment.Interpolation(result.current))
-//        result.pop()
-//        off.pop()
-//        state.end()
-//      } else {
-//        onUnrecognized()
-//      }
-//    }
-//
-//    def onEOF(): Unit = logger.trace {
-//      submitUnclosed()
-//      rewind()
-//    }
-//
-//    def onEOL(): Unit = logger.trace {
-//      submitPlainSegment(AST.Text.Segment.EOL())
-//    }
-//
-//    val stringChar = noneOf("'`\"\\\n")
-//    val seg        = stringChar.many1
-//    val escape_int = "\\" >> num.decimal
-//    val escape_u16 = "\\u" >> repeat(stringChar, 0, 4)
-//    val escape_u32 = "\\U" >> repeat(stringChar, 0, 8)
-//
-//    val INTP: State        = state.define("Text")
-//    val RAW: State         = state.define("Raw Text")
-//    val INTERPOLATE: State = state.define("Interpolate")
-//    INTERPOLATE.parent = ROOT
-//  }
-//
-//  ROOT      || '`'      || reify { text.onInterpolateEnd()               }
-//  text.INTP || '`'      || reify { text.onInterpolateBegin()             }
-//  ROOT      || "'"      || reify { text.onBegin(text.INTP, Quote.Single) }
-//  ROOT      || "'''"    || reify { text.onBegin(text.INTP, Quote.Triple) }
-//  text.INTP || "'"      || reify { text.onQuote(Quote.Single)            }
-//  text.INTP || "'''"    || reify { text.onQuote(Quote.Triple)            }
-//  text.INTP || text.seg || reify { text.onPlainSegment()                 }
-//  text.INTP || eof      || reify { text.onEOF()                          }
-//  text.INTP || '\n'     || reify { text.onEOL()                          }
-//
-//  ROOT     || "\""           || reify { text.onBegin(text.RAW, Quote.Single) }
-//  ROOT     || "\"\"\""       || reify { text.onBegin(text.RAW, Quote.Triple) }
-//  text.RAW || "\""           || reify { text.onQuote(Quote.Single)           }
-//  text.RAW || "\"\"\""       || reify { text.onQuote(Quote.Triple)           }
-//  text.RAW || noneOf("\"\n") || reify { text.onPlainSegment()                }
-//  text.RAW || eof            || reify { text.onEOF()                         }
-//  text.RAW || '\n'           || reify { text.onEOL()                         }
-//
-//  AST.Text.Segment.Escape.Character.codes.foreach { ctrl =>
-//    import scala.reflect.runtime.universe._
-//    val name = TermName(ctrl.toString)
-//    val func = q"text.onEscape(AST.Text.Segment.Escape.Character.$name)"
-//    text.INTP || s"\\$ctrl" || func
-//  }
-//
-//  AST.Text.Segment.Escape.Control.codes.foreach { ctrl =>
-//    import scala.reflect.runtime.universe._
-//    val name = TermName(ctrl.toString)
-//    val func = q"text.onEscape(AST.Text.Segment.Escape.Control.$name)"
-//    text.INTP || s"\\$ctrl" || func
-//  }
-//
-//  text.INTP || text.escape_u16           || reify { text.onEscapeU16()      }
-//  text.INTP || text.escape_u32           || reify { text.onEscapeU32()      }
-//  text.INTP || text.escape_int           || reify { text.onEscapeInt()      }
-//  text.INTP || "\\\\"                    || reify { text.onEscapeSlash()    }
-//  text.INTP || "\\'"                     || reify { text.onEscapeQuote()    }
-//  text.INTP || "\\\""                    || reify { text.onEscapeRawQuote() }
-//  text.INTP || ("\\" >> text.stringChar) || reify { text.onInvalidEscape()  }
-//  text.INTP || "\\"                      || reify { text.onPlainSegment()   }
+  class TextState(
+    val offset: Int,
+    var lines: List[AST.Text.LineOf[AST.Text.Segment._Fmt[AST]]],
+    var lineBuilder: List[AST.Text.Segment.Fmt],
+    val quote: Quote
+  )
+
+  final object text {
+
+    import AST.Text.Segment
+
+    var stack: List[TextState] = Nil
+    var current                = new TextState(0, Nil, Nil, Quote.Single)
+
+    def push(quoteSize: Quote): Unit = logger.trace {
+      stack +:= current
+    }
+
+    def pop(): Unit = logger.trace {
+      current = stack.head
+      stack   = stack.tail
+    }
+
+    def submitEmpty(groupIx: State, quoteNum: Quote): Unit = logger.trace {
+      if (groupIx == RAW)
+        result.app(AST.Text.Raw(AST.Text.Body(quoteNum)))
+      else
+        result.app(AST.Text.Fmt(AST.Text.Body(quoteNum)))
+    }
+
+    def finishCurrent(): AST.Text = logger.trace {
+      onSubmitLine()
+      val t    = current
+      val body = AST.Text.BodyOf(t.offset, t.quote, List1(t.lines.reverse).get)
+      pop()
+      state.end()
+      if (state.current == RAW)
+        AST.Text.RawOf(body.asInstanceOf[AST.Text.BodyOf[Segment._Raw[AST]]])
+      else
+        AST.Text.FmtOf(body)
+    }
+
+    def submit(): Unit = logger.trace {
+      result.app(finishCurrent())
+    }
+
+    def submit(segment: Segment.Fmt): Unit = logger.trace {
+      current.lineBuilder :+= segment
+    }
+
+    def submitUnclosed(): Unit = logger.trace {
+      result.app(AST.Text.UnclosedOf(finishCurrent()))
+    }
+
+    def onBegin(grp: State, quoteSize: Quote): Unit = logger.trace {
+      push(quoteSize)
+      state.begin(grp)
+    }
+
+    def submitPlainSegment(): Unit = logger.trace {
+      current.lineBuilder = current.lineBuilder match {
+        case Segment._Plain(t) :: _ =>
+          Segment._Plain(currentMatch + t) :: current.lineBuilder.tail
+        case _ => Segment._Plain(currentMatch) :: current.lineBuilder
+      }
+    }
+
+    def onQuote(quoteSize: Quote): Unit = logger.trace {
+      if (current.quote == Quote.Triple
+          && quoteSize == Quote.Single)
+        submitPlainSegment()
+      else if (current.quote == Quote.Single
+               && quoteSize == Quote.Triple) {
+        val groupIx = state.current
+        submit()
+        submitEmpty(groupIx, Quote.Single)
+      } else
+        submit()
+    }
+
+    def onEscape(code: Segment.Escape[AST]): Unit = logger.trace {
+      submit(code)
+    }
+
+    def onEscapeU16(): Unit = logger.trace {
+      val code = currentMatch.drop(2)
+      submit(Segment.Escape.Unicode.U16(code))
+    }
+
+    def onEscapeU32(): Unit = logger.trace {
+      val code = currentMatch.drop(2)
+      submit(Segment.Escape.Unicode.U32(code))
+    }
+
+    def onEscapeInt(): Unit = logger.trace {
+      val int = currentMatch.drop(1).toInt
+      submit(Segment.Escape.Number(int))
+    }
+
+    def onInvalidEscape(): Unit = logger.trace {
+      val str = currentMatch.drop(1)
+      submit(Segment.Escape.Invalid(str))
+    }
+
+    def onEscapeSlash(): Unit = logger.trace {
+      submit(Segment.Escape.SimpleOf(Segment.Escape.Slash))
+    }
+
+    def onEscapeQuote(): Unit = logger.trace {
+      submit(Segment.Escape.SimpleOf(Segment.Escape.Quote))
+    }
+
+    def onEscapeRawQuote(): Unit = logger.trace {
+      submit(Segment.Escape.SimpleOf(Segment.Escape.RawQuote))
+    }
+
+    def onInterpolateBegin(): Unit = logger.trace {
+      result.push()
+      off.push()
+      state.begin(INTERPOLATE)
+    }
+
+    def onInterpolateEnd(): Unit = logger.trace {
+      if (state.isInside(INTERPOLATE)) {
+        state.endTill(INTERPOLATE)
+        submit(Segment._Expr(result.current))
+        result.pop()
+        off.pop()
+        state.end()
+      } else {
+        onUnrecognized()
+      }
+    }
+
+    def onEOF(): Unit = logger.trace {
+      submitUnclosed()
+      rewind()
+    }
+
+    def onSubmitLine(): Unit = logger.trace {
+      off.pop()
+      current.lines +:= AST.Text.LineOf(off.use(), current.lineBuilder.reverse)
+      current.lineBuilder = Nil
+    }
+
+    def onNewLine(): Unit = logger.trace {
+      state.end()
+      onSubmitLine()
+      off.on()
+      off.push()
+    }
+
+    val stringChar = noneOf("'`\"\\\n")
+    val seg        = stringChar.many1
+    val escape_int = "\\" >> num.decimal
+    val escape_u16 = "\\u" >> repeat(stringChar, 0, 4)
+    val escape_u32 = "\\U" >> repeat(stringChar, 0, 8)
+
+    val FMT: State         = state.define("Formatted Text")
+    val RAW: State         = state.define("Raw Text")
+    val NEWLINE: State     = state.define("Text Newline")
+    val INTERPOLATE: State = state.define("Interpolate")
+    INTERPOLATE.parent = ROOT
+  }
+
+  ROOT     || '`'      || reify { text.onInterpolateEnd()              }
+  text.FMT || '`'      || reify { text.onInterpolateBegin()            }
+  ROOT     || "'"      || reify { text.onBegin(text.FMT, Quote.Single) }
+  ROOT     || "'''"    || reify { text.onBegin(text.FMT, Quote.Triple) }
+  text.FMT || "'"      || reify { text.onQuote(Quote.Single)           }
+  text.FMT || "'''"    || reify { text.onQuote(Quote.Triple)           }
+  text.FMT || text.seg || reify { text.submitPlainSegment()            }
+  text.FMT || eof      || reify { text.onEOF()                         }
+  text.FMT || '\n'     || reify { state.begin(text.NEWLINE)            }
+
+  ROOT     || "\""           || reify { text.onBegin(text.RAW, Quote.Single) }
+  ROOT     || "\"\"\""       || reify { text.onBegin(text.RAW, Quote.Triple) }
+  text.RAW || "\""           || reify { text.onQuote(Quote.Single)           }
+  text.RAW || "\"\"\""       || reify { text.onQuote(Quote.Triple)           }
+  text.RAW || noneOf("\"\n") || reify { text.submitPlainSegment()            }
+  text.RAW || eof            || reify { text.onEOF()                         }
+  text.RAW || '\n'           || reify { state.begin(text.NEWLINE)            }
+
+  text.NEWLINE || space.opt || reify { text.onNewLine() }
+
+  AST.Text.Segment.Escape.Character.codes.foreach { ctrl =>
+    import scala.reflect.runtime.universe._
+    val name = TermName(ctrl.toString)
+    val func = q"text.onEscape(AST.Text.Segment.Escape.Character.$name)"
+    text.FMT || s"\\$ctrl" || func
+  }
+
+  AST.Text.Segment.Escape.Control.codes.foreach { ctrl =>
+    import scala.reflect.runtime.universe._
+    val name = TermName(ctrl.toString)
+    val func = q"text.onEscape(AST.Text.Segment.Escape.Control.$name)"
+    text.FMT || s"\\$ctrl" || func
+  }
+
+  text.FMT || text.escape_u16           || reify { text.onEscapeU16()        }
+  text.FMT || text.escape_u32           || reify { text.onEscapeU32()        }
+  text.FMT || text.escape_int           || reify { text.onEscapeInt()        }
+  text.FMT || "\\\\"                    || reify { text.onEscapeSlash()      }
+  text.FMT || "\\'"                     || reify { text.onEscapeQuote()      }
+  text.FMT || "\\\""                    || reify { text.onEscapeRawQuote()   }
+  text.FMT || ("\\" >> text.stringChar) || reify { text.onInvalidEscape()    }
+  text.FMT || "\\"                      || reify { text.submitPlainSegment() }
 
   //////////////
   /// Blocks ///

--- a/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
+++ b/syntax/specialization/src/test/scala/org/enso/syntax/text/Parser.scala
@@ -102,6 +102,8 @@ class ParserSpec extends FlatSpec with Matchers {
   //// Precedence + Associativity //////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
+  import AST.Number.fromInt
+
   "a b"            ?= ("a" $_ "b")
   "a +  b"         ?= ("a" $_ "+") $__ "b"
   "a + b + c"      ?= ("a" $_ "+" $_ "b") $_ "+" $_ "c"
@@ -160,75 +162,81 @@ class ParserSpec extends FlatSpec with Matchers {
   "16_"   ?= Number.DanglingBase("16")
   "7.5"   ?= App.Infix(7, 0, Opr("."), 0, 5)
 
-//  //////////////////////////////////////////////////////////////////////////////
-//  //// UTF Surrogates //////////////////////////////////////////////////////////
-//  //////////////////////////////////////////////////////////////////////////////
-//
-//  "\uD800\uDF1E" ?= Invalid.Unrecognized("\uD800\uDF1E")
-//
-//  //////////////////////////////////////////////////////////////////////////////
-//  //// Text ////////////////////////////////////////////////////////////////////
-//  //////////////////////////////////////////////////////////////////////////////
-//
-//  //////////////
-//  //// Text ////
-//  //////////////
-//
-////  "'"       ?= Text.Unclosed(Text())
-////  "''"      ?= Text()
-////  "'''"     ?= Text.Unclosed(Text(Text.Quote.Triple))
-////  "''''"    ?= Text.Unclosed(Text(Text.Quote.Triple, "'"))
-////  "'''''"   ?= Text.Unclosed(Text(Text.Quote.Triple, "''"))
-////  "''''''"  ?= Text(Text.Quote.Triple)
-////  "'''''''" ?= Text(Text.Quote.Triple) $ Text.Unclosed(Text())
-////  "'a'"     ?= Text("a")
-////  "'a"      ?= Text.Unclosed(Text("a"))
-////  "'a'''"   ?= Text("a") $ Text()
-////  "'''a'''" ?= Text(Text.Quote.Triple, "a")
-////  "'''a'"   ?= Text.Unclosed(Text(Text.Quote.Triple, "a'"))
-////  "'''a''"  ?= Text.Unclosed(Text(Text.Quote.Triple, "a''"))
-////
-////  "\""             ?= Text.Unclosed(Text.Raw())
-////  "\"\""           ?= Text.Raw()
-////  "\"\"\""         ?= Text.Unclosed(Text.Raw(Text.Quote.Triple))
-////  "\"\"\"\""       ?= Text.Unclosed(Text.Raw(Text.Quote.Triple, "\""))
-////  "\"\"\"\"\""     ?= Text.Unclosed(Text.Raw(Text.Quote.Triple, "\"\""))
-////  "\"\"\"\"\"\""   ?= Text.Raw(Text.Quote.Triple)
-////  "\"\"\"\"\"\"\"" ?= Text.Raw(Text.Quote.Triple) $ Text.Unclosed(Text.Raw())
-////  "\"a\""          ?= Text.Raw("a")
-////  "\"a"            ?= Text.Unclosed(Text.Raw("a"))
-////  "\"a\"\"\""      ?= Text.Raw("a") $ Text.Raw()
-////  "\"\"\"a\"\"\""  ?= Text.Raw(Text.Quote.Triple, "a")
-////  "\"\"\"a\""      ?= Text.Unclosed(Text.Raw(Text.Quote.Triple, "a\""))
-////  "\"\"\"a\"\""    ?= Text.Unclosed(Text.Raw(Text.Quote.Triple, "a\"\""))
-////
-////  "'''\nX\n Y\n'''" ?= Text.MultiLine(
-////    0,
-////    '\'',
-////    Text.Quote.Triple,
-////    List(EOL(), Plain("X"), EOL(), Plain(" Y"), EOL())
-////  )
-////
-////  //// Escapes ////
-////
-////  Text.Segment.Escape.Character.codes.foreach(i => s"'\\$i'" ?= Text(i))
-////  Text.Segment.Escape.Control.codes.foreach(i => s"'\\$i'"   ?= Text(i))
-////
-////  "'\\\\'"   ?= Text(Text.Segment.Escape.Slash)
-////  "'\\''"    ?= Text(Text.Segment.Escape.Quote)
-////  "'\\\"'"   ?= Text(Text.Segment.Escape.RawQuote)
-////  "'\\"      ?= Text.Unclosed(Text("\\"))
-////  "'\\c'"    ?= Text(Text.Segment.Escape.Invalid("c"))
-////  "'\\cd'"   ?= Text(Text.Segment.Escape.Invalid("c"), "d")
-////  "'\\123d'" ?= Text(Text.Segment.Escape.Number(123), "d")
-////
-////  //// Interpolation ////
-////
-////  "'a`b`c'" ?= Text("a", Text.Segment.Interpolation(Some("b")), "c")
-////  "'a`b 'c`d`e' f`g'" ?= {
-////    val bd = "b" $_ Text("c", Text.Segment.Interpolation(Some("d")), "e") $_ "f"
-////    Text("a", Text.Segment.Interpolation(Some(bd)), "g")
-////  }
+  //////////////////////////////////////////////////////////////////////////////
+  //// UTF Surrogates //////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////////
+
+  "\uD800\uDF1E" ?= Invalid.Unrecognized("\uD800\uDF1E")
+
+  //////////////////////////////////////////////////////////////////////////////
+  //// Text ////////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////////////////////////////////
+
+  //////////////
+  //// Text ////
+  //////////////
+
+  import Text.Segment.implicits.txtFromString
+
+  val q1 = Text.Quote.Single
+  val q3 = Text.Quote.Triple
+
+
+  "'"       ?= Text.Unclosed(Text(Text.Body(q1)))
+  "''"      ?= Text(Text.Body(q1))
+  "'''"     ?= Text.Unclosed(Text(Text.Body(q3)))
+  "''''"    ?= Text.Unclosed(Text(Text.Body(q3, "'")))
+  "'''''"   ?= Text.Unclosed(Text(Text.Body(q3, "''")))
+  "''''''"  ?= Text(Text.Body(q3))
+  "'''''''" ?= Text(Text.Body(q3)) $ Text.Unclosed(Text(Text.Body(q1)))
+  "'a'"     ?= Text(Text.Body(q1, "a"))
+  "'a"      ?= Text.Unclosed(Text(Text.Body(q1, "a")))
+  "'a'''"   ?= Text(Text.Body(q1, "a")) $ Text(Text.Body(q1))
+  "'''a'''" ?= Text(Text.Body(q3, "a"))
+  "'''a'"   ?= Text.Unclosed(Text(Text.Body(q3, "a'")))
+  "'''a''"  ?= Text.Unclosed(Text(Text.Body(q3, "a''")))
+
+//  "\""             ?= Text.Unclosed(Text.Raw())
+//  "\"\""           ?= Text.Raw()
+//  "\"\"\""         ?= Text.Unclosed(Text.Raw(q3))
+//  "\"\"\"\""       ?= Text.Unclosed(Text.Raw(q3, "\""))
+//  "\"\"\"\"\""     ?= Text.Unclosed(Text.Raw(q3, "\"\""))
+//  "\"\"\"\"\"\""   ?= Text.Raw(q3)
+//  "\"\"\"\"\"\"\"" ?= Text.Raw(q3) $ Text.Unclosed(Text.Raw())
+//  "\"a\""          ?= Text.Raw("a")
+//  "\"a"            ?= Text.Unclosed(Text.Raw("a"))
+//  "\"a\"\"\""      ?= Text.Raw("a") $ Text.Raw()
+//  "\"\"\"a\"\"\""  ?= Text.Raw(q3, "a")
+//  "\"\"\"a\""      ?= Text.Unclosed(Text.Raw(q3, "a\""))
+//  "\"\"\"a\"\""    ?= Text.Unclosed(Text.Raw(q3, "a\"\""))
+
+  "'''\nX\n Y\n'''" ?= Text(Text.BodyOf(0, q3, List1(
+    Text.LineOf(0, Nil),
+    Text.LineOf(0, List("X")),
+    Text.LineOf(1, List("Y")),
+    Text.LineOf(0, Nil))))
+
+  //// Escapes ////
+
+  Text.Segment.Escape.Character.codes.foreach(i => s"'\\$i'" ?= Text(Text.Body(q1, Text.Segment.Escape.SimpleOf(i))))
+  Text.Segment.Escape.Control.codes.foreach(i => s"'\\$i'"   ?= Text(Text.Body(q1, Text.Segment.Escape.SimpleOf(i))))
+
+  "'\\\\'"   ?= Text(Text.Body(q1, Text.Segment.Escape.SimpleOf(Text.Segment.Escape.Slash)))
+  "'\\''"    ?= Text(Text.Body(q1, Text.Segment.Escape.SimpleOf(Text.Segment.Escape.Quote)))
+  "'\\\"'"   ?= Text(Text.Body(q1, Text.Segment.Escape.SimpleOf(Text.Segment.Escape.RawQuote)))
+  "'\\"      ?= Text.Unclosed(Text(Text.Body(q1, "\\")))
+  "'\\c'"    ?= Text(Text.Body(q1, Text.Segment.Escape.Invalid("c")))
+  "'\\cd'"   ?= Text(Text.Body(q1, Text.Segment.Escape.Invalid("c"), "d"))
+  "'\\123d'" ?= Text(Text.Body(q1, Text.Segment.Escape.Number(123), "d"))
+
+  //// Interpolation ////
+
+  "'a`b`c'" ?= Text(Text.Body(q1, "a", Text.Segment._Expr(Some("b")), "c"))
+  "'a`b 'c`d`e' f`g'" ?= {
+    val bd = "b" $_ Text(Text.Body(q1, "c", Text.Segment._Expr(Some("d")), "e")) $_ "f"
+    Text(Text.Body(q1, "a", Text.Segment._Expr(Some(bd)), "g"))
+  }
+
 ////  //  "'`a(`'" ?= Text(Text.Segment.Interpolated(Some("a" $ Group.Unclosed())))
 ////  //  // Comments
 //////    expr("#"              , Comment)


### PR DESCRIPTION
### Pull Request Description

Implementation of text literals for cata parser.

### Important Notes

Isn't working yet, but I need help to move forward.

### Checklist

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

