### PR TITLE
Bump SBT and GraalVM Versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,9 +17,8 @@ trigger:
 pr: none
 
 variables:
-  graalVersion: 19.2.0.1 # Please ensure this is in sync with the graalAPIVersion in build.sbt
-  sbtVersion: 1.3.2      # Please ensure this is in sync with project/build.properties
-  historicMacOSSbtFormula: https://raw.githubusercontent.com/Homebrew/homebrew-core/5311047af872538de3bd9fa10d78eda3185a7559/Formula/sbt.rb
+  graalVersion: 19.2.1 # Please ensure this is in sync with the graalAPIVersion in build.sbt
+  sbtVersion: 1.3.3    # Please ensure this is in sync with project/build.properties
 
 jobs:
 - job: Linux

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import org.enso.build.WithDebugCommand
 //////////////////////////////
 
 val scalacVersion = "2.12.10"
-val graalVersion = "19.2.1"
+val graalVersion = "19.2.0.1"
 organization in ThisBuild := "org.enso"
 scalaVersion in ThisBuild := scalacVersion
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import org.enso.build.WithDebugCommand
 //////////////////////////////
 
 val scalacVersion = "2.12.10"
-val graalVersion = "19.2.0.1"
+val graalVersion = "19.2.1"
 organization in ThisBuild := "org.enso"
 scalaVersion in ThisBuild := scalacVersion
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.3


### PR DESCRIPTION
### Pull Request Description
This PR bumps the versions of GraalVM (to 19.2.1) and sbt (to 1.3.3) used for building Enso. 

### Important Notes
It explicitly does _not_ bump the GraalVM API versions as there are no new packages available at this point in time. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
