### PR TITLE
Methods on Any type and pattern matches on arbitrary values

### DIFF
--- a/Interpreter/src/main/java/org/enso/interpreter/Constants.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/Constants.java
@@ -11,6 +11,7 @@ public class Constants {
 
   public static final String THIS_ARGUMENT_NAME = "this";
   public static final String SCOPE_SEPARATOR = ".";
+  public static final String ANY_TYPE_NAME = "Any";
 
   /** Cache sizes for different AST nodes. */
   public static class CacheSizes {

--- a/Interpreter/src/main/java/org/enso/interpreter/builder/ExpressionFactory.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/builder/ExpressionFactory.java
@@ -26,12 +26,7 @@ import org.enso.interpreter.node.callable.ForceNodeGen;
 import org.enso.interpreter.node.callable.argument.ReadArgumentNode;
 import org.enso.interpreter.node.callable.function.CreateFunctionNode;
 import org.enso.interpreter.node.callable.function.FunctionBodyNode;
-import org.enso.interpreter.node.controlflow.CaseNode;
-import org.enso.interpreter.node.controlflow.ConstructorCaseNode;
-import org.enso.interpreter.node.controlflow.DefaultFallbackNode;
-import org.enso.interpreter.node.controlflow.FallbackNode;
-import org.enso.interpreter.node.controlflow.IfZeroNode;
-import org.enso.interpreter.node.controlflow.MatchNode;
+import org.enso.interpreter.node.controlflow.*;
 import org.enso.interpreter.node.expression.constant.ConstructorNode;
 import org.enso.interpreter.node.expression.constant.DynamicSymbolNode;
 import org.enso.interpreter.node.expression.literal.IntegerLiteralNode;
@@ -395,7 +390,7 @@ public class ExpressionFactory implements AstExpressionVisitor<ExpressionNode> {
             .map(fb -> (CaseNode) new FallbackNode(fb.visit(this)))
             .orElseGet(DefaultFallbackNode::new);
 
-    return new MatchNode(targetNode, cases, fallbackNode);
+    return MatchNodeGen.create(cases, fallbackNode, targetNode);
   }
 
   /* Note [Pattern Match Fallbacks]

--- a/Interpreter/src/main/java/org/enso/interpreter/builder/ModuleScopeExpressionFactory.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/builder/ModuleScopeExpressionFactory.java
@@ -90,10 +90,6 @@ public class ModuleScopeExpressionFactory implements AstGlobalScopeVisitor<Expre
             });
 
     for (AstMethodDef method : bindings) {
-      AtomConstructor constructor =
-          moduleScope
-              .getConstructor(method.typeName())
-              .orElseThrow(() -> new VariableDoesNotExistException(method.typeName()));
       ExpressionFactory expressionFactory =
           new ExpressionFactory(
               language,
@@ -105,7 +101,16 @@ public class ModuleScopeExpressionFactory implements AstGlobalScopeVisitor<Expre
       funNode.markTail();
       Function function =
           new Function(funNode.getCallTarget(), null, new ArgumentSchema(funNode.getArgs()));
-      moduleScope.registerMethod(constructor, method.methodName(), function);
+
+      if (method.typeName().equals(Constants.ANY_TYPE_NAME)) {
+        moduleScope.registerAnyMethod(method.methodName(), function);
+      } else {
+        AtomConstructor constructor =
+            moduleScope
+                .getConstructor(method.typeName())
+                .orElseThrow(() -> new VariableDoesNotExistException(method.typeName()));
+        moduleScope.registerMethod(constructor, method.methodName(), function);
+      }
     }
 
     ExpressionFactory factory = new ExpressionFactory(this.language, moduleScope);

--- a/Interpreter/src/main/java/org/enso/interpreter/builder/ModuleScopeExpressionFactory.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/builder/ModuleScopeExpressionFactory.java
@@ -103,7 +103,7 @@ public class ModuleScopeExpressionFactory implements AstGlobalScopeVisitor<Expre
           new Function(funNode.getCallTarget(), null, new ArgumentSchema(funNode.getArgs()));
 
       if (method.typeName().equals(Constants.ANY_TYPE_NAME)) {
-        moduleScope.registerAnyMethod(method.methodName(), function);
+        moduleScope.registerMethodForAny(method.methodName(), function);
       } else {
         AtomConstructor constructor =
             moduleScope

--- a/Interpreter/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
@@ -107,16 +107,9 @@ public abstract class InvokeCallableNode extends BaseNode {
         thisExecutor = ThunkExecutorNodeGen.create(false);
       }
 
-      Object selfArgument =
-          thisExecutor.executeThunk(((Thunk) arguments[thisArgumentPosition]));
-
-      if (methodCalledOnNonAtom.profile(TypesGen.isAtom(selfArgument))) {
-        Atom self = (Atom) selfArgument;
-        Function function = methodResolverNode.execute(symbol, self);
-        return this.argumentSorter.execute(function, arguments);
-      } else {
-        throw new MethodDoesNotExistException(selfArgument, symbol.getName(), this);
-      }
+      Object selfArgument = thisExecutor.executeThunk(((Thunk) arguments[thisArgumentPosition]));
+      Function function = methodResolverNode.execute(symbol, selfArgument);
+      return this.argumentSorter.execute(function, arguments);
     } else {
       throw new RuntimeException("Currying without `this` argument is not yet supported.");
     }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/callable/MethodResolverNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/callable/MethodResolverNode.java
@@ -14,41 +14,14 @@ import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.error.MethodDoesNotExistException;
 
 /**
- * A node performing lookups of method definitions. Uses a polymorphic inline cache to ensure the
- * best performance.
+ * A node performing lookups of method definitions.
+ *
+ * <p>Uses a polymorphic inline cache to ensure the best performance.
+ *
+ * <p>The dispatch algorithm works by matching the kind of value the method is requested for and
+ * delegating to the proper lookup method of {@link UnresolvedSymbol}.
  */
 public abstract class MethodResolverNode extends Node {
-
-  @Specialization(guards = "isValidAtomCache(symbol, cachedSymbol, atom, cachedConstructor)")
-  protected Function resolveAtomCached(
-      UnresolvedSymbol symbol,
-      Atom atom,
-      @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextRef,
-      @Cached("symbol") UnresolvedSymbol cachedSymbol,
-      @Cached("atom.getConstructor()") AtomConstructor cachedConstructor,
-      @Cached("resolveAtomMethod(cachedConstructor, cachedSymbol)") Function function) {
-    return function;
-  }
-
-  @Specialization(guards = "cachedSymbol == symbol")
-  protected Function resolveNumberCached(
-      UnresolvedSymbol symbol,
-      long self,
-      @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextReference,
-      @Cached("symbol") UnresolvedSymbol cachedSymbol,
-      @Cached("resolveNumberMethod(cachedSymbol)") Function function) {
-    return function;
-  }
-
-  @Specialization(guards = "cachedSymbol == symbol")
-  protected Function resolveFunctionCached(
-      UnresolvedSymbol symbol,
-      Function self,
-      @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextReference,
-      @Cached("symbol") UnresolvedSymbol cachedSymbol,
-      @Cached("resolveFunctionMethod(cachedSymbol)") Function function) {
-    return function;
-  }
 
   /**
    * Entry point for this node.
@@ -59,14 +32,38 @@ public abstract class MethodResolverNode extends Node {
    */
   public abstract Function execute(UnresolvedSymbol symbol, Object self);
 
-  /**
-   * Handles the actual method lookup. Not for manual use.
-   *
-   * @param cons Type for which to resolve the method.
-   * @param symbol symbol representing the method to resolve
-   * @return Resolved method definition.
-   */
-  public Function resolveAtomMethod(AtomConstructor cons, UnresolvedSymbol symbol) {
+  @Specialization(guards = "isValidAtomCache(symbol, cachedSymbol, atom, cachedConstructor)")
+  Function resolveAtomCached(
+      UnresolvedSymbol symbol,
+      Atom atom,
+      @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextRef,
+      @Cached("symbol") UnresolvedSymbol cachedSymbol,
+      @Cached("atom.getConstructor()") AtomConstructor cachedConstructor,
+      @Cached("resolveAtomMethod(cachedConstructor, cachedSymbol)") Function function) {
+    return function;
+  }
+
+  @Specialization(guards = "cachedSymbol == symbol")
+  Function resolveNumberCached(
+      UnresolvedSymbol symbol,
+      long self,
+      @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextReference,
+      @Cached("symbol") UnresolvedSymbol cachedSymbol,
+      @Cached("resolveNumberMethod(cachedSymbol)") Function function) {
+    return function;
+  }
+
+  @Specialization(guards = "cachedSymbol == symbol")
+  Function resolveFunctionCached(
+      UnresolvedSymbol symbol,
+      Function self,
+      @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextReference,
+      @Cached("symbol") UnresolvedSymbol cachedSymbol,
+      @Cached("resolveFunctionMethod(cachedSymbol)") Function function) {
+    return function;
+  }
+
+  Function resolveAtomMethod(AtomConstructor cons, UnresolvedSymbol symbol) {
     Function result = symbol.resolveFor(cons);
     if (result == null) {
       throw new MethodDoesNotExistException(cons, symbol.getName(), this);
@@ -74,7 +71,7 @@ public abstract class MethodResolverNode extends Node {
     return result;
   }
 
-  protected Function resolveNumberMethod(UnresolvedSymbol symbol) {
+  Function resolveNumberMethod(UnresolvedSymbol symbol) {
     Function result = symbol.resolveForNumber();
     if (result == null) {
       throw new MethodDoesNotExistException("Number", symbol.getName(), this);
@@ -82,7 +79,7 @@ public abstract class MethodResolverNode extends Node {
     return result;
   }
 
-  protected Function resolveFunctionMethod(UnresolvedSymbol symbol) {
+  Function resolveFunctionMethod(UnresolvedSymbol symbol) {
     Function result = symbol.resolveForFunction();
     if (result == null) {
       throw new MethodDoesNotExistException("Function", symbol.getName(), this);
@@ -90,11 +87,7 @@ public abstract class MethodResolverNode extends Node {
     return result;
   }
 
-  /**
-   * Checks the cache validity. For use by the DSL. The cache entry is valid if it's resolved for
-   * the same method name and this argument type. Not for manual use.
-   */
-  public boolean isValidAtomCache(
+  boolean isValidAtomCache(
       UnresolvedSymbol symbol,
       UnresolvedSymbol cachedSymbol,
       Atom atom,

--- a/Interpreter/src/main/java/org/enso/interpreter/node/callable/MethodResolverNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/callable/MethodResolverNode.java
@@ -19,18 +19,34 @@ import org.enso.interpreter.runtime.error.MethodDoesNotExistException;
  */
 public abstract class MethodResolverNode extends Node {
 
-  /**
-   * DSL method to generate the actual cached code. Uses Cached arguments and performs all the logic
-   * through the DSL. Not for manual use.
-   */
-  @Specialization(guards = "isValidCache(symbol, cachedSymbol, atom, cachedConstructor)")
-  public Function resolveCached(
+  @Specialization(guards = "isValidAtomCache(symbol, cachedSymbol, atom, cachedConstructor)")
+  protected Function resolveAtomCached(
       UnresolvedSymbol symbol,
       Atom atom,
       @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextRef,
       @Cached("symbol") UnresolvedSymbol cachedSymbol,
       @Cached("atom.getConstructor()") AtomConstructor cachedConstructor,
-      @Cached("resolveMethod(cachedConstructor, cachedSymbol)") Function function) {
+      @Cached("resolveAtomMethod(cachedConstructor, cachedSymbol)") Function function) {
+    return function;
+  }
+
+  @Specialization(guards = "cachedSymbol == symbol")
+  protected Function resolveNumberCached(
+      UnresolvedSymbol symbol,
+      long self,
+      @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextReference,
+      @Cached("symbol") UnresolvedSymbol cachedSymbol,
+      @Cached("resolveNumberMethod(cachedSymbol)") Function function) {
+    return function;
+  }
+
+  @Specialization(guards = "cachedSymbol == symbol")
+  protected Function resolveFunctionCached(
+      UnresolvedSymbol symbol,
+      Function self,
+      @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextReference,
+      @Cached("symbol") UnresolvedSymbol cachedSymbol,
+      @Cached("resolveFunctionMethod(cachedSymbol)") Function function) {
     return function;
   }
 
@@ -38,10 +54,10 @@ public abstract class MethodResolverNode extends Node {
    * Entry point for this node.
    *
    * @param symbol Method name to resolve.
-   * @param atom Object for which to resolve the method.
+   * @param self Object for which to resolve the method.
    * @return Resolved method.
    */
-  public abstract Function execute(UnresolvedSymbol symbol, Atom atom);
+  public abstract Function execute(UnresolvedSymbol symbol, Object self);
 
   /**
    * Handles the actual method lookup. Not for manual use.
@@ -50,12 +66,26 @@ public abstract class MethodResolverNode extends Node {
    * @param symbol symbol representing the method to resolve
    * @return Resolved method definition.
    */
-  public Function resolveMethod(
-      AtomConstructor cons,
-      UnresolvedSymbol symbol) {
+  public Function resolveAtomMethod(AtomConstructor cons, UnresolvedSymbol symbol) {
     Function result = symbol.resolveFor(cons);
     if (result == null) {
       throw new MethodDoesNotExistException(cons, symbol.getName(), this);
+    }
+    return result;
+  }
+
+  protected Function resolveNumberMethod(UnresolvedSymbol symbol) {
+    Function result = symbol.resolveForNumber();
+    if (result == null) {
+      throw new MethodDoesNotExistException("Number", symbol.getName(), this);
+    }
+    return result;
+  }
+
+  protected Function resolveFunctionMethod(UnresolvedSymbol symbol) {
+    Function result = symbol.resolveForFunction();
+    if (result == null) {
+      throw new MethodDoesNotExistException("Function", symbol.getName(), this);
     }
     return result;
   }
@@ -64,8 +94,11 @@ public abstract class MethodResolverNode extends Node {
    * Checks the cache validity. For use by the DSL. The cache entry is valid if it's resolved for
    * the same method name and this argument type. Not for manual use.
    */
-  public boolean isValidCache(
-      UnresolvedSymbol symbol, UnresolvedSymbol cachedSymbol, Atom atom, AtomConstructor cachedConstructor) {
+  public boolean isValidAtomCache(
+      UnresolvedSymbol symbol,
+      UnresolvedSymbol cachedSymbol,
+      Atom atom,
+      AtomConstructor cachedConstructor) {
     return (symbol == cachedSymbol) && (atom.getConstructor() == cachedConstructor);
   }
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/CaseNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/CaseNode.java
@@ -9,19 +9,35 @@ import org.enso.interpreter.runtime.callable.function.Function;
 /** An abstract representation of a case expression. */
 public abstract class CaseNode extends BaseNode {
   /**
-   * Executes the case expression.
+   * Executes the case expression with an atom scrutinee.
    *
    * @param frame the stack frame in which to execute
-   * @param target the constructor to destructure
+   * @param target the atom to match and destructure
    * @throws UnexpectedResultException when the result of desctructuring {@code target} can't be
    *     represented as a value of the expected return type
    */
   public abstract void executeAtom(VirtualFrame frame, Atom target)
       throws UnexpectedResultException;
 
+  /**
+   * Executes the case expression with a function scrutinee.
+   *
+   * @param frame the stack frame in which to execute
+   * @param target the function to match
+   * @throws UnexpectedResultException when the result of desctructuring {@code target} can't be
+   *     represented as a value of the expected return type
+   */
   public abstract void executeFunction(VirtualFrame frame, Function target)
       throws UnexpectedResultException;
 
+  /**
+   * * Executes the case expression with a number scrutinee.
+   *
+   * @param frame the stack frame in which to execute
+   * @param target the number to match
+   * @throws UnexpectedResultException when the result of desctructuring {@code target} can't be
+   *     represented as a value of the expected return type
+   */
   public abstract void executeNumber(VirtualFrame frame, long target)
       throws UnexpectedResultException;
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/CaseNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/CaseNode.java
@@ -4,6 +4,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.function.Function;
 
 /** An abstract representation of a case expression. */
 public abstract class CaseNode extends BaseNode {
@@ -15,5 +16,12 @@ public abstract class CaseNode extends BaseNode {
    * @throws UnexpectedResultException when the result of desctructuring {@code target} can't be
    *     represented as a value of the expected return type
    */
-  public abstract void execute(VirtualFrame frame, Atom target) throws UnexpectedResultException;
+  public abstract void executeAtom(VirtualFrame frame, Atom target)
+      throws UnexpectedResultException;
+
+  public abstract void executeFunction(VirtualFrame frame, Function target)
+      throws UnexpectedResultException;
+
+  public abstract void executeNumber(VirtualFrame frame, long target)
+      throws UnexpectedResultException;
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/ConstructorCaseNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/ConstructorCaseNode.java
@@ -11,7 +11,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-/** An implementation of the case expression specialised to working on explicit constructors. */
+/** An implementation of the case expression specialised to working on constructors. */
 public class ConstructorCaseNode extends CaseNode {
   @Child private ExpressionNode matcher;
   @Child private ExpressionNode branch;
@@ -40,15 +40,14 @@ public class ConstructorCaseNode extends CaseNode {
   }
 
   /**
-   * Executes the case expression.
+   * Handles the atom scrutinee case.
    *
-   * <p>It has no direct return value and instead uses a {@link BranchSelectedException} to signal
-   * the correct result back to the parent of the case expression.
+   * <p>The atoms constructor is checked and if it matches, the conditional branch is executed with
+   * all the atom's fields as arguments.
    *
    * @param frame the stack frame in which to execute
-   * @param target the constructor to destructure
-   * @throws UnexpectedResultException when the result of desctructuring {@code target} can't be
-   *     represented as a value of the expected return type
+   * @param target the atom to destructure
+   * @throws UnexpectedResultException
    */
   @Override
   public void executeAtom(VirtualFrame frame, Atom target) throws UnexpectedResultException {
@@ -59,9 +58,21 @@ public class ConstructorCaseNode extends CaseNode {
     }
   }
 
+  /**
+   * Handles the function scrutinee case, by not matching it at all.
+   *
+   * @param frame the stack frame in which to execute
+   * @param target the function to match
+   */
   @Override
   public void executeFunction(VirtualFrame frame, Function target) {}
 
+  /**
+   * Handles the number scrutinee case, by not matching it at all.
+   *
+   * @param frame the stack frame in which to execute
+   * @param target the function to match
+   */
   @Override
   public void executeNumber(VirtualFrame frame, long target) {}
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/ConstructorCaseNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/ConstructorCaseNode.java
@@ -9,6 +9,7 @@ import org.enso.interpreter.node.callable.ExecuteCallNodeGen;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.type.TypesGen;
 
 /** An implementation of the case expression specialised to working on explicit constructors. */
 public class ConstructorCaseNode extends CaseNode {
@@ -49,11 +50,18 @@ public class ConstructorCaseNode extends CaseNode {
    * @throws UnexpectedResultException when the result of desctructuring {@code target} can't be
    *     represented as a value of the expected return type
    */
-  public void execute(VirtualFrame frame, Atom target) throws UnexpectedResultException {
+  @Override
+  public void executeAtom(VirtualFrame frame, Atom target) throws UnexpectedResultException {
     AtomConstructor matcherVal = matcher.executeAtomConstructor(frame);
     if (profile.profile(matcherVal == target.getConstructor())) {
       Function function = branch.executeFunction(frame);
       throw new BranchSelectedException(executeCallNode.executeCall(function, target.getFields()));
     }
   }
+
+  @Override
+  public void executeFunction(VirtualFrame frame, Function target) {}
+
+  @Override
+  public void executeNumber(VirtualFrame frame, long target) {}
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/ConstructorCaseNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/ConstructorCaseNode.java
@@ -42,7 +42,7 @@ public class ConstructorCaseNode extends CaseNode {
   /**
    * Handles the atom scrutinee case.
    *
-   * <p>The atoms constructor is checked and if it matches, the conditional branch is executed with
+   * <p>The atom's constructor is checked and if it matches the conditional branch is executed with
    * all the atom's fields as arguments.
    *
    * @param frame the stack frame in which to execute

--- a/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/DefaultFallbackNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/DefaultFallbackNode.java
@@ -1,7 +1,9 @@
 package org.enso.interpreter.node.controlflow;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.error.InexhaustivePatternMatchException;
 
 /**
@@ -16,8 +18,22 @@ public class DefaultFallbackNode extends CaseNode {
    * @param frame the stack frame in which to execute
    * @param target the constructor to destructure
    */
-  @Override
-  public void execute(VirtualFrame frame, Atom target) {
+  private void execute(VirtualFrame frame, Object target) {
     throw new InexhaustivePatternMatchException(this.getParent());
+  }
+
+  @Override
+  public void executeAtom(VirtualFrame frame, Atom target) {
+    execute(frame, target);
+  }
+
+  @Override
+  public void executeFunction(VirtualFrame frame, Function target) {
+    execute(frame, target);
+  }
+
+  @Override
+  public void executeNumber(VirtualFrame frame, long target) {
+    execute(frame, target);
   }
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/DefaultFallbackNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/DefaultFallbackNode.java
@@ -13,7 +13,8 @@ import org.enso.interpreter.runtime.error.InexhaustivePatternMatchException;
 public class DefaultFallbackNode extends CaseNode {
 
   /**
-   * Executes the case expression's error case.
+   * Executes the case expression's error case, by throwing a {@link
+   * InexhaustivePatternMatchException}.
    *
    * @param frame the stack frame in which to execute
    * @param target the constructor to destructure
@@ -22,16 +23,37 @@ public class DefaultFallbackNode extends CaseNode {
     throw new InexhaustivePatternMatchException(this.getParent());
   }
 
+  /**
+   * Executes the case expression's error case, by throwing a {@link
+   * InexhaustivePatternMatchException}.
+   *
+   * @param frame the stack frame in which to execute
+   * @param target the atom to match and destructure
+   */
   @Override
   public void executeAtom(VirtualFrame frame, Atom target) {
     execute(frame, target);
   }
 
+  /**
+   * Executes the case expression's error case, by throwing a {@link
+   * InexhaustivePatternMatchException}.
+   *
+   * @param frame the stack frame in which to execute
+   * @param target the function to match
+   */
   @Override
   public void executeFunction(VirtualFrame frame, Function target) {
     execute(frame, target);
   }
 
+  /**
+   * Executes the case expression's error case, by throwing a {@link
+   * InexhaustivePatternMatchException}.
+   *
+   * @param frame the stack frame in which to execute
+   * @param target the number to match
+   */
   @Override
   public void executeNumber(VirtualFrame frame, long target) {
     execute(frame, target);

--- a/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/FallbackNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/FallbackNode.java
@@ -36,9 +36,24 @@ public class FallbackNode extends CaseNode {
    * @throws UnexpectedResultException when the result of desctructuring {@code target} can't be
    *     represented as a value of the expected return type
    */
-  @Override
-  public void execute(VirtualFrame frame, Atom target) throws UnexpectedResultException {
+  public void execute(VirtualFrame frame, Object target) throws UnexpectedResultException {
     Function function = functionNode.executeFunction(frame);
     throw new BranchSelectedException(executeCallNode.executeCall(function, new Object[0]));
+  }
+
+  @Override
+  public void executeAtom(VirtualFrame frame, Atom target) throws UnexpectedResultException {
+    execute(frame, target);
+  }
+
+  @Override
+  public void executeFunction(VirtualFrame frame, Function target)
+      throws UnexpectedResultException {
+    execute(frame, target);
+  }
+
+  @Override
+  public void executeNumber(VirtualFrame frame, long target) throws UnexpectedResultException {
+    execute(frame, target);
   }
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/FallbackNode.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/node/controlflow/FallbackNode.java
@@ -25,6 +25,11 @@ public class FallbackNode extends CaseNode {
     this.functionNode = functionNode;
   }
 
+  private void execute(VirtualFrame frame, Object target) throws UnexpectedResultException {
+    Function function = functionNode.executeFunction(frame);
+    throw new BranchSelectedException(executeCallNode.executeCall(function, new Object[0]));
+  }
+
   /**
    * Executes the case expression catch-all case.
    *
@@ -36,22 +41,39 @@ public class FallbackNode extends CaseNode {
    * @throws UnexpectedResultException when the result of desctructuring {@code target} can't be
    *     represented as a value of the expected return type
    */
-  public void execute(VirtualFrame frame, Object target) throws UnexpectedResultException {
-    Function function = functionNode.executeFunction(frame);
-    throw new BranchSelectedException(executeCallNode.executeCall(function, new Object[0]));
-  }
-
   @Override
   public void executeAtom(VirtualFrame frame, Atom target) throws UnexpectedResultException {
     execute(frame, target);
   }
 
+  /**
+   * Executes the case expression catch-all case.
+   *
+   * <p>It has no direct return value and instead uses a {@link BranchSelectedException} to signal
+   * the correct result back to the parent of the case expression.
+   *
+   * @param frame the stack frame in which to execute
+   * @param target the constructor to destructure
+   * @throws UnexpectedResultException when the result of desctructuring {@code target} can't be
+   *     represented as a value of the expected return type
+   */
   @Override
   public void executeFunction(VirtualFrame frame, Function target)
       throws UnexpectedResultException {
     execute(frame, target);
   }
 
+  /**
+   * Executes the case expression catch-all case.
+   *
+   * <p>It has no direct return value and instead uses a {@link BranchSelectedException} to signal
+   * the correct result back to the parent of the case expression.
+   *
+   * @param frame the stack frame in which to execute
+   * @param target the constructor to destructure
+   * @throws UnexpectedResultException when the result of desctructuring {@code target} can't be
+   *     represented as a value of the expected return type
+   */
   @Override
   public void executeNumber(VirtualFrame frame, long target) throws UnexpectedResultException {
     execute(frame, target);

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedSymbol.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedSymbol.java
@@ -28,7 +28,7 @@ public class UnresolvedSymbol implements TruffleObject {
    * <p>All names for dynamic symbols are interned, making it safe to compare symbol names using the
    * standard {@code ==} equality operator.
    *
-   * @return the name of this symbol.
+   * @return the name of this symbol
    */
   public String getName() {
     return name;
@@ -41,14 +41,24 @@ public class UnresolvedSymbol implements TruffleObject {
    * @return the resolved function definition, or null if not found
    */
   public Function resolveFor(AtomConstructor cons) {
-    return scope.lookupMethodDefinition(cons, name);
+    return scope.lookupMethodDefinitionForAtom(cons, name);
   }
 
+  /**
+   * Resolves the symbol for a number.
+   *
+   * @return the resolved function definition, or null if not found
+   */
   @CompilerDirectives.TruffleBoundary
   public Function resolveForNumber() {
     return scope.lookupMethodDefinitionForAny(name).orElse(null);
   }
 
+  /**
+   * Resolves the symbol for a function.
+   *
+   * @return the resolved function definition, or null if not found
+   */
   @CompilerDirectives.TruffleBoundary
   public Function resolveForFunction() {
     return scope.lookupMethodDefinitionForAny(name).orElse(null);

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedSymbol.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedSymbol.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.runtime.callable;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.interop.TruffleObject;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
@@ -41,5 +42,15 @@ public class UnresolvedSymbol implements TruffleObject {
    */
   public Function resolveFor(AtomConstructor cons) {
     return scope.lookupMethodDefinition(cons, name);
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  public Function resolveForNumber() {
+    return scope.lookupMethodDefinitionForAny(name).orElse(null);
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  public Function resolveForFunction() {
+    return scope.lookupMethodDefinitionForAny(name).orElse(null);
   }
 }

--- a/Interpreter/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/Interpreter/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -92,7 +92,7 @@ public class ModuleScope {
         .orElseGet(() -> lookupMethodDefinitionForAny(name).orElse(null));
   }
 
-  private Optional<Function> lookupMethodDefinitionForAny(String name) {
+  public Optional<Function> lookupMethodDefinitionForAny(String name) {
     Function definedHere = anyMethods.get(name);
     if (definedHere != null) {
       return Optional.of(definedHere);

--- a/Interpreter/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
+++ b/Interpreter/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
@@ -44,4 +44,31 @@ class MethodsTest extends LanguageTest {
         |""".stripMargin
     the[PolyglotException] thrownBy eval(code) should have message "Object 7 does not define method foo."
   }
+
+  "Methods defined on Any type" should "be callable for any atom" in {
+    val code =
+      """
+        |type Foo;
+        |type Bar;
+        |type Baz;
+        |
+        |Any.method = { match this <
+        |  Foo ~ { 1 };
+        |  Bar ~ { 2 };
+        |  Baz ~ { 3 };
+        |  { 0 };
+        |>}
+        |
+        |@{
+        |  @println [@IO, @method [@Foo]];
+        |  @println [@IO, @method [@Bar]];
+        |  @println [@IO, @method [@Baz]];
+        |  @println [@IO, @method [@Unit]];
+        |  @println [@IO, @method [@Nil]];
+        |  0
+        |}
+        |""".stripMargin
+    eval(code)
+    consumeOut shouldEqual List("1", "2", "3", "0", "0")
+  }
 }

--- a/Interpreter/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
+++ b/Interpreter/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
@@ -42,10 +42,10 @@ class MethodsTest extends LanguageTest {
       """
         |@foo [7]
         |""".stripMargin
-    the[PolyglotException] thrownBy eval(code) should have message "Object 7 does not define method foo."
+    the[PolyglotException] thrownBy eval(code) should have message "Object Number does not define method foo."
   }
 
-  "Methods defined on Any type" should "be callable for any atom" in {
+  "Methods defined on Any type" should "be callable for any type" in {
     val code =
       """
         |type Foo;
@@ -64,11 +64,12 @@ class MethodsTest extends LanguageTest {
         |  @println [@IO, @method [@Bar]];
         |  @println [@IO, @method [@Baz]];
         |  @println [@IO, @method [@Unit]];
-        |  @println [@IO, @method [@Nil]];
+        |  @println [@IO, @method [123]];
+        |  @println [@IO, @method [{|x| x }]];
         |  0
         |}
         |""".stripMargin
     eval(code)
-    consumeOut shouldEqual List("1", "2", "3", "0", "0")
+    consumeOut shouldEqual List("1", "2", "3", "0", "0", "0")
   }
 }


### PR DESCRIPTION
### Pull Request Description
This PR introduces three connected issues, previously omitted in the implementation:
1. There exists a (virtual & magical) type `Any` that is the top of the type hierarchy. Any methods defined for this type are visible as methods for any type.
2. Methods can now be called for `this` being a number or a function. While there isn't a way to define a method for those types yet, methods defined on `Any` are visible.
3. Pattern matches will now accept a scrutinee being a number or a function. While there isn't a way to match on the meaningfully yet, the previous implementation would just throw a TypeError. The new one will always result in calling the fallback case.

### Important Notes
There's massive code repetition going on in the `MatchNode` and as discussed with Ara, I see no way of getting rid of it for now. Probably deserves a second glance when we have a whole day to debug performance issues coming from a refactoring.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
