### PR TITLE
Documentation Parser: Fix lists parsing, changes to HTML file rendering

### DIFF
--- a/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
+++ b/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
@@ -447,7 +447,7 @@ case class DocParserDef() extends Parser[Doc] {
     ): Unit = logger.trace {
       var wantToChangeIndent = true
       val diff               = indent - latest
-      if (diff == listIndent) {
+      if (diff >= listIndent) {
         /* NOTE
          * Used to push new line before pushing first list
          */
@@ -456,7 +456,7 @@ case class DocParserDef() extends Parser[Doc] {
         list.addNew(indent, typ, content)
       } else if (diff == 0 && list.inListFlag) {
         list.addContent(content)
-      } else if (diff == -listIndent && list.inListFlag) {
+      } else if (diff >= -listIndent && list.inListFlag) {
         list.appendInnerToOuter()
         list.addContent(content)
       } else {

--- a/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
+++ b/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
@@ -58,8 +58,8 @@ object DocParser {
   /**
     * Doc Parser running methods, as described above, in class [[DocParser]]
     */
-  def runMatched(input: String): Doc         = new DocParser().runMatched(input)
-  def run(input: String):        Result[Doc] = new DocParser().run(input)
+  def runMatched(input: String): Doc  = new DocParser().runMatched(input)
+  def run(input: String): Result[Doc] = new DocParser().run(input)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -383,7 +383,7 @@ object DocParserHTMLGenerator {
     val astCls   = HTML.`class` := "ASTData"
     val astHtml  = Seq(HTML.div(astCls)(createHTMLFromAST(ast)))
     val docClass = HTML.`class` := "Documentation"
-    HTML.div(docClass)(doc.html, astHtml)
+    HTML.div(docClass)(astHtml, doc.html)
   }
 
   /**

--- a/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
+++ b/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParser.scala
@@ -130,11 +130,11 @@ object DocParserRunner {
   ): AST.Def = {
     val firstLine        = Line(Option(b.firstLine.elem), b.firstLine.off)
     val linesToTransform = firstLine :: b.lines
-    val transforemdLines = attachDocToSubsequentAST(linesToTransform)
-    val TLHeadElem       = transforemdLines.head.elem.get
-    val TLHeadOff        = transforemdLines.head.off
+    val transformedLines = attachDocToSubsequentAST(linesToTransform)
+    val TLHeadElem       = transformedLines.head.elem.get
+    val TLHeadOff        = transformedLines.head.off
     val head             = AST.Block.Line(TLHeadElem, TLHeadOff)
-    val lines            = transforemdLines.tail
+    val lines            = transformedLines.tail
     val body             = AST.Block(b.typ, b.indent, b.emptyLines, head, lines)
     AST.Def(name, args, Some(body))
   }
@@ -382,32 +382,47 @@ object DocParserHTMLGenerator {
   ): TypedTag[String] = {
     val astCls   = HTML.`class` := "ASTData"
     val astHTML  = createHTMLFromAST(ast)
-    val astName  = Seq(HTML.div(astCls)(astHTML._1))
-    val astBody  = Seq(HTML.div(astCls)(astHTML._2))
+    val astName  = Seq(HTML.div(astCls)(astHTML.header))
+    val astBody  = Seq(HTML.div(astCls)(astHTML.body))
     val docClass = HTML.`class` := "Documentation"
     HTML.div(docClass)(astName, doc.html, astBody)
   }
 
   /**
+    * This case class is used to hold HTML-rendered AST
+    *
+    * @param header - header of AST - name of module/method with parameters
+    * @param body - body of AST - All of AST's documented submodules/methods
+    */
+  case class astHtmlRepr(header: TypedTag[String], body: TypedTag[String])
+  object astHtmlRepr {
+    def apply(header: TypedTag[String]): astHtmlRepr =
+      new astHtmlRepr(header, HTML.div())
+    def apply(): astHtmlRepr =
+      new astHtmlRepr(HTML.div(), HTML.div())
+  }
+
+  /**
     * Function invoked by [[DocumentedToHtml]] to create HTML from AST in
-    * [[AST.Documented]]
+    * [[AST.Documented]] on every matching element
     *
     * @param ast - AST
     * @return - HTML Code
     */
-  def createHTMLFromAST(ast: AST): (TypedTag[String], TypedTag[String]) = {
+  def createHTMLFromAST(ast: AST): astHtmlRepr = {
     ast match {
       case AST.Def.any(d) =>
         d.body match {
           case Some(body) =>
             body match {
               case AST.Block.any(b) => createDefWithBody(d.name, d.args, b)
-              case _                => (createDefWithoutBody(d.name, d.args), HTML.div())
+              case _ =>
+                astHtmlRepr(createDefWithoutBody(d.name, d.args))
             }
-          case None => (createDefWithoutBody(d.name, d.args), HTML.div())
+          case None => astHtmlRepr(createDefWithoutBody(d.name, d.args))
         }
-      case AST.App.Infix.any(i) => (createInfixHtmlRepr(i), HTML.div())
-      case _                    => (HTML.div(), HTML.div())
+      case AST.App.Infix.any(i) => astHtmlRepr(createInfixHtmlRepr(i))
+      case _                    => astHtmlRepr()
     }
   }
 
@@ -425,7 +440,7 @@ object DocParserHTMLGenerator {
     name: AST.Cons,
     args: List[AST],
     body: AST.Block
-  ): (TypedTag[String], TypedTag[String]) = {
+  ): astHtmlRepr = {
     val firstLine     = Line(Option(body.firstLine.elem), body.firstLine.off)
     val allLines      = firstLine :: body.lines
     val generatedCode = renderHTMLOnLine(allLines)
@@ -433,7 +448,7 @@ object DocParserHTMLGenerator {
     val clsBody       = HTML.`class` := "DefBody"
     val lines         = HTML.div(clsBody)(generatedCode)
     val cls           = HTML.`class` := "Def"
-    (HTML.div(cls)(head), HTML.div(cls)(lines))
+    astHtmlRepr(HTML.div(cls)(head), HTML.div(cls)(lines))
   }
 
   /**
@@ -497,7 +512,8 @@ object DocParserHTMLGenerator {
           case Line(Some(d), _) =>
             val cls     = HTML.`class` := "DefNoDoc"
             val astHtml = createHTMLFromAST(d)
-            HTML.div(cls)(astHtml._1, astHtml._2) :: renderHTMLOnLine(rest)
+            val div     = HTML.div(cls)(astHtml.header, astHtml.body)
+            div :: renderHTMLOnLine(rest)
           case _ => renderHTMLOnLine(rest)
         }
       case other =>

--- a/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParserStyle/style.sass
+++ b/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParserStyle/style.sass
@@ -199,7 +199,6 @@ h2
     font-weight: 400
     letter-spacing: -0.021em
     font-family: "SF Pro Text", "SF Pro Icons", "Helvetica Neue", "Helvetica","Arial", sans-serif
-    background-color: white
     color: #333333
     font-style: normal
 

--- a/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParserStyle/style.sass
+++ b/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/DocParserStyle/style.sass
@@ -40,7 +40,7 @@ code
     color: #0070c9
     background-color: transparent
     font-size: inherit
-    font-family: monospace
+    font-family: "SF Pro Text", "SF Pro Icons", "Helvetica Neue", "Helvetica", "Arial", sans-serif
     line-height: inherit
     display: inline-block
     white-space: pre-wrap
@@ -312,47 +312,57 @@ h2
         background-color: #ffffff
 
 
-@media (min-width: 300px) 
-    .Synopsis,
-    .Body,
-    .Tags,
-    .Documentation .ASTData
-        width: 380px
+@media (max-width: 500px)
+  .Synopsis,
+  .Body,
+  .Tags
+    width: 380px
+
+  .Documentation .ASTData
+    width: 400px
     
 
 
-@media (min-width: 500px) 
-    .Synopsis,
-    .Body,
-    .Tags,
-    .Documentation .ASTData 
-        width: 440px
+@media (min-width: 500px)
+  .Synopsis,
+  .Body,
+  .Tags
+    width: 440px
+
+  .Documentation .ASTData
+    width: 470px
     
 
 
-@media (min-width: 600px) 
-    .Synopsis,
-    .Body,
-    .Tags,
-    .Documentation .ASTData 
-        width: 490px
+@media (min-width: 600px)
+  .Synopsis,
+  .Body,
+  .Tags
+    width: 490px
+
+  .Documentation .ASTData
+    width: 520px
     
 
 
-@media (min-width: 900px) 
-    .Synopsis,
-    .Body,
-    .Tags,
-    .Documentation .ASTData 
-        width: 670px
+@media (min-width: 900px)
+  .Synopsis,
+  .Body,
+  .Tags
+    width: 670px
+
+  .Documentation .ASTData
+    width: 710px
     
 
 
 @media (min-width: 1300px) 
     .Synopsis,
     .Body,
-    .Tags,
-    .Documentation .ASTData  
+    .Tags
         width: 780px
+
+    .Documentation .ASTData
+        width: 820px
     
 

--- a/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -301,6 +301,7 @@ object Main extends App {
   val inC =
     """
       |## Optional values.
+      |
       |   Type `Option` represents an optional value: every `Option` is either `Some`
       |   and contains a value, or `None`, and does not. Option types are very common
       |   in Enso code, as they have a number of uses:
@@ -313,11 +314,11 @@ object Main extends App {
       |   a value and take action, always accounting for the None case.
       |
       |type Option a
-      |    ## The `None` type indicates a presence of a value.
+      |    ## The `Some` type indicates a presence of a value.
       |    type Some a
       |
-      |    ##
-      |     The `None` type indicates a lack of a value.
+      |    ## The `None` type indicates a lack of a value.
+      |     
       |     It is a very common type and is used by such types as `Maybe` or `List`.
       |     Also, `None` is the return value of functions which do not return an
       |     explicit value.

--- a/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -219,7 +219,7 @@ class Parser {
 
 object Parser {
   type IDMap = Seq[(Span, AST.ID)]
-  def apply(): Parser = new Parser()
+  def apply(): Parser   = new Parser()
   private val newEngine = flexer.Parser.compile(ParserDef())
 
   //// Exceptions ////
@@ -304,11 +304,11 @@ object Main extends App {
       |   Type `Option` represents an optional value: every `Option` is either `Some`
       |   and contains a value, or `None`, and does not. Option types are very common
       |   in Enso code, as they have a number of uses:
-      |     - Initial values.
-      |     - Return values for functions that are not defined over their entire input range (partial functions).
-      |     - Return value for otherwise reporting simple errors, where `None` is returned on error.
-      |     - Optional struct fields.
-      |     - Optional function arguments.
+      |      - Initial values.
+      |      - Return values for functions that are not defined over their entire input range (partial functions).
+      |      - Return value for otherwise reporting simple errors, where `None` is returned on error.
+      |      - Optional struct fields.
+      |      - Optional function arguments.
       |   `Option`s are commonly paired with pattern matching to query the presence of
       |   a value and take action, always accounting for the None case.
       |

--- a/common/scala/syntax/specialization/src/test/scala/org/enso/syntax/text/DocParserTests.scala
+++ b/common/scala/syntax/specialization/src/test/scala/org/enso/syntax/text/DocParserTests.scala
@@ -17,6 +17,7 @@ class DocParserTests extends FlatSpec with Matchers {
     val output = DocParser.run(input)
     output match {
       case Result(_, Result.Success(value)) =>
+        pprint.pprintln(value)
         assert(value == result)
         assert(value.show() == new Reader(input).toString())
       case _ =>
@@ -486,7 +487,7 @@ class DocParserTests extends FlatSpec with Matchers {
               " Second unordered sub item"
             ),
             " Third ordered sub item",
-            List.Indent.Invalid(3, List.Ordered, " Wrong Indent Item")
+            List.Indent.Invalid(3, List.Ordered, " Wrong Indent Item") //FIXME this doesnt work with indent >= 2
           ),
           " Fourth unordered item"
         )

--- a/common/scala/syntax/specialization/src/test/scala/org/enso/syntax/text/DocParserTests.scala
+++ b/common/scala/syntax/specialization/src/test/scala/org/enso/syntax/text/DocParserTests.scala
@@ -6,6 +6,7 @@ import org.enso.syntax.text.ast.Doc.Elem._
 import org.enso.Logger
 import org.enso.flexer.Parser.Result
 import org.enso.flexer.Reader
+import org.enso.syntax.text.ast.Doc.Tags.Tag
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import org.scalatest.Assertion
@@ -342,6 +343,46 @@ class DocParserTests extends FlatSpec with Matchers {
   """List
     |  - First unordered item
     |  - Second unordered item
+    |  - Third unordered item""".stripMargin
+    .replaceAll(System.lineSeparator(), "\n") ?= Doc(
+    Synopsis(
+      Section.Raw(
+        "List",
+        Newline,
+        List(
+          2,
+          List.Unordered,
+          " First unordered item",
+          " Second unordered item",
+          " Third unordered item"
+        )
+      )
+    )
+  )
+  """List
+    |  - First unordered item
+    |  - Second unordered item
+    |  - Third unordered item
+    |""".stripMargin
+    .replaceAll(System.lineSeparator(), "\n") ?= Doc(
+    Synopsis(
+      Section.Raw(
+        "List",
+        Newline,
+        List(
+          2,
+          List.Unordered,
+          " First unordered item",
+          " Second unordered item",
+          " Third unordered item"
+        ),
+        Newline
+      )
+    )
+  )
+  """List
+    |  - First unordered item
+    |  - Second unordered item
     |    * First ordered sub item
     |    * Second ordered sub item
     |  - Third unordered item""".stripMargin
@@ -487,7 +528,7 @@ class DocParserTests extends FlatSpec with Matchers {
               " Second unordered sub item"
             ),
             " Third ordered sub item",
-            List.Indent.Invalid(3, List.Ordered, " Wrong Indent Item") //FIXME this doesnt work with indent >= 2
+            List.Indent.Invalid(3, List.Ordered, " Wrong Indent Item")
           ),
           " Fourth unordered item"
         )
@@ -583,7 +624,8 @@ class DocParserTests extends FlatSpec with Matchers {
   //// Tags ////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  val allPossibleTags = Tags.Tag.Type.codes.-(Tags.Tag.Unrecognized)
+  val allPossibleTags: Set[Tag.Type] =
+    Tags.Tag.Type.codes.-(Tags.Tag.Unrecognized)
 
   allPossibleTags.foreach(
     t =>

--- a/common/scala/syntax/specialization/src/test/scala/org/enso/syntax/text/DocParserTests.scala
+++ b/common/scala/syntax/specialization/src/test/scala/org/enso/syntax/text/DocParserTests.scala
@@ -711,7 +711,7 @@ class DocParserTests extends FlatSpec with Matchers {
     Synopsis(
       Section.Raw(
         Newline,
-        " - bar",
+        List(1, List.Unordered, " bar"),
         Newline,
         CodeBlock(CodeBlock.Line(1, "baz")),
         Newline


### PR DESCRIPTION
### Pull Request Description
In this Pull Request i've fixed parsing of lists, an error i've noticed just a while ago.
Thanks to that i've also got rid of any hardcoded values in parser.
I've also applied a quick change to html rendering process, now the file displays properly what it should display - first module name, then module documentation, and lastly module functions with theirs documentations.

Here you can see how an example file is rendered, please note that style isn't ready, i'll continue working on it in the next PR, as we're trying to keep pushing many small pr's.

<img width="955" alt="Zrzut ekranu 2019-11-26 o 22 03 03" src="https://user-images.githubusercontent.com/26655166/69672991-98ee0d80-1099-11ea-9cc0-d7ccf1b0863d.png">

### Important Notes
Nothing important. quick fix.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
