### PR TITLE
Add source locations info to old parser

### DIFF
--- a/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -251,7 +251,9 @@ object AST {
     * @param end the exclusive, 0-indexed position of the end of
     *            the expression
     */
-  case class Location(start: Int, end: Int)
+  case class Location(start: Int, end: Int) {
+    def length: Int = end - start
+  }
 
   object Location {
     implicit val optionSpanMonoid: Monoid[Option[Location]] =


### PR DESCRIPTION
### Pull Request Description
Adds source location info to old parser structures, for incorporation into the new-to-old translation passes.

### Important Notes
### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
