### PR TITLE
Set "-encoding UTF-8" for javac. 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,12 +18,15 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 //// Compiler Options ////
 //////////////////////////
 
-javacOptions in ThisBuild ++= Seq("-encoding", "UTF-8")
+javacOptions in ThisBuild ++= Seq(
+  "-encoding", // Provide explicit encoding (the next line)
+  "UTF-8"      // Specify character encoding used by Java source files.
+)
 
 scalacOptions in ThisBuild ++= Seq(
   "-deprecation",                       // Emit warning and location for usages of deprecated APIs.
   "-encoding",                          // Provide explicit encoding (the next line)
-  "utf-8",                              // Specify character encoding used by source files.
+  "utf-8",                              // Specify character encoding used by Scala source files.
   "-explaintypes",                      // Explain type errors in more detail.
   "-feature",                           // Emit warning and location for usages of features that should be imported explicitly.
   "-language:existentials",             // Existential types (besides wildcard types) can be written and inferred

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 //// Compiler Options ////
 //////////////////////////
 
+javacOptions in ThisBuild ++= Seq("-encoding", "UTF-8")
+
 scalacOptions in ThisBuild ++= Seq(
   "-deprecation",                       // Emit warning and location for usages of deprecated APIs.
   "-encoding",                          // Provide explicit encoding (the next line)


### PR DESCRIPTION
### Pull Request Description
Marks java sources as UTF-8 encoded. Without this compilation on Windows might fail, as javac defaults to default codepage, like:
```
sbt:enso> compile
[info] Compiling 1 Scala source and 83 Java sources to C:\dev\enso\Interpreter\target\scala-2.12\classes ...
[error] C:\dev\enso\Interpreter\src\main\java\org\enso\interpreter\node\callable\dispatch\LoopingCallOptimiserNode.java:14:1: unmappable character for encoding MS932
[error] C:\dev\enso\Interpreter\src\main\java\org\enso\interpreter\node\controlflow\MatchNode.java:54:1: unmappable character for encoding MS932
[error] (interpreter / Compile / compileIncremental) javac returned non-zero exit code
[error] Total time: 2 s, completed 2019-11-04 13:18:04
```



### Important Notes

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
