### PR TITLE
Interop Library Improvements

### DIFF
--- a/Interpreter/src/bench/scala/org/enso/interpreter/RegressionTest.scala
+++ b/Interpreter/src/bench/scala/org/enso/interpreter/RegressionTest.scala
@@ -15,6 +15,7 @@ class RegressionTest extends FlatSpec with Matchers {
     benchmark should "not be slower than before" in {
       val item       = runner.run(benchmark)
       val difference = (item.getScore / item.getBestScore) - 1
+      println(s"Difference was: $difference.")
       difference should be < TOLERANCE
     }
   }

--- a/Interpreter/src/bench/scala/org/enso/interpreter/fixtures/RecursionFixtures.scala
+++ b/Interpreter/src/bench/scala/org/enso/interpreter/fixtures/RecursionFixtures.scala
@@ -53,4 +53,5 @@ class RecursionFixtures extends LanguageRunner {
     """.stripMargin
 
   val sumRecursive = ctx.eval(Constants.LANGUAGE_ID, sumRecursiveCode)
+
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/Constants.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/Constants.java
@@ -14,7 +14,7 @@ public class Constants {
 
   /** Cache sizes for different AST nodes. */
   public static class CacheSizes {
-    public static final String SORTER_NODE_CACHE_SIZE = "10";
-    public static final String INTEROP_LIBRARY_CACHE_SIZE = "10";
+    public static final String ARGUMENT_SORTER_NODE = "10";
+    public static final String FUNCTION_INTEROP_LIBRARY = "10";
   }
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/Constants.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/Constants.java
@@ -1,8 +1,6 @@
 package org.enso.interpreter;
 
-/**
- * Language-level constants for use throughout the program.
- */
+/** Language-level constants for use throughout the program. */
 public class Constants {
   public static final String LANGUAGE_ID = "enso";
   public static final String LANGUAGE_NAME = "Enso";
@@ -13,4 +11,10 @@ public class Constants {
 
   public static final String THIS_ARGUMENT_NAME = "this";
   public static final String SCOPE_SEPARATOR = ".";
+
+  /** Cache sizes for different AST nodes. */
+  public static class CacheSizes {
+    public static final String SORTER_NODE_CACHE_SIZE = "10";
+    public static final String INTEROP_LIBRARY_CACHE_SIZE = "10";
+  }
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/callable/argument/sorter/ArgumentSorterNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/callable/argument/sorter/ArgumentSorterNode.java
@@ -47,7 +47,7 @@ public abstract class ArgumentSorterNode extends BaseNode {
    * @param optimiser a cached call optimizer node, capable of performing the actual function call
    * @return the result of applying the function with remapped arguments
    */
-  @Specialization(guards = "mappingNode.isCompatible(function)")
+  @Specialization(guards = "mappingNode.isCompatible(function)", limit="100")
   public Object invokeCached(
       Function function,
       Object[] arguments,

--- a/Interpreter/src/main/java/org/enso/interpreter/node/callable/argument/sorter/ArgumentSorterNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/callable/argument/sorter/ArgumentSorterNode.java
@@ -1,13 +1,13 @@
 package org.enso.interpreter.node.callable.argument.sorter;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
-import com.oracle.truffle.api.dsl.*;
-import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.NodeInfo;
+import org.enso.interpreter.Constants;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.dispatch.CallOptimiserNode;
 import org.enso.interpreter.optimiser.tco.TailCallException;
-import org.enso.interpreter.runtime.callable.argument.CallArgument;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
 
@@ -16,21 +16,20 @@ import org.enso.interpreter.runtime.callable.function.Function;
  * positional order expected by the definition of the {@link Function}.
  */
 @NodeInfo(shortName = "ArgumentSorter")
-@GenerateUncached
-public abstract class ArgumentSorterNode extends Node {
+public abstract class ArgumentSorterNode extends BaseNode {
 
-  //  private @CompilationFinal(dimensions = 1) CallArgumentInfo[] schema;
-  //  private final boolean hasDefaultsSuspended;
+  private @CompilationFinal(dimensions = 1) CallArgumentInfo[] schema;
+  private final boolean hasDefaultsSuspended;
 
   /**
    * Creates a node that performs the argument organisation for the provided schema.
    *
    * @param schema information about the call arguments in positional order
    */
-  //  public ArgumentSorterNode(CallArgumentInfo[] schema, boolean hasDefaultsSuspended) {
-  //    this.schema = schema;
-  //    this.hasDefaultsSuspended = hasDefaultsSuspended;
-  //  }
+  public ArgumentSorterNode(CallArgumentInfo[] schema, boolean hasDefaultsSuspended) {
+    this.schema = schema;
+    this.hasDefaultsSuspended = hasDefaultsSuspended;
+  }
 
   /**
    * Generates the argument mapping where it has already been computed and executes the function.
@@ -49,19 +48,18 @@ public abstract class ArgumentSorterNode extends Node {
    * @param optimiser a cached call optimizer node, capable of performing the actual function call
    * @return the result of applying the function with remapped arguments
    */
-  @Specialization(guards = "mappingNode.isCompatible(function)", limit="100")
+  @Specialization(
+      guards = "mappingNode.isCompatible(function)",
+      limit = Constants.CacheSizes.SORTER_NODE_CACHE_SIZE)
   public Object invokeCached(
       Function function,
       Object[] arguments,
-      CallArgumentInfo[] schema,
-      boolean hasDefaultsSuspended,
-      boolean isTail,
-      @Cached(value = "create(function, schema, hasDefaultsSuspended)", allowUncached = true)
+      @Cached("create(function, getSchema(), hasDefaultsSuspended())")
           CachedArgumentSorterNode mappingNode,
-      @Cached(allowUncached = true) CallOptimiserNode optimiser) {
+      @Cached CallOptimiserNode optimiser) {
     Object[] mappedArguments = mappingNode.execute(function, arguments);
     if (mappingNode.appliesFully()) {
-      if (isTail) {
+      if (this.isTail()) {
         throw new TailCallException(mappingNode.getOriginalFunction(), mappedArguments);
       } else {
         return optimiser.executeDispatch(mappingNode.getOriginalFunction(), mappedArguments);
@@ -76,28 +74,46 @@ public abstract class ArgumentSorterNode extends Node {
   }
 
   /**
+   * Generates an argument mapping and executes a function with properly ordered arguments. Does not
+   * perform any caching and is thus a slow-path operation.
+   *
+   * @param function the function to execute.
+   * @param arguments the arguments to reorder and supply to the {@code function}.
+   * @return the result of calling {@code function} with the supplied {@code arguments}.
+   */
+  @Specialization(replaces = "invokeCached")
+  public Object invokeUncached(Function function, Object[] arguments) {
+    return invokeCached(
+        function,
+        arguments,
+        CachedArgumentSorterNode.create(function, getSchema(), hasDefaultsSuspended()),
+        CallOptimiserNode.create());
+  }
+
+  /**
    * Executes the {@link ArgumentSorterNode} to reorder the arguments.
    *
    * @param callable the function to sort arguments for
    * @param arguments the arguments being passed to {@code function}
    * @return the result of executing the {@code function} with reordered {@code arguments}
    */
-  public abstract Object execute(
-      Function callable,
-      Object[] arguments,
-      CallArgumentInfo[] schema,
-      boolean hasDefaultsSuspended,
-      boolean isTail);
+  public abstract Object execute(Function callable, Object[] arguments);
 
   /**
    * Gets the schema for use in Truffle DSL guards.
    *
    * @return the argument schema
    */
+  CallArgumentInfo[] getSchema() {
+    return schema;
+  }
 
   /**
    * Checks whether the function whose arguments are being sorted has suspended defaults arguments.
    *
    * @return {@code true} if it has suspended defaults, otherwise {@code false}
    */
+  boolean hasDefaultsSuspended() {
+    return this.hasDefaultsSuspended;
+  }
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/callable/argument/sorter/ArgumentSorterNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/callable/argument/sorter/ArgumentSorterNode.java
@@ -50,7 +50,7 @@ public abstract class ArgumentSorterNode extends BaseNode {
    */
   @Specialization(
       guards = "mappingNode.isCompatible(function)",
-      limit = Constants.CacheSizes.SORTER_NODE_CACHE_SIZE)
+      limit = Constants.CacheSizes.ARGUMENT_SORTER_NODE)
   public Object invokeCached(
       Function function,
       Object[] arguments,

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/argument/CallArgumentInfo.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/argument/CallArgumentInfo.java
@@ -81,7 +81,7 @@ public class CallArgumentInfo {
    */
   @ExplodeLoop
   public static void reorderArguments(int[] order, Object[] args, Object[] result) {
-    for (int i = 0; i < args.length; i++) {
+    for (int i = 0; i < order.length; i++) {
       result[order[i]] = args[i];
     }
   }

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
@@ -139,7 +139,7 @@ public final class Function implements TruffleObject {
       for (int i = 0; i < length; i++) {
         args[i] = new CallArgumentInfo(null, false, true);
       }
-      return ArgumentSorterNodeGen.create(args);
+      return ArgumentSorterNodeGen.create(args, false);
     }
 
     /**

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
@@ -137,7 +137,7 @@ public final class Function implements TruffleObject {
      */
     @Specialization(
         guards = "arguments.length == cachedArgsLength",
-        limit = Constants.CacheSizes.INTEROP_LIBRARY_CACHE_SIZE)
+        limit = Constants.CacheSizes.FUNCTION_INTEROP_LIBRARY)
     protected static Object callCached(
         Function function,
         Object[] arguments,

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
@@ -9,9 +9,8 @@ import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
-import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
-import com.oracle.truffle.api.nodes.IndirectCallNode;
+import org.enso.interpreter.Constants;
 import org.enso.interpreter.node.callable.argument.sorter.ArgumentSorterNode;
 import org.enso.interpreter.node.callable.argument.sorter.ArgumentSorterNodeGen;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
@@ -113,26 +112,11 @@ public final class Function implements TruffleObject {
   public abstract static class Execute {
 
     /**
-     * Calls the function directly.
+     * Builds an argument sorter node prepared to apply a predefined number of arguments.
      *
-     * <p>This specialisation comes into play where the call target for the provided function is
-     * already cached. THis means that the call can be made quickly.
-     *
-     * @param function the function to execute
-     * @param arguments the arguments passed to {@code function} in the expected positional order
-     * @param cachedTarget the cached call target for {@code function}
-     * @param callNode the cached call node for {@code cachedTarget}
-     * @return the result of executing {@code function} on {@code arguments}
+     * @param length the number of arguments to build the sorter node for.
+     * @return an argument sorter node ready to apply {@code length} arguments.
      */
-    @Specialization(guards = "arguments.length == cachedArgsLength", limit="100")
-    protected static Object callDirect(
-        Function function,
-        Object[] arguments,
-        @Cached("arguments.length") final int cachedArgsLength,
-        @Cached("buildSorter(cachedArgsLength)") final ArgumentSorterNode sorterNode) {
-      return sorterNode.execute(function, arguments);
-    }
-
     @ExplodeLoop
     protected static ArgumentSorterNode buildSorter(int length) {
       CallArgumentInfo[] args = new CallArgumentInfo[length];
@@ -143,22 +127,35 @@ public final class Function implements TruffleObject {
     }
 
     /**
-     * Calls the function with a lookup.
-     *
-     * <p>This specialisation is used in the case where there is no cached call target for the
-     * provided function. This is much slower and should, in general, be avoided.
+     * Calls a function extensively caching relevant metadata. This is the fast path operation.
      *
      * @param function the function to execute
      * @param arguments the arguments passed to {@code function} in the expected positional order
-     * @param callNode the cached call node for making indirect calls
+     * @param cachedArgsLength the cached arguments count
+     * @param sorterNode the cached argument sorter node for the particular arguments array length.
      * @return the result of executing {@code function} on {@code arguments}
      */
-    @Specialization(replaces = "callDirect")
-    protected static Object callIndirect(
-        Function function, Object[] arguments, @Cached IndirectCallNode callNode) {
-      throw new RuntimeException("just don't");
+    @Specialization(
+        guards = "arguments.length == cachedArgsLength",
+        limit = Constants.CacheSizes.INTEROP_LIBRARY_CACHE_SIZE)
+    protected static Object callCached(
+        Function function,
+        Object[] arguments,
+        @Cached(value = "arguments.length") int cachedArgsLength,
+        @Cached(value = "buildSorter(cachedArgsLength)") ArgumentSorterNode sorterNode) {
+      return sorterNode.execute(function, arguments);
+    }
 
-//      return callNode.call(function.getCallTarget(), function.getScope(), arguments);
+    /**
+     * Calls a function without any caching. This is the slow path variant.
+     *
+     * @param function the function to execute.
+     * @param arguments the arguments to pass to the {@code function}.
+     * @return the result of function application.
+     */
+    @Specialization(replaces = "callCached")
+    protected static Object callUncached(Function function, Object[] arguments) {
+      return callCached(function, arguments, arguments.length, buildSorter(arguments.length));
     }
   }
 

--- a/Interpreter/src/test/scala/org/enso/interpreter/InteropTest.scala
+++ b/Interpreter/src/test/scala/org/enso/interpreter/InteropTest.scala
@@ -1,0 +1,36 @@
+package org.enso.interpreter
+
+class InteropTest extends LanguageTest {
+  "Interop library" should "support tail recursive functions" in {
+    val code =
+      """
+        |@{
+        |  recurFun = { |i| ifZero: [i, 0, @recurFun [i - 1]] };
+        |  recurFun
+        |}
+        |""".stripMargin
+    val recurFun = eval(code)
+    recurFun.call(15) shouldEqual 0
+  }
+
+  "Interop library" should "support calling curried functions" in {
+    val code =
+      """
+        |@{
+        |  fun = { |x, y, z| (x + y) + z };
+        |  @fun [y = 1]
+        |}
+        |""".stripMargin
+    val curriedFun = eval(code)
+    curriedFun.call(2, 3) shouldEqual 6
+  }
+
+  "Interop library" should "support creating curried calls" in {
+    val code =
+      """
+        |{ |x, y, z| (x + y) + z }
+        |""".stripMargin
+    val fun = eval(code)
+    fun.call(1).call(2).call(3) shouldEqual 6
+  }
+}

--- a/Interpreter/src/test/scala/org/enso/interpreter/LanguageTest.scala
+++ b/Interpreter/src/test/scala/org/enso/interpreter/LanguageTest.scala
@@ -8,7 +8,8 @@ import org.scalatest.Matchers
 
 trait LanguageRunner {
   implicit class RichValue(value: Value) {
-    def call(l: Long): Value = value.execute(l.asInstanceOf[AnyRef])
+//    def call(l: Long): Value = value.execute(l.asInstanceOf[AnyRef])
+    def call(l: Long*): Value = value.execute(l.map(_.asInstanceOf[AnyRef]): _*)
   }
   val ctx = Context.newBuilder(Constants.LANGUAGE_ID).build()
   def eval(code: String): Value = ctx.eval(Constants.LANGUAGE_ID, code)

--- a/Interpreter/src/test/scala/org/enso/interpreter/LanguageTest.scala
+++ b/Interpreter/src/test/scala/org/enso/interpreter/LanguageTest.scala
@@ -8,7 +8,6 @@ import org.scalatest.Matchers
 
 trait LanguageRunner {
   implicit class RichValue(value: Value) {
-//    def call(l: Long): Value = value.execute(l.asInstanceOf[AnyRef])
     def call(l: Long*): Value = value.execute(l.map(_.asInstanceOf[AnyRef]): _*)
   }
   val ctx = Context.newBuilder(Constants.LANGUAGE_ID).build()


### PR DESCRIPTION
### Pull Request Description
This PR makes the interop library handle TCO and currying. No performance improvements were introduced and I stop to see room for some there – the calls are not getting hot enough to get compiled quickly. This however is an artificial issue for now – it only affects the speed of microbenchmarks and won't have impact on larger pure-enso projects. We may need to revisit this when the foreign languages interoperability is being implemented, though I doubt it will be the case.

### Important Notes
Should be self explanatory

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

