### PR TITLE
Fix Paren Operator Bug

### DIFF
--- a/Syntax/specialization/src/test/scala/org/enso/syntax/text/ParserTest.scala
+++ b/Syntax/specialization/src/test/scala/org/enso/syntax/text/ParserTest.scala
@@ -314,9 +314,9 @@ class ParserTest extends FlatSpec with Matchers {
   def _amb_group_(i: Int)(t: AST): Macro.Ambiguous =
     amb("(", List(List(")")), Shifted(i, t))
 
-  val amb_group                 = _amb_group_(0)(_)
-  val amb_group_                = _amb_group_(1)(_)
-  val amb_group__               = _amb_group_(2)(_)
+  val amb_group   = _amb_group_(0)(_)
+  val amb_group_  = _amb_group_(1)(_)
+  val amb_group__ = _amb_group_(2)(_)
   def group_(): Macro.Ambiguous = amb("(", List(List(")")))
 
   def _amb_if(i: Int)(t: AST) =
@@ -330,6 +330,8 @@ class ParserTest extends FlatSpec with Matchers {
   "( )"         ?= Group()
   "( (  )   )"  ?= Group(Group())
   "(a)"         ?= Group("a")
+  "(+a)"        ?= Group("+" $ "a")
+  "(a+)"        ?= Group("a" $ "+")
   "((a))"       ?= Group(Group("a"))
   "(((a)))"     ?= Group(Group(Group("a")))
   "( (  a   ))" ?= Group(Group("a"))


### PR DESCRIPTION
### Pull Request Description
Fixes parsing of `(+foo)`. The `(+` was parsed as an operator `(` with an incorrect suffix before that fix.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
