### PR TITLE
Better way of registering builtin functions

### DIFF
--- a/Interpreter/src/main/java/org/enso/interpreter/builder/ExpressionFactory.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/builder/ExpressionFactory.java
@@ -32,7 +32,6 @@ import org.enso.interpreter.node.controlflow.DefaultFallbackNode;
 import org.enso.interpreter.node.controlflow.FallbackNode;
 import org.enso.interpreter.node.controlflow.IfZeroNode;
 import org.enso.interpreter.node.controlflow.MatchNode;
-import org.enso.interpreter.node.expression.builtin.PrintNodeGen;
 import org.enso.interpreter.node.expression.constant.ConstructorNode;
 import org.enso.interpreter.node.expression.constant.DynamicSymbolNode;
 import org.enso.interpreter.node.expression.literal.IntegerLiteralNode;
@@ -368,17 +367,6 @@ public class ExpressionFactory implements AstExpressionVisitor<ExpressionNode> {
     currentVarName = varName;
     FrameSlot slot = scope.createVarSlot(varName);
     return AssignmentNodeGen.create(expr.visit(this), slot);
-  }
-
-  /**
-   * Creates a runtime node representing a print expression.
-   *
-   * @param body an expression that computes the value to print
-   * @return a runtime node representing the print
-   */
-  @Override
-  public ExpressionNode visitPrint(AstExpression body) {
-    return PrintNodeGen.create(body.visit(this));
   }
 
   /**

--- a/Interpreter/src/main/java/org/enso/interpreter/node/ExpressionNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/ExpressionNode.java
@@ -14,7 +14,7 @@ import org.enso.interpreter.runtime.type.TypesGen;
  *
  * <p>Enso is an expression-oriented language, and hence doesn't have any statements. This means
  * that all expression execution will return a value, even if that is just the {@link
- * Builtins#UNIT} type.
+ * Builtins#unit} type.
  *
  * <p>This class contains specialisations of the {@link #executeGeneric(VirtualFrame)
  * executeGeneric} method for various scenarios in order to improve performance.

--- a/Interpreter/src/main/java/org/enso/interpreter/node/ExpressionNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/ExpressionNode.java
@@ -14,7 +14,7 @@ import org.enso.interpreter.runtime.type.TypesGen;
  *
  * <p>Enso is an expression-oriented language, and hence doesn't have any statements. This means
  * that all expression execution will return a value, even if that is just the {@link
- * Builtins#getUnit()} type.
+ * Builtins#unit()} type.
  *
  * <p>This class contains specialisations of the {@link #executeGeneric(VirtualFrame)
  * executeGeneric} method for various scenarios in order to improve performance.

--- a/Interpreter/src/main/java/org/enso/interpreter/node/ExpressionNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/ExpressionNode.java
@@ -14,7 +14,7 @@ import org.enso.interpreter.runtime.type.TypesGen;
  *
  * <p>Enso is an expression-oriented language, and hence doesn't have any statements. This means
  * that all expression execution will return a value, even if that is just the {@link
- * Builtins#unit} type.
+ * Builtins#getUnit()} type.
  *
  * <p>This class contains specialisations of the {@link #executeGeneric(VirtualFrame)
  * executeGeneric} method for various scenarios in order to improve performance.

--- a/Interpreter/src/main/java/org/enso/interpreter/node/expression/builtin/PrintNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/expression/builtin/PrintNode.java
@@ -1,6 +1,9 @@
 package org.enso.interpreter.node.expression.builtin;
 
+import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -10,43 +13,50 @@ import org.enso.interpreter.Language;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.Builtins;
 import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
+import org.enso.interpreter.runtime.callable.function.ArgumentSchema;
 import org.enso.interpreter.runtime.callable.function.Function;
 
 import java.io.PrintStream;
 
-/** This node allows for printing the result of an arbitrary expression to standard output. */
-@NodeInfo(shortName = "print", description = "Prints the value of child expression.")
+/** This node allows for printing the result of arbitrary values to standard output. */
+@NodeInfo(shortName = "print", description = "Root of the IO.println method.")
 public abstract class PrintNode extends RootNode {
 
   /**
-   * Creates a node that prints the result of its expression.
+   * Creates a root node for the builtin IO.println method.
    *
-   * @param expression the expression to print the result of
+   * @param language the current {@link Language} instance.
    */
   public PrintNode(Language language) {
     super(language);
   }
 
-  /**
-   * Executes the print node.
-   *
-   * @param frame the stack frame for execution
-   * @return unit {@link Builtins#getUnit()} type
-   */
   @Specialization
-  public Object doPrint(VirtualFrame frame, @CachedContext(Language.class) Context ctx) {
+  protected Object doPrint(VirtualFrame frame, @CachedContext(Language.class) Context ctx) {
     doPrint(ctx.getOut(), Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[1]);
 
     return ctx.getUnit().newInstance();
   }
 
-  /**
-   * Prints the provided value to standard output.
-   *
-   * @param object the value to print
-   */
   @CompilerDirectives.TruffleBoundary
   private void doPrint(PrintStream out, Object object) {
     out.println(object);
+  }
+
+  /**
+   * Creates a {@link Function} object ignoring its first argument and printing the second to the
+   * standard output.
+   *
+   * @param language the current {@link Language} instance
+   * @return a {@link Function} object wrapping the behavior of this node
+   */
+  public static Function toFunction(Language language) {
+    PrintNode node = PrintNodeGen.create(language);
+    RootCallTarget callTarget = Truffle.getRuntime().createCallTarget(node);
+    ArgumentSchema schema =
+        new ArgumentSchema(
+            new ArgumentDefinition(0, "this", false), new ArgumentDefinition(1, "value", false));
+    return new Function(callTarget, null, schema);
   }
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/expression/builtin/PrintNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/expression/builtin/PrintNode.java
@@ -5,25 +5,26 @@ import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.nodes.RootNode;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.Builtins;
 import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.callable.function.Function;
 
 import java.io.PrintStream;
 
 /** This node allows for printing the result of an arbitrary expression to standard output. */
 @NodeInfo(shortName = "print", description = "Prints the value of child expression.")
-public abstract class PrintNode extends ExpressionNode {
-  @Child private ExpressionNode expression;
+public abstract class PrintNode extends RootNode {
 
   /**
    * Creates a node that prints the result of its expression.
    *
    * @param expression the expression to print the result of
    */
-  public PrintNode(ExpressionNode expression) {
-    this.expression = expression;
+  public PrintNode(Language language) {
+    super(language);
   }
 
   /**
@@ -34,7 +35,7 @@ public abstract class PrintNode extends ExpressionNode {
    */
   @Specialization
   public Object doPrint(VirtualFrame frame, @CachedContext(Language.class) Context ctx) {
-    doPrint(ctx.getOut(), expression.executeGeneric(frame));
+    doPrint(ctx.getOut(), Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[1]);
 
     return ctx.getUnit().newInstance();
   }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/expression/builtin/PrintNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/expression/builtin/PrintNode.java
@@ -10,7 +10,6 @@ import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.Builtins;
 import org.enso.interpreter.runtime.Context;
 
-import java.io.OutputStream;
 import java.io.PrintStream;
 
 /** This node allows for printing the result of an arbitrary expression to standard output. */
@@ -31,13 +30,13 @@ public abstract class PrintNode extends ExpressionNode {
    * Executes the print node.
    *
    * @param frame the stack frame for execution
-   * @return unit {@link Builtins#UNIT unit} type
+   * @return unit {@link Builtins#getUnit()} type
    */
   @Specialization
   public Object doPrint(VirtualFrame frame, @CachedContext(Language.class) Context ctx) {
     doPrint(ctx.getOut(), expression.executeGeneric(frame));
 
-    return Builtins.UNIT.newInstance();
+    return ctx.getUnit().newInstance();
   }
 
   /**

--- a/Interpreter/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
@@ -23,7 +23,8 @@ public abstract class AssignmentNode extends ExpressionNode {
    *
    * @param frame the frame to write to
    * @param value the value to write
-   * @return the {@link Builtins#unit unit} type
+   * @param ctx language context for global values access
+   * @return the unit type
    */
   @Specialization
   protected Object writeLong(
@@ -39,7 +40,8 @@ public abstract class AssignmentNode extends ExpressionNode {
    *
    * @param frame the frame to write to
    * @param value the value to write
-   * @return the {@link Builtins#unit unit} type
+   * @param ctx language context for global values access
+   * @return the unit type
    */
   @Specialization
   protected Object writeObject(

--- a/Interpreter/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.node.scope;
 
+import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -7,8 +8,10 @@ import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
+import org.enso.interpreter.Language;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.Builtins;
+import org.enso.interpreter.runtime.Context;
 
 /** This node represents an assignment to a variable in a given scope. */
 @NodeInfo(shortName = "=", description = "Assigns expression result to a variable.")
@@ -20,14 +23,15 @@ public abstract class AssignmentNode extends ExpressionNode {
    *
    * @param frame the frame to write to
    * @param value the value to write
-   * @return the {@link Builtins#UNIT unit} type
+   * @return the {@link Builtins#unit unit} type
    */
   @Specialization
-  protected Object writeLong(VirtualFrame frame, long value) {
+  protected Object writeLong(
+      VirtualFrame frame, long value, @CachedContext(Language.class) Context ctx) {
     frame.getFrameDescriptor().setFrameSlotKind(getFrameSlot(), FrameSlotKind.Long);
     frame.setLong(getFrameSlot(), value);
 
-    return Builtins.UNIT.newInstance();
+    return ctx.getUnit().newInstance();
   }
 
   /**
@@ -35,14 +39,15 @@ public abstract class AssignmentNode extends ExpressionNode {
    *
    * @param frame the frame to write to
    * @param value the value to write
-   * @return the {@link Builtins#UNIT unit} type
+   * @return the {@link Builtins#unit unit} type
    */
   @Specialization
-  protected Object writeObject(VirtualFrame frame, Object value) {
+  protected Object writeObject(
+      VirtualFrame frame, Object value, @CachedContext(Language.class) Context ctx) {
     frame.getFrameDescriptor().setFrameSlotKind(getFrameSlot(), FrameSlotKind.Object);
     frame.setObject(getFrameSlot(), value);
 
-    return Builtins.UNIT.newInstance();
+    return ctx.getUnit().newInstance();
   }
 
   /**

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/Builtins.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/Builtins.java
@@ -1,24 +1,31 @@
 package org.enso.interpreter.runtime;
 
+import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 
 /** Container class for static predefined atoms and their containing scope. */
 public class Builtins {
-  public static final ModuleScope BUILTIN_SCOPE = new ModuleScope();
-  public static final AtomConstructor UNIT =
-      new AtomConstructor("Unit", BUILTIN_SCOPE).initializeFields();
-  public static final AtomConstructor NIL =
-      new AtomConstructor("Nil", BUILTIN_SCOPE).initializeFields();
-  public static final AtomConstructor CONS =
-      new AtomConstructor("Cons", BUILTIN_SCOPE)
+  private final ModuleScope scope = new ModuleScope();
+  private final AtomConstructor unit = new AtomConstructor("Unit", scope).initializeFields();
+  private final AtomConstructor nil = new AtomConstructor("Nil", scope).initializeFields();
+  private final AtomConstructor cons =
+      new AtomConstructor("Cons", scope)
           .initializeFields(
               new ArgumentDefinition(0, "head", false), new ArgumentDefinition(1, "rest", false));
 
-  static {
-    BUILTIN_SCOPE.registerConstructor(Builtins.CONS);
-    BUILTIN_SCOPE.registerConstructor(Builtins.NIL);
-    BUILTIN_SCOPE.registerConstructor(Builtins.UNIT);
+  public Builtins(Language language) {
+    scope.registerConstructor(cons);
+    scope.registerConstructor(nil);
+    scope.registerConstructor(unit);
+  }
+
+  public AtomConstructor getUnit() {
+    return unit;
+  }
+
+  public ModuleScope getScope() {
+    return scope;
   }
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/Builtins.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/Builtins.java
@@ -40,7 +40,7 @@ public class Builtins {
    *
    * @return the {@code Unit} atom constructor
    */
-  public AtomConstructor getUnit() {
+  public AtomConstructor unit() {
     return unit;
   }
 

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/Builtins.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/Builtins.java
@@ -1,8 +1,14 @@
 package org.enso.interpreter.runtime;
 
+import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.Truffle;
 import org.enso.interpreter.Language;
+import org.enso.interpreter.node.expression.builtin.PrintNode;
+import org.enso.interpreter.node.expression.builtin.PrintNodeGen;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.callable.function.ArgumentSchema;
+import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 
 /** Container class for static predefined atoms and their containing scope. */
@@ -14,11 +20,33 @@ public class Builtins {
       new AtomConstructor("Cons", scope)
           .initializeFields(
               new ArgumentDefinition(0, "head", false), new ArgumentDefinition(1, "rest", false));
+  private final AtomConstructor builtins =
+      new AtomConstructor("Builtins", scope).initializeFields();
 
   public Builtins(Language language) {
     scope.registerConstructor(cons);
     scope.registerConstructor(nil);
     scope.registerConstructor(unit);
+    scope.registerConstructor(builtins);
+
+    installBuiltinMethods(builtins, language);
+  }
+
+  private void installBuiltinMethods(AtomConstructor atom, Language language) {
+    scope.registerMethod(
+        atom,
+        "print",
+        new Function(
+            printCallTarget(language),
+            null,
+            new ArgumentSchema(
+                new ArgumentDefinition(0, "this", false),
+                new ArgumentDefinition(1, "value", false))));
+  }
+
+  private RootCallTarget printCallTarget(Language language) {
+    PrintNode node = PrintNodeGen.create(language);
+    return Truffle.getRuntime().createCallTarget(node);
   }
 
   public AtomConstructor getUnit() {

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/Context.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/Context.java
@@ -20,6 +20,7 @@ import org.enso.interpreter.Language;
 import org.enso.interpreter.builder.ModuleScopeExpressionFactory;
 import org.enso.interpreter.node.EnsoRootNode;
 import org.enso.interpreter.node.ExpressionNode;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.error.ModuleDoesNotExistException;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.interpreter.util.ScalaConversions;
@@ -36,6 +37,7 @@ public class Context {
   private final Env environment;
   private final Map<String, Module> knownFiles;
   private final PrintStream out;
+  private final Builtins builtins;
 
   /**
    * Creates a new Enso context.
@@ -47,6 +49,7 @@ public class Context {
     this.language = language;
     this.environment = environment;
     this.out = new PrintStream(environment.out());
+    this.builtins = new Builtins(language);
 
     List<File> packagePaths = RuntimeOptions.getPackagesPaths(environment);
     // TODO [MK] Replace getTruffleFile with getInternalTruffleFile when Graal 19.3.0 comes out.
@@ -86,7 +89,7 @@ public class Context {
    * @return a call target which execution corresponds to the toplevel executable bits in the module
    */
   public CallTarget parse(Source source) {
-    return parse(source, new ModuleScope());
+    return parse(source, createScope());
   }
 
   /**
@@ -130,5 +133,19 @@ public class Context {
    */
   public PrintStream getOut() {
     return out;
+  }
+
+  public ModuleScope createScope() {
+    ModuleScope moduleScope = new ModuleScope();
+    moduleScope.addImport(getBuiltins().getScope());
+    return moduleScope;
+  }
+
+  public Builtins getBuiltins() {
+    return builtins;
+  }
+
+  public AtomConstructor getUnit() {
+    return getBuiltins().getUnit();
   }
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/Context.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/Context.java
@@ -135,16 +135,27 @@ public class Context {
     return out;
   }
 
+  /**
+   * Creates a new module scope that automatically imports all the builtin types and methods.
+   *
+   * @return a new module scope with automatic builtins dependency.
+   */
   public ModuleScope createScope() {
     ModuleScope moduleScope = new ModuleScope();
     moduleScope.addImport(getBuiltins().getScope());
     return moduleScope;
   }
 
-  public Builtins getBuiltins() {
+  private Builtins getBuiltins() {
     return builtins;
   }
 
+  /**
+   * Returns the atom constructor corresponding to the {@code Unit} type, for builtin constructs
+   * that need to return an atom of this type.
+   *
+   * @return the builtin {@code Unit} atom constructor
+   */
   public AtomConstructor getUnit() {
     return getBuiltins().getUnit();
   }

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/Context.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/Context.java
@@ -157,6 +157,6 @@ public class Context {
    * @return the builtin {@code Unit} atom constructor
    */
   public AtomConstructor getUnit() {
-    return getBuiltins().getUnit();
+    return getBuiltins().unit();
   }
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -28,7 +28,7 @@ public class Module {
    */
   public ModuleScope requestParse(Context context) throws IOException {
     if (cachedScope == null) {
-      cachedScope = new ModuleScope();
+      cachedScope = context.createScope();
       context.parse(file, cachedScope);
     }
     return cachedScope;

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/function/ArgumentSchema.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/function/ArgumentSchema.java
@@ -48,7 +48,7 @@ public class ArgumentSchema {
    *
    * @param argumentInfos Definition site arguments information
    */
-  public ArgumentSchema(ArgumentDefinition[] argumentInfos) {
+  public ArgumentSchema(ArgumentDefinition... argumentInfos) {
     this(argumentInfos, new boolean[argumentInfos.length], new CallArgumentInfo[0]);
   }
 

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.runtime.scope;
 
 import org.enso.interpreter.runtime.Builtins;
+import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
 
@@ -13,11 +14,6 @@ public class ModuleScope {
   private final Map<AtomConstructor, Map<String, Function>> methods = new HashMap<>();
   private final Set<ModuleScope> imports = new HashSet<>();
   private final Set<ModuleScope> transitiveImports = new HashSet<>();
-
-  /** Creates a new scope. Every scope implicitly imports the builtin scope. */
-  public ModuleScope() {
-    imports.add(Builtins.BUILTIN_SCOPE);
-  }
 
   /**
    * Adds an Atom constructor definition to the module scope.
@@ -81,9 +77,13 @@ public class ModuleScope {
    */
   public Function lookupMethodDefinition(AtomConstructor atom, String name) {
     Function definedWithAtom = atom.getDefinitionScope().getMethodMapFor(atom).get(name);
-    if (definedWithAtom != null) { return definedWithAtom; }
+    if (definedWithAtom != null) {
+      return definedWithAtom;
+    }
     Function definedHere = getMethodMapFor(atom).get(name);
-    if (definedHere != null) { return definedHere; }
+    if (definedHere != null) {
+      return definedHere;
+    }
     return transitiveImports.stream()
         .map(scope -> scope.getMethodMapFor(atom).get(name))
         .filter(Objects::nonNull)

--- a/Interpreter/src/main/scala/org/enso/interpreter/Parser.scala
+++ b/Interpreter/src/main/scala/org/enso/interpreter/Parser.scala
@@ -41,8 +41,6 @@ trait AstExpressionVisitor[+T] {
 
   def visitAssignment(varName: String, expr: AstExpression): T
 
-  def visitPrint(body: AstExpression): T
-
   def visitMatch(
     target: AstExpression,
     branches: java.util.List[AstCase],
@@ -203,11 +201,6 @@ case class AstAssignment(name: String, body: AstExpression)
     visitor.visitAssignment(name, body)
 }
 
-case class AstPrint(body: AstExpression) extends AstExpression {
-  override def visit[T](visitor: AstExpressionVisitor[T]): T =
-    visitor.visitPrint(body)
-}
-
 case class AstIfZero(
   cond: AstExpression,
   ifTrue: AstExpression,
@@ -293,7 +286,7 @@ class EnsoParserInternal extends JavaTokenParsers {
     }
 
   def expression: Parser[AstExpression] =
-    desuspend | print | ifZero | matchClause | arith | function
+    desuspend | ifZero | matchClause | arith | function
 
   def functionCall: Parser[AstApply] =
     "@" ~> expression ~ (argList ?) ~ defaultSuspend ^^ {
@@ -312,8 +305,6 @@ class EnsoParserInternal extends JavaTokenParsers {
   def assignment: Parser[AstAssignment] = ident ~ ("=" ~> expression) ^^ {
     case v ~ exp => AstAssignment(v, exp)
   }
-
-  def print: Parser[AstPrint] = "print:" ~> expression ^^ AstPrint
 
   def ifZero: Parser[AstIfZero] =
     "ifZero:" ~> "[" ~> (expression ~ ("," ~> expression ~ ("," ~> expression))) <~ "]" ^^ {

--- a/Interpreter/src/test/scala/org/enso/interpreter/test/semantic/LazyArgumentsTest.scala
+++ b/Interpreter/src/test/scala/org/enso/interpreter/test/semantic/LazyArgumentsTest.scala
@@ -8,7 +8,7 @@ class LazyArgumentsTest extends LanguageTest {
       """
         |@{
         |  foo = { |i, $x, $y| ifZero: [i, $x, $y] };
-        |  @foo [1, @print [@Builtins, 1], @print [@Builtins, 2]]
+        |  @foo [1, @println [@IO, 1], @println [@IO, 2]]
         |}
         |""".stripMargin
     noException should be thrownBy parse(code)
@@ -53,9 +53,9 @@ class LazyArgumentsTest extends LanguageTest {
         |Bar.method = { |x| 10 }
         |
         |@{
-        |  @method [@Foo, @print [@Builtins, 1]];
-        |  @method [@Bar, @print [@Builtins, 2]];
-        |  @method [@Foo, @print [@Builtins, 3]]
+        |  @method [@Foo, @println [@IO, 1]];
+        |  @method [@Bar, @println [@IO, 2]];
+        |  @method [@Foo, @println [@IO, 3]]
         |}
         |""".stripMargin
     eval(code)
@@ -68,8 +68,8 @@ class LazyArgumentsTest extends LanguageTest {
         |@{
         |  if = { |c, $ifT, $ifF| ifZero: [c, $ifT, $ifF] };
         |  foo = { |c| @if [c] };
-        |  @foo [0, @print [@Builtins, 1], @print [@Builtins, 2]];
-        |  @foo [1, @print [@Builtins, 3], @print [@Builtins, 4]]
+        |  @foo [0, @println [@IO, 1], @println [@IO, 2]];
+        |  @foo [1, @println [@IO, 3], @println [@IO, 4]]
         |}
         |""".stripMargin
     eval(code)

--- a/Interpreter/src/test/scala/org/enso/interpreter/test/semantic/LazyArgumentsTest.scala
+++ b/Interpreter/src/test/scala/org/enso/interpreter/test/semantic/LazyArgumentsTest.scala
@@ -8,7 +8,7 @@ class LazyArgumentsTest extends LanguageTest {
       """
         |@{
         |  foo = { |i, $x, $y| ifZero: [i, $x, $y] };
-        |  @foo [1, (print: 1), (print: 2)]
+        |  @foo [1, @print [@Builtins, 1], @print [@Builtins, 2]]
         |}
         |""".stripMargin
     noException should be thrownBy parse(code)
@@ -53,9 +53,9 @@ class LazyArgumentsTest extends LanguageTest {
         |Bar.method = { |x| 10 }
         |
         |@{
-        |  @method [@Foo, (print: 1)];
-        |  @method [@Bar, (print: 2)];
-        |  @method [@Foo, (print: 3)]
+        |  @method [@Foo, @print [@Builtins, 1]];
+        |  @method [@Bar, @print [@Builtins, 2]];
+        |  @method [@Foo, @print [@Builtins, 3]]
         |}
         |""".stripMargin
     eval(code)
@@ -68,8 +68,8 @@ class LazyArgumentsTest extends LanguageTest {
         |@{
         |  if = { |c, $ifT, $ifF| ifZero: [c, $ifT, $ifF] };
         |  foo = { |c| @if [c] };
-        |  @foo [0, (print: 1), (print: 2)];
-        |  @foo [1, (print: 3), (print: 4)]
+        |  @foo [0, @print [@Builtins, 1], @print [@Builtins, 2]];
+        |  @foo [1, @print [@Builtins, 3], @print [@Builtins, 4]]
         |}
         |""".stripMargin
     eval(code)


### PR DESCRIPTION
### Pull Request Description
Given we wan't to introduce more and more builtin functions and operators, it was about time to start properly handling builtin methods.
This cleans up the way builtin atoms were defined so far and makes the primitive print operator into a builtin function.

### Important Notes
Not too many surprises here.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
