### PR TITLE
Fix incremental compile for parser test env

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import org.enso.build.WithDebugCommand
 //////////////////////////////
 
 val scalacVersion = "2.12.10"
-val graalVersion = "19.2.0.1"
+val graalVersion  = "19.2.0.1"
 organization in ThisBuild := "org.enso"
 scalaVersion in ThisBuild := scalacVersion
 
@@ -182,7 +182,7 @@ lazy val syntax = (project in file("Syntax/specialization"))
       "org.scalatest"     %% "scalatest"  % "3.0.5" % Test,
       "com.lihaoyi"       %% "pprint"     % "0.5.3"
     ),
-    (Compile / compile) := (Compile / compile)
+    compile := (Compile / compile)
       .dependsOn(Def.taskDyn {
         val parserCompile =
           (syntax_definition / Compile / compileIncremental).value


### PR DESCRIPTION
### Pull Request Description
The magic I've introduced for incremental parser recompilations in the presence of scalac's "subpar" macro system was not triggering properly for the Test config. It does now.

### Important Notes

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
