### PR TITLE
Include relevant resources for native-image generation

### DIFF
--- a/Pkg/src/main/resources/Main.enso
+++ b/Pkg/src/main/resources/Main.enso
@@ -1,4 +1,3 @@
 @{
-  print: 0;
-  0
+  @println [@IO,0]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -252,11 +252,12 @@ lazy val interpreter = (project in file("Interpreter"))
   .settings(
     buildNativeImage := Def
       .task {
-        val javaHome        = System.getProperty("java.home")
-        val nativeImagePath = s"$javaHome/bin/native-image"
-        val classPath       = (Runtime / fullClasspath).value.files.mkString(":")
+        val javaHome         = System.getProperty("java.home")
+        val nativeImagePath  = s"$javaHome/bin/native-image"
+        val classPath        = (Runtime / fullClasspath).value.files.mkString(":")
+        val resourcesGlobOpt = "-H:IncludeResources=.*Main.enso$"
         val cmd =
-          s"$nativeImagePath --macro:truffle --no-fallback --initialize-at-build-time -cp $classPath ${(Compile / mainClass).value.get} enso"
+          s"$nativeImagePath $resourcesGlobOpt --macro:truffle --no-fallback --initialize-at-build-time -cp $classPath ${(Compile / mainClass).value.get} enso"
         cmd !
       }
       .dependsOn(Compile / compile)


### PR DESCRIPTION
### Pull Request Description
Fixes https://github.com/luna/enso/issues/261 – the native image of the interpreter failed on creating new projects, due to not being able to locate resources. This PR adds the relevant resources explicitly to the native image generation command.

### Important Notes

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
