### PR TITLE
Fix lexical scope resolution in recursive calls

### DIFF
--- a/Interpreter/src/main/java/org/enso/interpreter/node/callable/argument/sorter/CachedArgumentSorterNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/callable/argument/sorter/CachedArgumentSorterNode.java
@@ -98,13 +98,13 @@ public class CachedArgumentSorterNode extends BaseNode {
     if (this.appliesFully()) {
       if (!postApplicationSchema.hasOversaturatedArgs()) {
         if (this.isTail()) {
-          throw new TailCallException(this.getOriginalFunction(), mappedAppliedArguments);
+          throw new TailCallException(function, mappedAppliedArguments);
         } else {
-          return optimiser.executeDispatch(this.getOriginalFunction(), mappedAppliedArguments);
+          return optimiser.executeDispatch(function, mappedAppliedArguments);
         }
       } else {
         Object evaluatedVal =
-            optimiser.executeDispatch(this.getOriginalFunction(), mappedAppliedArguments);
+            optimiser.executeDispatch(function, mappedAppliedArguments);
 
         return this.oversaturatedCallableNode.execute(
             evaluatedVal, generateOversaturatedArguments(function, arguments));

--- a/Interpreter/src/test/scala/org/enso/interpreter/test/semantic/FunctionArgumentsTest.scala
+++ b/Interpreter/src/test/scala/org/enso/interpreter/test/semantic/FunctionArgumentsTest.scala
@@ -91,4 +91,17 @@ class FunctionArgumentsTest extends LanguageTest {
 
     eval(code) shouldEqual 1
   }
+
+  "Recursion closing over lexical scope" should "work properly" in {
+    val code =
+      """
+        |@{
+        |  summator = { |current| ifZero: [current, 0,  @{@summator [current - 1]} ] };
+        |  res = @summator [0];
+        |  res
+        |}
+        |""".stripMargin
+
+    eval(code) shouldEqual 0
+  }
 }


### PR DESCRIPTION
### Pull Request Description
Fixes an issue I've randomly stumbled upon when testing lazy arguments. Without this change, the test added here diverges.

### Important Notes
Nothing important here. Amazingly enough, two benchmarks got a significant improvement, with no regressions elsewhere.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

