### PR TITLE
WIP: Replace Scala parser combinators with fastparse

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -229,6 +229,7 @@ lazy val interpreter = (project in file("Interpreter"))
       "org.graalvm.truffle"    % "truffle-tck"               % "19.2.0",
       "org.graalvm.truffle"    % "truffle-tck-common"        % "19.2.0",
       "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+      "com.lihaoyi"            %% "fastparse"                % "2.1.3",
       "org.scalacheck"         %% "scalacheck"               % "1.14.0" % Test,
       "org.scalactic"          %% "scalactic"                % "3.0.8" % Test,
       "org.scalatest"          %% "scalatest"                % "3.2.0-SNAP10" % Test,


### PR DESCRIPTION
### Pull Request Description
This PR replaces Scala parser combinators with [fastparse](https://www.lihaoyi.com/fastparse/).
Here's a [comparison of fastparse to other parsers](https://www.lihaoyi.com/fastparse/#Comparisons). In [benchmarks it is 2-300x faster than Scala's own parser combinators](https://www.lihaoyi.com/fastparse/#Performance).

### Important Notes
* I only saw the [PR which seems to introduce a new parser](https://github.com/luna/enso/pull/172) after doing the code changes, so I'm not sure if this PR is still relevant at all...
* The PR is WIP, as most tests don't yet pass. I'll comment once they do.


### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [ ] All code has been tested where possible.

