### PR TITLE
Graph API: definition discovery

### DIFF
--- a/Syntax/graph/src/main/scala/org/enso/syntax/graph/DoubleRepresentation.scala
+++ b/Syntax/graph/src/main/scala/org/enso/syntax/graph/DoubleRepresentation.scala
@@ -204,11 +204,12 @@ final case class DoubleRepresentation(
     if (lhs.exists(_.is[AST.App.Prefix]))
       return None
 
-    val id       = ast.unsafeID
-    val spanTree = SpanTree(rhs, TextPosition.Start)
-    val output   = lhs.map(SpanTree(_, TextPosition.Start))
-    val metadata = state.getMetadata(module, id)
-    val node     = Node.Description(id, spanTree, output, metadata)
-    Some(node)
+    ast.id.map { id =>
+      val spanTree = SpanTree(rhs, TextPosition.Start)
+      val output   = lhs.map(SpanTree(_, TextPosition.Start))
+      val metadata = state.getMetadata(module, id)
+      val node     = Node.Description(id, spanTree, output, metadata)
+      node
+    }
   }
 }

--- a/Syntax/graph/src/main/scala/org/enso/syntax/graph/DoubleRepresentation.scala
+++ b/Syntax/graph/src/main/scala/org/enso/syntax/graph/DoubleRepresentation.scala
@@ -193,8 +193,8 @@ final case class DoubleRepresentation(
       case Some(Infix(AST.App.Prefix(ast, _), _, _)) => findName(ast)
       case _                                         => return None
     }
-    val description = Definition.Description(name, ast.unsafeID)
-    Some(description)
+
+    ast.id.map(Definition.Description(name, _))
   }
 
   def describeNode(

--- a/Syntax/graph/src/main/scala/org/enso/syntax/graph/DoubleRepresentation.scala
+++ b/Syntax/graph/src/main/scala/org/enso/syntax/graph/DoubleRepresentation.scala
@@ -97,7 +97,7 @@ final case class DoubleRepresentation(
 
   def getDefinitions(loc: Module.Location): List[Definition.Description] = {
     val ast = state.getModule(loc)
-    ast.flatTraverse(describeDefinition(loc, _))
+    ast.flatTraverse(describeDefinition)
   }
   def addNode(
     context: Node.Context,
@@ -181,21 +181,11 @@ final case class DoubleRepresentation(
   //// Helpers ////
   /////////////////
 
-  def describeDefinition(
-    module: Module.Location,
-    ast: AST
-  ): Option[API.Definition.Description] = {
-    def findName(ast: AST): String = ast match {
-      case AST.App.Prefix(fn, _) => findName(fn)
-      case AST.Var(name)         => name
-    }
-    val name = ast.toAssignment match {
-      case Some(Infix(AST.App.Prefix(ast, _), _, _)) => findName(ast)
-      case _                                         => return None
-    }
-
-    ast.id.map(Definition.Description(name, _))
-  }
+  def describeDefinition(ast: AST): Option[API.Definition.Description] =
+    for {
+      info <- DefinitionInfo(ast)
+      id   <- ast.id
+    } yield Definition.Description(info.name.name, id)
 
   def describeNode(
     module: Module.Location,

--- a/Syntax/graph/src/main/scala/org/enso/syntax/graph/SpanTree.scala
+++ b/Syntax/graph/src/main/scala/org/enso/syntax/graph/SpanTree.scala
@@ -296,7 +296,7 @@ object SpanTree {
     case AST.Var.any(_)            => Node.AstLeaf(pos, ast)
     case AST.App.Prefix.any(app) =>
       val info          = Positioned(ast, pos)
-      val childrenAsts  = ast.flattenPrefix(pos, app)
+      val childrenAsts  = app.flattenPrefix(pos)
       val childrenNodes = childrenAsts.map(SpanTree(_))
       childrenNodes match {
         case callee :: args => Node.AppChain(info, callee, args)

--- a/Syntax/graph/src/test/scala/org/enso/syntax/graph/Tests.scala
+++ b/Syntax/graph/src/test/scala/org/enso/syntax/graph/Tests.scala
@@ -124,6 +124,8 @@ class Tests extends FunSuite with TestUtils {
       """import Foo.Bar
         |the a = a
         |The a = a
+        |node = a
+        |Match = a
         |a , b = the, Bar
         |""".stripMargin
     withDR(program) { dr =>

--- a/Syntax/graph/src/test/scala/org/enso/syntax/graph/Tests.scala
+++ b/Syntax/graph/src/test/scala/org/enso/syntax/graph/Tests.scala
@@ -123,6 +123,7 @@ class Tests extends FunSuite with TestUtils {
     val program =
       """import Foo.Bar
         |the a = a
+        |The a = a
         |a , b = the, Bar
         |""".stripMargin
     withDR(program) { dr =>

--- a/Syntax/graph/src/test/scala/org/enso/syntax/graph/Tests.scala
+++ b/Syntax/graph/src/test/scala/org/enso/syntax/graph/Tests.scala
@@ -119,6 +119,17 @@ class Tests extends FunSuite with TestUtils {
       graph.links should have size 0
     }
   }
+  test("test definitions") {
+    val program =
+      """import Foo.Bar
+        |the a = a
+        |a , b = the, Bar
+        |""".stripMargin
+    withDR(program) { dr =>
+      val definitions = dr.getDefinitions(mockModule).map(_.name)
+      definitions shouldBe List("the")
+    }
+  }
 //  test("no nodes from operator def") {
 //    withDR(
 //      "+ a b = a + b",


### PR DESCRIPTION
### Pull Request Description

Implements listing enterable definitions in module's or definiton's scope, i.e. the getDefinitions API.

### Checklist
Please include the following checklist in your PR:
- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

