### PR TITLE
Add debugging capabilities to bench only

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,6 @@
 import scala.sys.process._
+import org.enso.build.BenchTasks._
+import org.enso.build.WithDebugCommand
 
 // Global Configuration
 organization := "org.enso"
@@ -15,9 +17,9 @@ scalacOptions ++= Seq(
 javacOptions ++= Seq("-source", "12", "-target", "1.8")
 
 // Benchmark Configuration
-lazy val Benchmark = config("bench") extend Test
-lazy val bench     = taskKey[Unit]("Run Benchmarks")
-lazy val benchOnly = inputKey[Unit]("Run benchmarks by name substring")
+lazy val Benchmark = config("bench") extend sbt.Test
+
+// Native Image Generation
 lazy val buildNativeImage =
   taskKey[Unit]("Build native image for the Enso executable")
 
@@ -93,7 +95,7 @@ lazy val interpreter = (project in file("Interpreter"))
     mainClass in (Compile, run) := Some("org.enso.interpreter.Main"),
     version := "0.1"
   )
-  .settings(commands += RunDebugCommand.runDebug)
+  .settings(commands += WithDebugCommand.withDebug)
   .settings(
     libraryDependencies ++= Seq(
       "com.chuusai"            %% "shapeless"                % "2.3.3",

--- a/project/BenchTasks.scala
+++ b/project/BenchTasks.scala
@@ -1,0 +1,12 @@
+package org.enso.build
+
+import sbt.inputKey
+import sbt.taskKey
+
+/**
+  * Defines benchmarking related task keys.
+  */
+object BenchTasks {
+  lazy val bench     = taskKey[Unit]("Run Benchmarks")
+  lazy val benchOnly = inputKey[Unit]("Run benchmarks by name substring")
+}


### PR DESCRIPTION
### Pull Request Description
The easy debugging machinery can now be used with benchmark task.

### Important Notes
Rather than implementing new logic for this, I've just changed the `runDebug` command to accept the task name as an argument. `runDebug` becomes `withDebug run`, while the new capability is `withDebug benchOnly`.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

