### PR TITLE
Rust prelude library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 
 members = [
-    "common/rust/parser"
+    "common/rust/parser",
+    "common/rust/prelude"
 ]

--- a/common/rust/parser/Cargo.toml
+++ b/common/rust/parser/Cargo.toml
@@ -10,7 +10,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 failure           = "0.1"
 matches           = "0.1"
-serde             = { version = "1.0", features = ["derive"] }
+prelude           = { version = "0.1.0", path = "../prelude"     }
+serde             = { version = "1.0"  , features = ["derive"]   }
 serde_json        = "1.0"
 shrinkwraprs      = "0.2.1"
 wasm-bindgen      = "0.2"

--- a/common/rust/parser/src/api.rs
+++ b/common/rust/parser/src/api.rs
@@ -1,4 +1,4 @@
-use failure::Fail;
+use prelude::*;
 
 // ============
 // == Parser ==

--- a/common/rust/parser/src/jsclient.rs
+++ b/common/rust/parser/src/jsclient.rs
@@ -1,5 +1,5 @@
 use crate::{api, api::IsParser};
-use failure::Fail;
+use prelude::*;
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/common/rust/parser/src/lib.rs
+++ b/common/rust/parser/src/lib.rs
@@ -1,16 +1,17 @@
 pub mod api;
 
+use prelude::*;
+
 mod jsclient;
 mod wsclient;
 
-use std::ops::DerefMut;
 
 /// Handle to a parser implementation.
 ///
 /// Currently this component is implemented as a wrapper over parser written
 /// in Scala. Depending on compilation target (native or wasm) it uses either
 /// implementation provided by `wsclient` or `jsclient`.
-#[derive(shrinkwraprs::Shrinkwrap)]
+#[derive(Shrinkwrap)]
 #[shrinkwrap(mutable)]
 pub struct Parser(pub Box<dyn api::IsParser>);
 

--- a/common/rust/parser/src/wsclient.rs
+++ b/common/rust/parser/src/wsclient.rs
@@ -1,7 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use failure::Fail;
-use std::default::Default;
+use prelude::*;
+
 use websocket::{
     stream::sync::TcpStream, ClientBuilder, Message, OwnedMessage,
 };

--- a/common/rust/prelude/Cargo.toml
+++ b/common/rust/prelude/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name    = "prelude"
+version = "0.1.0"
+authors = ["Wojciech Danilo <wojciech.danilo@luna-lang.org>"]
+edition = "2018"
+
+[lib]
+
+[dependencies]
+failure      = "0.1.5"
+derive_more  = "0.15.0"
+shrinkwraprs = "0.2.1"
+itertools    = "0.8"
+derivative   = "1.0.3"
+num          = "0.2.0"
+boolinator   = "2.4.0"

--- a/common/rust/prelude/src/lib.rs
+++ b/common/rust/prelude/src/lib.rs
@@ -1,0 +1,50 @@
+#![feature(trait_alias)]
+
+pub use boolinator::Boolinator;
+pub use core::{any::type_name, fmt::Debug};
+pub use derivative::Derivative;
+pub use derive_more::*;
+pub use failure::Fail;
+pub use itertools::Itertools;
+pub use num::Num;
+pub use shrinkwraprs::Shrinkwrap;
+pub use std::{
+    cell::{Ref, RefCell},
+    collections::{HashMap, HashSet},
+    convert::{identity, TryFrom, TryInto},
+    fmt::Display,
+    hash::Hash,
+    iter,
+    iter::FromIterator,
+    marker::PhantomData,
+    ops::{Deref, DerefMut, Index, IndexMut},
+    rc::{Rc, Weak},
+    slice,
+    slice::SliceIndex,
+};
+
+pub trait Str = AsRef<str>;
+
+pub fn default<T: Default>() -> T {
+    Default::default()
+}
+
+#[derive(Derivative, Shrinkwrap)]
+#[shrinkwrap(mutable)]
+#[derivative(Clone(bound = "T: Clone"))]
+pub struct WithPhantomType<T, P = ()> {
+    #[shrinkwrap(main_field)]
+    pub t: T,
+    phantom: PhantomData<P>,
+}
+
+impl<T, P> WithPhantomType<T, P> {
+    pub fn new(t: T) -> Self {
+        let phantom = PhantomData;
+        Self { t, phantom }
+    }
+}
+
+pub fn with<T, F: FnOnce(T) -> Out, Out>(t: T, f: F) -> Out {
+    f(t)
+}


### PR DESCRIPTION
### Pull Request Description
Indroduces `prelude` library, initially implemented in [basegl](https://github.com/luna/basegl) respository. @wdanilo says that this version is newer. 
Also, introduce `prelude` usage to `parser` library.

The library is expected to be used basically across our whole Rust codebase.

Part of work on #341.

### Important Notes
Library name was changed to `prelude` (from `basegl-prelude`) and company e-mail was used in the package description.

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [ ] All code has been tested where possible.
