### PR TITLE
Source location in Truffle nodes

### DIFF
--- a/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -1361,10 +1361,8 @@ object AST {
     implicit def span[T[_]]: HasSpan[ASTOf[T]] = t => t.span
     implicit def wrap[T[_]](
       t: T[AST]
-    )(implicit ev: HasSpan[T[AST]], foldEv: Foldable[T]): ASTOf[T] = {
-      val absSpan = foldEv.foldMap(t)(_.location)
-      ASTOf(t, ev.span(t), location = absSpan)
-    }
+    )(implicit ev: HasSpan[T[AST]]): ASTOf[T] = ASTOf(t, ev.span(t))
+
   }
 
   trait AstImplicits extends AstImplicits2 {

--- a/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -364,68 +364,68 @@ object Shape extends ShapeImplicit {
   }
 
   object Unrecognized {
-    implicit def ftor: Functor[Unrecognized]         = semi.functor
-    implicit def fold: Foldable[Unrecognized]        = semi.foldable
+    implicit def ftor:    Functor[Unrecognized]      = semi.functor
+    implicit def fold:    Foldable[Unrecognized]     = semi.foldable
     implicit def repr[T]: Repr[Unrecognized[T]]      = _.str
     implicit def ozip[T]: OffsetZip[Unrecognized, T] = t => t.coerce
     implicit def span[T]: HasSpan[Unrecognized[T]]   = _.str.length
   }
 
   object Unexpected {
-    implicit def ftor: Functor[Unexpected]          = semi.functor
-    implicit def fold: Foldable[Unexpected]         = semi.foldable
-    implicit def repr[T: Repr]: Repr[Unexpected[T]] = t => Repr(t.stream)
+    implicit def ftor:          Functor[Unexpected]  = semi.functor
+    implicit def fold:          Foldable[Unexpected] = semi.foldable
+    implicit def repr[T: Repr]: Repr[Unexpected[T]]  = t => Repr(t.stream)
     implicit def ozip[T: HasSpan]: OffsetZip[Unexpected, T] =
       t => t.copy(stream = OffsetZip(t.stream))
     implicit def span[T: HasSpan]: HasSpan[Unexpected[T]] =
       t => t.stream.span()
   }
   object Ident {
-    implicit def ftor: Functor[Ident]    = semi.functor
-    implicit def fold: Foldable[Ident]   = semi.foldable
-    implicit def repr[T]: Repr[Ident[T]] = _.name
+    implicit def ftor:    Functor[Ident]  = semi.functor
+    implicit def fold:    Foldable[Ident] = semi.foldable
+    implicit def repr[T]: Repr[Ident[T]]  = _.name
     implicit def ozip[T: HasSpan]: OffsetZip[Ident, T] = { ident =>
       OffsetZip[Shape, T](ident).asInstanceOf
     }
   }
   object Blank {
-    implicit def ftor: Functor[Blank]         = semi.functor
-    implicit def fold: Foldable[Blank]        = semi.foldable
+    implicit def ftor:    Functor[Blank]      = semi.functor
+    implicit def fold:    Foldable[Blank]     = semi.foldable
     implicit def repr[T]: Repr[Blank[T]]      = _.name
     implicit def ozip[T]: OffsetZip[Blank, T] = t => t.coerce
     implicit def span[T]: HasSpan[Blank[T]]   = _ => 1
   }
   object Var {
-    implicit def ftor: Functor[Var]         = semi.functor
-    implicit def fold: Foldable[Var]        = semi.foldable
+    implicit def ftor:    Functor[Var]      = semi.functor
+    implicit def fold:    Foldable[Var]     = semi.foldable
     implicit def repr[T]: Repr[Var[T]]      = _.name
     implicit def ozip[T]: OffsetZip[Var, T] = t => t.coerce
     implicit def span[T]: HasSpan[Var[T]]   = t => t.name.length
   }
   object Cons {
-    implicit def ftor: Functor[Cons]         = semi.functor
-    implicit def fold: Foldable[Cons]        = semi.foldable
+    implicit def ftor:    Functor[Cons]      = semi.functor
+    implicit def fold:    Foldable[Cons]     = semi.foldable
     implicit def repr[T]: Repr[Cons[T]]      = _.name
     implicit def ozip[T]: OffsetZip[Cons, T] = t => t.coerce
     implicit def span[T]: HasSpan[Cons[T]]   = t => t.name.length
   }
   object Mod {
-    implicit def ftor: Functor[Mod]         = semi.functor
-    implicit def fold: Foldable[Mod]        = semi.foldable
+    implicit def ftor:    Functor[Mod]      = semi.functor
+    implicit def fold:    Foldable[Mod]     = semi.foldable
     implicit def repr[T]: Repr[Mod[T]]      = R + _.name + "="
     implicit def ozip[T]: OffsetZip[Mod, T] = t => t.coerce
     implicit def span[T]: HasSpan[Mod[T]]   = t => t.name.length + 1
   }
   object Opr {
-    implicit def ftor: Functor[Opr]         = semi.functor
-    implicit def fold: Foldable[Opr]        = semi.foldable
+    implicit def ftor:    Functor[Opr]      = semi.functor
+    implicit def fold:    Foldable[Opr]     = semi.foldable
     implicit def repr[T]: Repr[Opr[T]]      = _.name
     implicit def ozip[T]: OffsetZip[Opr, T] = t => t.coerce
     implicit def span[T]: HasSpan[Opr[T]]   = t => t.name.length
   }
   object InvalidSuffix {
-    implicit def ftor: Functor[InvalidSuffix]         = semi.functor
-    implicit def fold: Foldable[InvalidSuffix]        = semi.foldable
+    implicit def ftor:    Functor[InvalidSuffix]      = semi.functor
+    implicit def fold:    Foldable[InvalidSuffix]     = semi.foldable
     implicit def ozip[T]: OffsetZip[InvalidSuffix, T] = t => t.coerce
     implicit def repr[T]: Repr[InvalidSuffix[T]] =
       t => R + t.elem.repr + t.suffix
@@ -440,18 +440,18 @@ object Shape extends ShapeImplicit {
     }
   }
   object Number {
-    implicit def fromInt[T](int: Int): AST.Number = AST.Number(int)
-    implicit def ftor: Functor[Number]            = semi.functor
-    implicit def fold: Foldable[Number]           = semi.foldable
-    implicit def ozip[T]: OffsetZip[Number, T]    = t => t.coerce
+    implicit def fromInt[T](int: Int): AST.Number           = AST.Number(int)
+    implicit def ftor:                 Functor[Number]      = semi.functor
+    implicit def fold:                 Foldable[Number]     = semi.foldable
+    implicit def ozip[T]:              OffsetZip[Number, T] = t => t.coerce
     implicit def repr[T]: Repr[Number[T]] =
       t => t.base.map(_ + "_").getOrElse("") + t.int
     implicit def span[T]: HasSpan[Number[T]] =
       t => t.base.map(_.length + 1).getOrElse(0) + t.int.length
   }
   object DanglingBase {
-    implicit def ftor: Functor[DanglingBase]         = semi.functor
-    implicit def fold: Foldable[DanglingBase]        = semi.foldable
+    implicit def ftor:    Functor[DanglingBase]      = semi.functor
+    implicit def fold:    Foldable[DanglingBase]     = semi.foldable
     implicit def repr[T]: Repr[DanglingBase[T]]      = R + _.base + '_'
     implicit def ozip[T]: OffsetZip[DanglingBase, T] = t => t.coerce
     implicit def span[T]: HasSpan[DanglingBase[T]] =
@@ -479,15 +479,15 @@ object Shape extends ShapeImplicit {
     }
   }
   object InvalidQuote {
-    implicit def ftor: Functor[InvalidQuote]          = semi.functor
-    implicit def fold: Foldable[InvalidQuote]         = semi.foldable
-    implicit def repr[T: Repr]: Repr[InvalidQuote[T]] = _.quote
-    implicit def ozip[T]: OffsetZip[InvalidQuote, T]  = t => t.coerce
-    implicit def span[T]: HasSpan[InvalidQuote[T]]    = _.quote.span
+    implicit def ftor:          Functor[InvalidQuote]      = semi.functor
+    implicit def fold:          Foldable[InvalidQuote]     = semi.foldable
+    implicit def repr[T: Repr]: Repr[InvalidQuote[T]]      = _.quote
+    implicit def ozip[T]:       OffsetZip[InvalidQuote, T] = t => t.coerce
+    implicit def span[T]:       HasSpan[InvalidQuote[T]]   = _.quote.span
   }
   object InlineBlock {
-    implicit def ftor: Functor[InlineBlock]         = semi.functor
-    implicit def fold: Foldable[InlineBlock]        = semi.foldable
+    implicit def ftor:    Functor[InlineBlock]      = semi.functor
+    implicit def fold:    Foldable[InlineBlock]     = semi.foldable
     implicit def repr[T]: Repr[InlineBlock[T]]      = _.quote
     implicit def ozip[T]: OffsetZip[InlineBlock, T] = t => t.coerce
     implicit def span[T]: HasSpan[InlineBlock[T]]   = _.quote.span
@@ -598,8 +598,8 @@ object Shape extends ShapeImplicit {
     }
   }
   object SegmentFmt {
-    implicit def ftor[T]: Functor[SegmentFmt] = semi.functor
-    implicit def fold: Foldable[SegmentFmt]   = semi.foldable
+    implicit def ftor[T]: Functor[SegmentFmt]  = semi.functor
+    implicit def fold:    Foldable[SegmentFmt] = semi.foldable
     implicit def repr[T: Repr]: Repr[SegmentFmt[T]] = {
       case t: SegmentPlain[T]  => Repr(t)
       case t: SegmentExpr[T]   => Repr(t)
@@ -617,8 +617,8 @@ object Shape extends ShapeImplicit {
     }
   }
   object SegmentRaw {
-    implicit def ftor[T]: Functor[SegmentRaw] = semi.functor
-    implicit def fold: Foldable[SegmentRaw]   = semi.foldable
+    implicit def ftor[T]: Functor[SegmentRaw]  = semi.functor
+    implicit def fold:    Foldable[SegmentRaw] = semi.foldable
     implicit def repr[T]: Repr[SegmentRaw[T]] = {
       case t: SegmentPlain[T] => Repr(t)
     }
@@ -633,9 +633,9 @@ object Shape extends ShapeImplicit {
     implicit def txtFromString[T](str: String): SegmentPlain[T] =
       SegmentPlain(str)
 
-    implicit def fold: Foldable[SegmentPlain]   = semi.foldable
-    implicit def ftor[T]: Functor[SegmentPlain] = semi.functor
-    implicit def repr[T]: Repr[SegmentPlain[T]] = _.value
+    implicit def fold:    Foldable[SegmentPlain] = semi.foldable
+    implicit def ftor[T]: Functor[SegmentPlain]  = semi.functor
+    implicit def repr[T]: Repr[SegmentPlain[T]]  = _.value
     implicit def ozip[T]: OffsetZip[SegmentPlain, T] =
       t => t.coerce
     implicit def span[T]: HasSpan[SegmentPlain[T]] = _.value.length
@@ -643,8 +643,8 @@ object Shape extends ShapeImplicit {
   object SegmentExpr {
     val quote: Repr.Builder = "`"
 
-    implicit def ftor[T]: Functor[SegmentExpr] = semi.functor
-    implicit def fold: Foldable[SegmentExpr]   = semi.foldable
+    implicit def ftor[T]: Functor[SegmentExpr]  = semi.functor
+    implicit def fold:    Foldable[SegmentExpr] = semi.foldable
     implicit def repr[T: Repr]: Repr[SegmentExpr[T]] =
       R + quote + _.value + quote
     implicit def ozip[T]: OffsetZip[SegmentExpr, T] =
@@ -665,8 +665,8 @@ object Shape extends ShapeImplicit {
       introducer.span + _.code.repr.length
   }
   object App extends IntermediateTrait[App] {
-    implicit def ftor[T]: Functor[App] = semi.functor
-    implicit def fold: Foldable[App]   = semi.foldable
+    implicit def ftor[T]: Functor[App]  = semi.functor
+    implicit def fold:    Foldable[App] = semi.foldable
     implicit def ozip[T: HasSpan]: OffsetZip[App, T] =
       t => OffsetZip[Shape, T](t).asInstanceOf
   }
@@ -699,8 +699,8 @@ object Shape extends ShapeImplicit {
   }
 
   object Section extends IntermediateTrait[Section] {
-    implicit def ftor[T]: Functor[Section] = semi.functor
-    implicit def fold: Foldable[Section]   = semi.foldable
+    implicit def ftor[T]: Functor[Section]  = semi.functor
+    implicit def fold:    Foldable[Section] = semi.foldable
     implicit def ozip[T: HasSpan]: OffsetZip[Section, T] =
       t => OffsetZip[Shape, T](t).asInstanceOf
   }
@@ -725,17 +725,17 @@ object Shape extends ShapeImplicit {
       t => t.opr.span + t.off + t.arg.span
   }
   object SectionSides {
-    implicit def ftor: Functor[SectionSides]          = semi.functor
-    implicit def fold: Foldable[SectionSides]         = semi.foldable
-    implicit def repr[T: Repr]: Repr[SectionSides[T]] = t => R + t.opr
-    implicit def ozip[T]: OffsetZip[SectionSides, T]  = t => t.coerce
+    implicit def ftor:          Functor[SectionSides]      = semi.functor
+    implicit def fold:          Foldable[SectionSides]     = semi.foldable
+    implicit def repr[T: Repr]: Repr[SectionSides[T]]      = t => R + t.opr
+    implicit def ozip[T]:       OffsetZip[SectionSides, T] = t => t.coerce
     implicit def span[T: HasSpan]: HasSpan[SectionSides[T]] =
       t => t.opr.span
   }
 
   object Block {
-    implicit def ftorBlock: Functor[Block] = semi.functor
-    implicit def fold: Foldable[Block]     = semi.foldable
+    implicit def ftorBlock: Functor[Block]  = semi.functor
+    implicit def fold:      Foldable[Block] = semi.foldable
     implicit def reprBlock[T: Repr]: Repr[Block[T]] = t => {
       val headRepr       = if (t.isOrphan) R else newline
       val emptyLinesRepr = t.emptyLines.map(R + _ + newline)
@@ -782,9 +782,9 @@ object Shape extends ShapeImplicit {
       def toOptional: Line[Option[T]] = copy(elem = Some(elem))
     }
     object Line {
-      implicit def ftor: Functor[Line]          = semi.functor
-      implicit def fold: Foldable[Line]         = semi.foldable
-      implicit def repr[T: Repr]: Repr[Line[T]] = t => R + t.elem + t.off
+      implicit def ftor:          Functor[Line]  = semi.functor
+      implicit def fold:          Foldable[Line] = semi.foldable
+      implicit def repr[T: Repr]: Repr[Line[T]]  = t => R + t.elem + t.off
       implicit def span[T: HasSpan]: HasSpan[Line[T]] =
         t => t.elem.span + t.off
       implicit def spanOpt[T: HasSpan]: HasSpan[OptLine[T]] =
@@ -793,8 +793,8 @@ object Shape extends ShapeImplicit {
   }
 
   object Module {
-    implicit def ftor: Functor[Module]         = semi.functor
-    implicit def fold: Foldable[Module]        = semi.foldable
+    implicit def ftor:    Functor[Module]      = semi.functor
+    implicit def fold:    Foldable[Module]     = semi.foldable
     implicit def ozip[T]: OffsetZip[Module, T] = _.map(Index.Start -> _)
     implicit def repr[T: Repr]: Repr[Module[T]] =
       t => R + t.lines.head + t.lines.tail.map(Block.newline + _)
@@ -803,8 +803,8 @@ object Shape extends ShapeImplicit {
   }
 
   object Macro extends IntermediateTrait[Macro] {
-    implicit def ftor[T]: Functor[Macro] = semi.functor
-    implicit def fold: Foldable[Macro]   = semi.foldable
+    implicit def ftor[T]: Functor[Macro]  = semi.functor
+    implicit def fold:    Foldable[Macro] = semi.foldable
     implicit def ozip[T: HasSpan]: OffsetZip[Macro, T] =
       t => OffsetZip[Shape, T](t).asInstanceOf
   }
@@ -874,14 +874,14 @@ object Shape extends ShapeImplicit {
 
     final case class Segment(head: AST, body: Option[AST.SAST])
     object Segment {
-      def apply(head: AST): Segment       = Segment(head, None)
-      implicit def repr: Repr[Segment]    = t => R + t.head + t.body
-      implicit def span: HasSpan[Segment] = t => t.head.span() + t.body.span()
+      def apply(head: AST): Segment          = Segment(head, None)
+      implicit def repr:    Repr[Segment]    = t => R + t.head + t.body
+      implicit def span:    HasSpan[Segment] = t => t.head.span() + t.body.span()
     }
   }
 
   object Comment {
-    val symbol                           = "#"
+    val symbol = "#"
     implicit def ftor: Functor[Comment]  = semi.functor
     implicit def fold: Foldable[Comment] = semi.foldable
     implicit def repr[T]: Repr[Comment[T]] =
@@ -1328,11 +1328,11 @@ object AST {
     id: Option[ID]             = None,
     location: Option[Location] = None
   ) {
-    override def toString        = s"Node($id,$location,$shape)"
+    override def toString = s"Node($id,$location,$shape)"
     override def hashCode(): Int = shape.hashCode()
 
     def setID(newID: ID): ASTOf[T] = copy(id = Some(newID))
-    def withNewID(): ASTOf[T]      = copy(id = Some(UUID.randomUUID()))
+    def withNewID():      ASTOf[T] = copy(id = Some(UUID.randomUUID()))
     def setLocation(newLocation: Option[Location]): ASTOf[T] =
       copy(location = newLocation)
     def setLocation(newLocation: Location): ASTOf[T] =
@@ -1361,8 +1361,10 @@ object AST {
     implicit def span[T[_]]: HasSpan[ASTOf[T]] = t => t.span
     implicit def wrap[T[_]](
       t: T[AST]
-    )(implicit ev: HasSpan[T[AST]]): ASTOf[T] =
-      ASTOf(t, ev.span(t))
+    )(implicit ev: HasSpan[T[AST]], foldEv: Foldable[T]): ASTOf[T] = {
+      val absSpan = foldEv.foldMap(t)(_.location)
+      ASTOf(t, ev.span(t), location = absSpan)
+    }
   }
 
   trait AstImplicits extends AstImplicits2 {
@@ -1524,10 +1526,10 @@ object AST {
     //// Conversions ////
 
     trait Conversions1 {
-      implicit def strToVar(str: String): Var   = Var(str)
+      implicit def strToVar(str: String):  Var  = Var(str)
       implicit def strToCons(str: String): Cons = Cons(str)
-      implicit def strToOpr(str: String): Opr   = Opr(str)
-      implicit def strToMod(str: String): Mod   = Mod(str)
+      implicit def strToOpr(str: String):  Opr  = Opr(str)
+      implicit def strToMod(str: String):  Mod  = Mod(str)
     }
 
     trait conversions extends Conversions1 {
@@ -1548,27 +1550,27 @@ object AST {
       private val cachedBlank = Shape.Blank[AST]()
       val any                 = UnapplyByType[Blank]
       def unapply(t: AST)     = Unapply[Blank].run(_ => true)(t)
-      def apply(): Blank      = cachedBlank
+      def apply(): Blank = cachedBlank
     }
     object Var {
-      val any                      = UnapplyByType[Var]
-      def unapply(t: AST)          = Unapply[Var].run(_.name)(t)
+      val any             = UnapplyByType[Var]
+      def unapply(t: AST) = Unapply[Var].run(_.name)(t)
       def apply(name: String): Var = Shape.Var[AST](name)
     }
     object Cons {
-      val any                       = UnapplyByType[Cons]
-      def unapply(t: AST)           = Unapply[Cons].run(_.name)(t)
+      val any             = UnapplyByType[Cons]
+      def unapply(t: AST) = Unapply[Cons].run(_.name)(t)
       def apply(name: String): Cons = Shape.Cons[AST](name)
     }
     object Mod {
-      val any                      = UnapplyByType[Mod]
-      def unapply(t: AST)          = Unapply[Mod].run(_.name)(t)
+      val any             = UnapplyByType[Mod]
+      def unapply(t: AST) = Unapply[Mod].run(_.name)(t)
       def apply(name: String): Mod = Shape.Mod[AST](name)
     }
     object Opr {
-      val app                      = Opr(" ")
-      val any                      = UnapplyByType[Opr]
-      def unapply(t: AST)          = Unapply[Opr].run(_.name)(t)
+      val app             = Opr(" ")
+      val any             = UnapplyByType[Opr]
+      def unapply(t: AST) = Unapply[Opr].run(_.name)(t)
       def apply(name: String): Opr = Shape.Opr[AST](name)
     }
   }
@@ -1600,12 +1602,12 @@ object AST {
       type DanglingBase = ASTOf[Shape.DanglingBase]
 
       //// Smart Constructors ////
-      def apply(i: String): Number            = Number(None, i)
+      def apply(i: String):            Number = Number(None, i)
       def apply(b: String, i: String): Number = Number(Some(b), i)
-      def apply(i: Int): Number               = Number(i.toString)
-      def apply(b: Int, i: String): Number    = Number(b.toString, i)
-      def apply(b: String, i: Int): Number    = Number(b, i.toString)
-      def apply(b: Int, i: Int): Number       = Number(b.toString, i.toString)
+      def apply(i: Int):               Number = Number(i.toString)
+      def apply(b: Int, i: String):    Number = Number(b.toString, i)
+      def apply(b: String, i: Int):    Number = Number(b, i.toString)
+      def apply(b: Int, i: Int):       Number = Number(b.toString, i.toString)
       def apply(b: Option[String], i: String): Number =
         Shape.Number[AST](b, i)
       def unapply(t: AST) = Unapply[Number].run(t => (t.base, t.int))(t)
@@ -1613,7 +1615,7 @@ object AST {
 
       //// DanglingBase ////
       object DanglingBase {
-        val any                               = UnapplyByType[DanglingBase]
+        val any = UnapplyByType[DanglingBase]
         def apply(base: String): DanglingBase = Shape.DanglingBase[AST](base)
         def unapply(t: AST) =
           Unapply[DanglingBase].run(_.base)(t)
@@ -1706,7 +1708,7 @@ object AST {
         type Raw = Shape.SegmentRaw[AST]
 
         object Expr  { def apply(t: Option[AST]): Fmt = Shape.SegmentExpr(t)  }
-        object Plain { def apply(s: String): Raw      = Shape.SegmentPlain(s) }
+        object Plain { def apply(s: String):      Raw = Shape.SegmentPlain(s) }
       }
     }
   }
@@ -1795,8 +1797,8 @@ object AST {
         def apply(opr: Opr, arg: AST): Right = Right(opr, 1, arg)
       }
       object Sides {
-        val any                    = UnapplyByType[Sides]
-        def unapply(t: AST)        = Unapply[Sides].run(_.opr)(t)
+        val any             = UnapplyByType[Sides]
+        def unapply(t: AST) = Unapply[Sides].run(_.opr)(t)
         def apply(opr: Opr): Sides = Shape.SectionSides[AST](opr)
       }
     }
@@ -1864,9 +1866,9 @@ object AST {
       def apply[T](elem: T)           = Shape.Block.Line(elem, 0)
     }
     object OptLine {
-      def apply(): OptLine          = Line(None, 0)
+      def apply():          OptLine = Line(None, 0)
       def apply(elem: AST): OptLine = Line(Some(elem))
-      def apply(off: Int): OptLine  = Line(None, off)
+      def apply(off: Int):  OptLine = Line(None, off)
     }
   }
 
@@ -1879,11 +1881,11 @@ object AST {
   object Module {
     import Block._
     type M = Module
-    val any                                     = UnapplyByType[M]
-    def unapply(t: AST)                         = Unapply[M].run(_.lines)(t)
-    def apply(ls: List1[OptLine]): M            = Shape.Module(ls)
-    def apply(l: OptLine): M                    = Module(List1(l))
-    def apply(l: OptLine, ls: OptLine*): M      = Module(List1(l, ls.to[List]))
+    val any             = UnapplyByType[M]
+    def unapply(t: AST) = Unapply[M].run(_.lines)(t)
+    def apply(ls: List1[OptLine]):            M = Shape.Module(ls)
+    def apply(l: OptLine):                    M = Module(List1(l))
+    def apply(l: OptLine, ls: OptLine*):      M = Module(List1(l, ls.to[List]))
     def apply(l: OptLine, ls: List[OptLine]): M = Module(List1(l, ls))
     def traverseWithOff(m: M)(f: (Index, AST) => AST): M = {
       val lines2 = m.lines.map { line: OptLine =>
@@ -2137,10 +2139,10 @@ object AST {
   type Import = ASTOf[Shape.Import]
 
   object Import {
-    def apply(path: List1[Cons]): Import            = Shape.Import[AST](path)
-    def apply(head: Cons): Import                   = Import(head, List())
+    def apply(path: List1[Cons]):            Import = Shape.Import[AST](path)
+    def apply(head: Cons):                   Import = Import(head, List())
     def apply(head: Cons, tail: List[Cons]): Import = Import(List1(head, tail))
-    def apply(head: Cons, tail: Cons*): Import      = Import(head, tail.toList)
+    def apply(head: Cons, tail: Cons*):      Import = Import(head, tail.toList)
     def unapply(t: AST): Option[List1[Cons]] =
       Unapply[Import].run(t => t.path)(t)
     val any = UnapplyByType[Import]
@@ -2165,12 +2167,12 @@ object AST {
 
   type Group = ASTOf[Shape.Group]
   object Group {
-    val any                                  = UnapplyByType[Group]
-    def unapply(t: AST): Option[Option[AST]] = Unapply[Group].run(_.body)(t)
-    def apply(body: Option[AST]): Group      = Shape.Group(body)
-    def apply(body: AST): Group              = Group(Some(body))
-    def apply(body: SAST): Group             = Group(body.el)
-    def apply(): Group                       = Group(None)
+    val any = UnapplyByType[Group]
+    def unapply(t: AST):          Option[Option[AST]] = Unapply[Group].run(_.body)(t)
+    def apply(body: Option[AST]): Group               = Shape.Group(body)
+    def apply(body: AST):         Group               = Group(Some(body))
+    def apply(body: SAST):        Group               = Group(body.el)
+    def apply():                  Group               = Group(None)
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -2179,8 +2181,8 @@ object AST {
 
   type Def = ASTOf[Shape.Def]
   object Def {
-    val any                                     = UnapplyByType[Def]
-    def apply(name: Cons): Def                  = Def(name, List())
+    val any = UnapplyByType[Def]
+    def apply(name: Cons):                  Def = Def(name, List())
     def apply(name: Cons, args: List[AST]): Def = Def(name, args, None)
     def apply(name: Cons, args: List[AST], body: Option[AST]): Def =
       Shape.Def(name, args, body)

--- a/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -122,7 +122,9 @@ object OffsetZip {
   * @param end the exclusive, 0-indexed position of the end of
   *            the expression
   */
-case class Location(start: Int, end: Int)
+case class Location(start: Int, end: Int) {
+  def length: Int = end - start
+}
 
 object Location {
   implicit val optionSpanMonoid: Monoid[Option[Location]] =
@@ -362,68 +364,68 @@ object Shape extends ShapeImplicit {
   }
 
   object Unrecognized {
-    implicit def ftor:    Functor[Unrecognized]      = semi.functor
-    implicit def fold:    Foldable[Unrecognized]     = semi.foldable
+    implicit def ftor: Functor[Unrecognized]         = semi.functor
+    implicit def fold: Foldable[Unrecognized]        = semi.foldable
     implicit def repr[T]: Repr[Unrecognized[T]]      = _.str
     implicit def ozip[T]: OffsetZip[Unrecognized, T] = t => t.coerce
     implicit def span[T]: HasSpan[Unrecognized[T]]   = _.str.length
   }
 
   object Unexpected {
-    implicit def ftor:          Functor[Unexpected]  = semi.functor
-    implicit def fold:          Foldable[Unexpected] = semi.foldable
-    implicit def repr[T: Repr]: Repr[Unexpected[T]]  = t => Repr(t.stream)
+    implicit def ftor: Functor[Unexpected]          = semi.functor
+    implicit def fold: Foldable[Unexpected]         = semi.foldable
+    implicit def repr[T: Repr]: Repr[Unexpected[T]] = t => Repr(t.stream)
     implicit def ozip[T: HasSpan]: OffsetZip[Unexpected, T] =
       t => t.copy(stream = OffsetZip(t.stream))
     implicit def span[T: HasSpan]: HasSpan[Unexpected[T]] =
       t => t.stream.span()
   }
   object Ident {
-    implicit def ftor:    Functor[Ident]  = semi.functor
-    implicit def fold:    Foldable[Ident] = semi.foldable
-    implicit def repr[T]: Repr[Ident[T]]  = _.name
+    implicit def ftor: Functor[Ident]    = semi.functor
+    implicit def fold: Foldable[Ident]   = semi.foldable
+    implicit def repr[T]: Repr[Ident[T]] = _.name
     implicit def ozip[T: HasSpan]: OffsetZip[Ident, T] = { ident =>
       OffsetZip[Shape, T](ident).asInstanceOf
     }
   }
   object Blank {
-    implicit def ftor:    Functor[Blank]      = semi.functor
-    implicit def fold:    Foldable[Blank]     = semi.foldable
+    implicit def ftor: Functor[Blank]         = semi.functor
+    implicit def fold: Foldable[Blank]        = semi.foldable
     implicit def repr[T]: Repr[Blank[T]]      = _.name
     implicit def ozip[T]: OffsetZip[Blank, T] = t => t.coerce
     implicit def span[T]: HasSpan[Blank[T]]   = _ => 1
   }
   object Var {
-    implicit def ftor:    Functor[Var]      = semi.functor
-    implicit def fold:    Foldable[Var]     = semi.foldable
+    implicit def ftor: Functor[Var]         = semi.functor
+    implicit def fold: Foldable[Var]        = semi.foldable
     implicit def repr[T]: Repr[Var[T]]      = _.name
     implicit def ozip[T]: OffsetZip[Var, T] = t => t.coerce
     implicit def span[T]: HasSpan[Var[T]]   = t => t.name.length
   }
   object Cons {
-    implicit def ftor:    Functor[Cons]      = semi.functor
-    implicit def fold:    Foldable[Cons]     = semi.foldable
+    implicit def ftor: Functor[Cons]         = semi.functor
+    implicit def fold: Foldable[Cons]        = semi.foldable
     implicit def repr[T]: Repr[Cons[T]]      = _.name
     implicit def ozip[T]: OffsetZip[Cons, T] = t => t.coerce
     implicit def span[T]: HasSpan[Cons[T]]   = t => t.name.length
   }
   object Mod {
-    implicit def ftor:    Functor[Mod]      = semi.functor
-    implicit def fold:    Foldable[Mod]     = semi.foldable
+    implicit def ftor: Functor[Mod]         = semi.functor
+    implicit def fold: Foldable[Mod]        = semi.foldable
     implicit def repr[T]: Repr[Mod[T]]      = R + _.name + "="
     implicit def ozip[T]: OffsetZip[Mod, T] = t => t.coerce
     implicit def span[T]: HasSpan[Mod[T]]   = t => t.name.length + 1
   }
   object Opr {
-    implicit def ftor:    Functor[Opr]      = semi.functor
-    implicit def fold:    Foldable[Opr]     = semi.foldable
+    implicit def ftor: Functor[Opr]         = semi.functor
+    implicit def fold: Foldable[Opr]        = semi.foldable
     implicit def repr[T]: Repr[Opr[T]]      = _.name
     implicit def ozip[T]: OffsetZip[Opr, T] = t => t.coerce
     implicit def span[T]: HasSpan[Opr[T]]   = t => t.name.length
   }
   object InvalidSuffix {
-    implicit def ftor:    Functor[InvalidSuffix]      = semi.functor
-    implicit def fold:    Foldable[InvalidSuffix]     = semi.foldable
+    implicit def ftor: Functor[InvalidSuffix]         = semi.functor
+    implicit def fold: Foldable[InvalidSuffix]        = semi.foldable
     implicit def ozip[T]: OffsetZip[InvalidSuffix, T] = t => t.coerce
     implicit def repr[T]: Repr[InvalidSuffix[T]] =
       t => R + t.elem.repr + t.suffix
@@ -438,18 +440,18 @@ object Shape extends ShapeImplicit {
     }
   }
   object Number {
-    implicit def fromInt[T](int: Int): AST.Number           = AST.Number(int)
-    implicit def ftor:                 Functor[Number]      = semi.functor
-    implicit def fold:                 Foldable[Number]     = semi.foldable
-    implicit def ozip[T]:              OffsetZip[Number, T] = t => t.coerce
+    implicit def fromInt[T](int: Int): AST.Number = AST.Number(int)
+    implicit def ftor: Functor[Number]            = semi.functor
+    implicit def fold: Foldable[Number]           = semi.foldable
+    implicit def ozip[T]: OffsetZip[Number, T]    = t => t.coerce
     implicit def repr[T]: Repr[Number[T]] =
       t => t.base.map(_ + "_").getOrElse("") + t.int
     implicit def span[T]: HasSpan[Number[T]] =
       t => t.base.map(_.length + 1).getOrElse(0) + t.int.length
   }
   object DanglingBase {
-    implicit def ftor:    Functor[DanglingBase]      = semi.functor
-    implicit def fold:    Foldable[DanglingBase]     = semi.foldable
+    implicit def ftor: Functor[DanglingBase]         = semi.functor
+    implicit def fold: Foldable[DanglingBase]        = semi.foldable
     implicit def repr[T]: Repr[DanglingBase[T]]      = R + _.base + '_'
     implicit def ozip[T]: OffsetZip[DanglingBase, T] = t => t.coerce
     implicit def span[T]: HasSpan[DanglingBase[T]] =
@@ -477,15 +479,15 @@ object Shape extends ShapeImplicit {
     }
   }
   object InvalidQuote {
-    implicit def ftor:          Functor[InvalidQuote]      = semi.functor
-    implicit def fold:          Foldable[InvalidQuote]     = semi.foldable
-    implicit def repr[T: Repr]: Repr[InvalidQuote[T]]      = _.quote
-    implicit def ozip[T]:       OffsetZip[InvalidQuote, T] = t => t.coerce
-    implicit def span[T]:       HasSpan[InvalidQuote[T]]   = _.quote.span
+    implicit def ftor: Functor[InvalidQuote]          = semi.functor
+    implicit def fold: Foldable[InvalidQuote]         = semi.foldable
+    implicit def repr[T: Repr]: Repr[InvalidQuote[T]] = _.quote
+    implicit def ozip[T]: OffsetZip[InvalidQuote, T]  = t => t.coerce
+    implicit def span[T]: HasSpan[InvalidQuote[T]]    = _.quote.span
   }
   object InlineBlock {
-    implicit def ftor:    Functor[InlineBlock]      = semi.functor
-    implicit def fold:    Foldable[InlineBlock]     = semi.foldable
+    implicit def ftor: Functor[InlineBlock]         = semi.functor
+    implicit def fold: Foldable[InlineBlock]        = semi.foldable
     implicit def repr[T]: Repr[InlineBlock[T]]      = _.quote
     implicit def ozip[T]: OffsetZip[InlineBlock, T] = t => t.coerce
     implicit def span[T]: HasSpan[InlineBlock[T]]   = _.quote.span
@@ -596,8 +598,8 @@ object Shape extends ShapeImplicit {
     }
   }
   object SegmentFmt {
-    implicit def ftor[T]: Functor[SegmentFmt]  = semi.functor
-    implicit def fold:    Foldable[SegmentFmt] = semi.foldable
+    implicit def ftor[T]: Functor[SegmentFmt] = semi.functor
+    implicit def fold: Foldable[SegmentFmt]   = semi.foldable
     implicit def repr[T: Repr]: Repr[SegmentFmt[T]] = {
       case t: SegmentPlain[T]  => Repr(t)
       case t: SegmentExpr[T]   => Repr(t)
@@ -615,8 +617,8 @@ object Shape extends ShapeImplicit {
     }
   }
   object SegmentRaw {
-    implicit def ftor[T]: Functor[SegmentRaw]  = semi.functor
-    implicit def fold:    Foldable[SegmentRaw] = semi.foldable
+    implicit def ftor[T]: Functor[SegmentRaw] = semi.functor
+    implicit def fold: Foldable[SegmentRaw]   = semi.foldable
     implicit def repr[T]: Repr[SegmentRaw[T]] = {
       case t: SegmentPlain[T] => Repr(t)
     }
@@ -631,9 +633,9 @@ object Shape extends ShapeImplicit {
     implicit def txtFromString[T](str: String): SegmentPlain[T] =
       SegmentPlain(str)
 
-    implicit def fold:    Foldable[SegmentPlain] = semi.foldable
-    implicit def ftor[T]: Functor[SegmentPlain]  = semi.functor
-    implicit def repr[T]: Repr[SegmentPlain[T]]  = _.value
+    implicit def fold: Foldable[SegmentPlain]   = semi.foldable
+    implicit def ftor[T]: Functor[SegmentPlain] = semi.functor
+    implicit def repr[T]: Repr[SegmentPlain[T]] = _.value
     implicit def ozip[T]: OffsetZip[SegmentPlain, T] =
       t => t.coerce
     implicit def span[T]: HasSpan[SegmentPlain[T]] = _.value.length
@@ -641,8 +643,8 @@ object Shape extends ShapeImplicit {
   object SegmentExpr {
     val quote: Repr.Builder = "`"
 
-    implicit def ftor[T]: Functor[SegmentExpr]  = semi.functor
-    implicit def fold:    Foldable[SegmentExpr] = semi.foldable
+    implicit def ftor[T]: Functor[SegmentExpr] = semi.functor
+    implicit def fold: Foldable[SegmentExpr]   = semi.foldable
     implicit def repr[T: Repr]: Repr[SegmentExpr[T]] =
       R + quote + _.value + quote
     implicit def ozip[T]: OffsetZip[SegmentExpr, T] =
@@ -663,8 +665,8 @@ object Shape extends ShapeImplicit {
       introducer.span + _.code.repr.length
   }
   object App extends IntermediateTrait[App] {
-    implicit def ftor[T]: Functor[App]  = semi.functor
-    implicit def fold:    Foldable[App] = semi.foldable
+    implicit def ftor[T]: Functor[App] = semi.functor
+    implicit def fold: Foldable[App]   = semi.foldable
     implicit def ozip[T: HasSpan]: OffsetZip[App, T] =
       t => OffsetZip[Shape, T](t).asInstanceOf
   }
@@ -697,8 +699,8 @@ object Shape extends ShapeImplicit {
   }
 
   object Section extends IntermediateTrait[Section] {
-    implicit def ftor[T]: Functor[Section]  = semi.functor
-    implicit def fold:    Foldable[Section] = semi.foldable
+    implicit def ftor[T]: Functor[Section] = semi.functor
+    implicit def fold: Foldable[Section]   = semi.foldable
     implicit def ozip[T: HasSpan]: OffsetZip[Section, T] =
       t => OffsetZip[Shape, T](t).asInstanceOf
   }
@@ -723,17 +725,17 @@ object Shape extends ShapeImplicit {
       t => t.opr.span + t.off + t.arg.span
   }
   object SectionSides {
-    implicit def ftor:          Functor[SectionSides]      = semi.functor
-    implicit def fold:          Foldable[SectionSides]     = semi.foldable
-    implicit def repr[T: Repr]: Repr[SectionSides[T]]      = t => R + t.opr
-    implicit def ozip[T]:       OffsetZip[SectionSides, T] = t => t.coerce
+    implicit def ftor: Functor[SectionSides]          = semi.functor
+    implicit def fold: Foldable[SectionSides]         = semi.foldable
+    implicit def repr[T: Repr]: Repr[SectionSides[T]] = t => R + t.opr
+    implicit def ozip[T]: OffsetZip[SectionSides, T]  = t => t.coerce
     implicit def span[T: HasSpan]: HasSpan[SectionSides[T]] =
       t => t.opr.span
   }
 
   object Block {
-    implicit def ftorBlock: Functor[Block]  = semi.functor
-    implicit def fold:      Foldable[Block] = semi.foldable
+    implicit def ftorBlock: Functor[Block] = semi.functor
+    implicit def fold: Foldable[Block]     = semi.foldable
     implicit def reprBlock[T: Repr]: Repr[Block[T]] = t => {
       val headRepr       = if (t.isOrphan) R else newline
       val emptyLinesRepr = t.emptyLines.map(R + _ + newline)
@@ -780,9 +782,9 @@ object Shape extends ShapeImplicit {
       def toOptional: Line[Option[T]] = copy(elem = Some(elem))
     }
     object Line {
-      implicit def ftor:          Functor[Line]  = semi.functor
-      implicit def fold:          Foldable[Line] = semi.foldable
-      implicit def repr[T: Repr]: Repr[Line[T]]  = t => R + t.elem + t.off
+      implicit def ftor: Functor[Line]          = semi.functor
+      implicit def fold: Foldable[Line]         = semi.foldable
+      implicit def repr[T: Repr]: Repr[Line[T]] = t => R + t.elem + t.off
       implicit def span[T: HasSpan]: HasSpan[Line[T]] =
         t => t.elem.span + t.off
       implicit def spanOpt[T: HasSpan]: HasSpan[OptLine[T]] =
@@ -791,8 +793,8 @@ object Shape extends ShapeImplicit {
   }
 
   object Module {
-    implicit def ftor:    Functor[Module]      = semi.functor
-    implicit def fold:    Foldable[Module]     = semi.foldable
+    implicit def ftor: Functor[Module]         = semi.functor
+    implicit def fold: Foldable[Module]        = semi.foldable
     implicit def ozip[T]: OffsetZip[Module, T] = _.map(Index.Start -> _)
     implicit def repr[T: Repr]: Repr[Module[T]] =
       t => R + t.lines.head + t.lines.tail.map(Block.newline + _)
@@ -801,8 +803,8 @@ object Shape extends ShapeImplicit {
   }
 
   object Macro extends IntermediateTrait[Macro] {
-    implicit def ftor[T]: Functor[Macro]  = semi.functor
-    implicit def fold:    Foldable[Macro] = semi.foldable
+    implicit def ftor[T]: Functor[Macro] = semi.functor
+    implicit def fold: Foldable[Macro]   = semi.foldable
     implicit def ozip[T: HasSpan]: OffsetZip[Macro, T] =
       t => OffsetZip[Shape, T](t).asInstanceOf
   }
@@ -872,14 +874,14 @@ object Shape extends ShapeImplicit {
 
     final case class Segment(head: AST, body: Option[AST.SAST])
     object Segment {
-      def apply(head: AST): Segment          = Segment(head, None)
-      implicit def repr:    Repr[Segment]    = t => R + t.head + t.body
-      implicit def span:    HasSpan[Segment] = t => t.head.span() + t.body.span()
+      def apply(head: AST): Segment       = Segment(head, None)
+      implicit def repr: Repr[Segment]    = t => R + t.head + t.body
+      implicit def span: HasSpan[Segment] = t => t.head.span() + t.body.span()
     }
   }
 
   object Comment {
-    val symbol = "#"
+    val symbol                           = "#"
     implicit def ftor: Functor[Comment]  = semi.functor
     implicit def fold: Foldable[Comment] = semi.foldable
     implicit def repr[T]: Repr[Comment[T]] =
@@ -1326,11 +1328,11 @@ object AST {
     id: Option[ID]             = None,
     location: Option[Location] = None
   ) {
-    override def toString = s"Node($id,$location,$shape)"
+    override def toString        = s"Node($id,$location,$shape)"
     override def hashCode(): Int = shape.hashCode()
 
     def setID(newID: ID): ASTOf[T] = copy(id = Some(newID))
-    def withNewID():      ASTOf[T] = copy(id = Some(UUID.randomUUID()))
+    def withNewID(): ASTOf[T]      = copy(id = Some(UUID.randomUUID()))
     def setLocation(newLocation: Option[Location]): ASTOf[T] =
       copy(location = newLocation)
     def setLocation(newLocation: Location): ASTOf[T] =
@@ -1359,10 +1361,8 @@ object AST {
     implicit def span[T[_]]: HasSpan[ASTOf[T]] = t => t.span
     implicit def wrap[T[_]](
       t: T[AST]
-    )(implicit ev: HasSpan[T[AST]], foldEv: Foldable[T]): ASTOf[T] = {
-      val absSpan = foldEv.foldMap(t)(_.location)
-      ASTOf(t, ev.span(t), location = absSpan)
-    }
+    )(implicit ev: HasSpan[T[AST]]): ASTOf[T] =
+      ASTOf(t, ev.span(t))
   }
 
   trait AstImplicits extends AstImplicits2 {
@@ -1524,10 +1524,10 @@ object AST {
     //// Conversions ////
 
     trait Conversions1 {
-      implicit def strToVar(str: String):  Var  = Var(str)
+      implicit def strToVar(str: String): Var   = Var(str)
       implicit def strToCons(str: String): Cons = Cons(str)
-      implicit def strToOpr(str: String):  Opr  = Opr(str)
-      implicit def strToMod(str: String):  Mod  = Mod(str)
+      implicit def strToOpr(str: String): Opr   = Opr(str)
+      implicit def strToMod(str: String): Mod   = Mod(str)
     }
 
     trait conversions extends Conversions1 {
@@ -1548,27 +1548,27 @@ object AST {
       private val cachedBlank = Shape.Blank[AST]()
       val any                 = UnapplyByType[Blank]
       def unapply(t: AST)     = Unapply[Blank].run(_ => true)(t)
-      def apply(): Blank = cachedBlank
+      def apply(): Blank      = cachedBlank
     }
     object Var {
-      val any             = UnapplyByType[Var]
-      def unapply(t: AST) = Unapply[Var].run(_.name)(t)
+      val any                      = UnapplyByType[Var]
+      def unapply(t: AST)          = Unapply[Var].run(_.name)(t)
       def apply(name: String): Var = Shape.Var[AST](name)
     }
     object Cons {
-      val any             = UnapplyByType[Cons]
-      def unapply(t: AST) = Unapply[Cons].run(_.name)(t)
+      val any                       = UnapplyByType[Cons]
+      def unapply(t: AST)           = Unapply[Cons].run(_.name)(t)
       def apply(name: String): Cons = Shape.Cons[AST](name)
     }
     object Mod {
-      val any             = UnapplyByType[Mod]
-      def unapply(t: AST) = Unapply[Mod].run(_.name)(t)
+      val any                      = UnapplyByType[Mod]
+      def unapply(t: AST)          = Unapply[Mod].run(_.name)(t)
       def apply(name: String): Mod = Shape.Mod[AST](name)
     }
     object Opr {
-      val app             = Opr(" ")
-      val any             = UnapplyByType[Opr]
-      def unapply(t: AST) = Unapply[Opr].run(_.name)(t)
+      val app                      = Opr(" ")
+      val any                      = UnapplyByType[Opr]
+      def unapply(t: AST)          = Unapply[Opr].run(_.name)(t)
       def apply(name: String): Opr = Shape.Opr[AST](name)
     }
   }
@@ -1600,12 +1600,12 @@ object AST {
       type DanglingBase = ASTOf[Shape.DanglingBase]
 
       //// Smart Constructors ////
-      def apply(i: String):            Number = Number(None, i)
+      def apply(i: String): Number            = Number(None, i)
       def apply(b: String, i: String): Number = Number(Some(b), i)
-      def apply(i: Int):               Number = Number(i.toString)
-      def apply(b: Int, i: String):    Number = Number(b.toString, i)
-      def apply(b: String, i: Int):    Number = Number(b, i.toString)
-      def apply(b: Int, i: Int):       Number = Number(b.toString, i.toString)
+      def apply(i: Int): Number               = Number(i.toString)
+      def apply(b: Int, i: String): Number    = Number(b.toString, i)
+      def apply(b: String, i: Int): Number    = Number(b, i.toString)
+      def apply(b: Int, i: Int): Number       = Number(b.toString, i.toString)
       def apply(b: Option[String], i: String): Number =
         Shape.Number[AST](b, i)
       def unapply(t: AST) = Unapply[Number].run(t => (t.base, t.int))(t)
@@ -1613,7 +1613,7 @@ object AST {
 
       //// DanglingBase ////
       object DanglingBase {
-        val any = UnapplyByType[DanglingBase]
+        val any                               = UnapplyByType[DanglingBase]
         def apply(base: String): DanglingBase = Shape.DanglingBase[AST](base)
         def unapply(t: AST) =
           Unapply[DanglingBase].run(_.base)(t)
@@ -1706,7 +1706,7 @@ object AST {
         type Raw = Shape.SegmentRaw[AST]
 
         object Expr  { def apply(t: Option[AST]): Fmt = Shape.SegmentExpr(t)  }
-        object Plain { def apply(s: String):      Raw = Shape.SegmentPlain(s) }
+        object Plain { def apply(s: String): Raw      = Shape.SegmentPlain(s) }
       }
     }
   }
@@ -1795,8 +1795,8 @@ object AST {
         def apply(opr: Opr, arg: AST): Right = Right(opr, 1, arg)
       }
       object Sides {
-        val any             = UnapplyByType[Sides]
-        def unapply(t: AST) = Unapply[Sides].run(_.opr)(t)
+        val any                    = UnapplyByType[Sides]
+        def unapply(t: AST)        = Unapply[Sides].run(_.opr)(t)
         def apply(opr: Opr): Sides = Shape.SectionSides[AST](opr)
       }
     }
@@ -1864,9 +1864,9 @@ object AST {
       def apply[T](elem: T)           = Shape.Block.Line(elem, 0)
     }
     object OptLine {
-      def apply():          OptLine = Line(None, 0)
+      def apply(): OptLine          = Line(None, 0)
       def apply(elem: AST): OptLine = Line(Some(elem))
-      def apply(off: Int):  OptLine = Line(None, off)
+      def apply(off: Int): OptLine  = Line(None, off)
     }
   }
 
@@ -1879,11 +1879,11 @@ object AST {
   object Module {
     import Block._
     type M = Module
-    val any             = UnapplyByType[M]
-    def unapply(t: AST) = Unapply[M].run(_.lines)(t)
-    def apply(ls: List1[OptLine]):            M = Shape.Module(ls)
-    def apply(l: OptLine):                    M = Module(List1(l))
-    def apply(l: OptLine, ls: OptLine*):      M = Module(List1(l, ls.to[List]))
+    val any                                     = UnapplyByType[M]
+    def unapply(t: AST)                         = Unapply[M].run(_.lines)(t)
+    def apply(ls: List1[OptLine]): M            = Shape.Module(ls)
+    def apply(l: OptLine): M                    = Module(List1(l))
+    def apply(l: OptLine, ls: OptLine*): M      = Module(List1(l, ls.to[List]))
     def apply(l: OptLine, ls: List[OptLine]): M = Module(List1(l, ls))
     def traverseWithOff(m: M)(f: (Index, AST) => AST): M = {
       val lines2 = m.lines.map { line: OptLine =>
@@ -2137,10 +2137,10 @@ object AST {
   type Import = ASTOf[Shape.Import]
 
   object Import {
-    def apply(path: List1[Cons]):            Import = Shape.Import[AST](path)
-    def apply(head: Cons):                   Import = Import(head, List())
+    def apply(path: List1[Cons]): Import            = Shape.Import[AST](path)
+    def apply(head: Cons): Import                   = Import(head, List())
     def apply(head: Cons, tail: List[Cons]): Import = Import(List1(head, tail))
-    def apply(head: Cons, tail: Cons*):      Import = Import(head, tail.toList)
+    def apply(head: Cons, tail: Cons*): Import      = Import(head, tail.toList)
     def unapply(t: AST): Option[List1[Cons]] =
       Unapply[Import].run(t => t.path)(t)
     val any = UnapplyByType[Import]
@@ -2165,12 +2165,12 @@ object AST {
 
   type Group = ASTOf[Shape.Group]
   object Group {
-    val any = UnapplyByType[Group]
-    def unapply(t: AST):          Option[Option[AST]] = Unapply[Group].run(_.body)(t)
-    def apply(body: Option[AST]): Group               = Shape.Group(body)
-    def apply(body: AST):         Group               = Group(Some(body))
-    def apply(body: SAST):        Group               = Group(body.el)
-    def apply():                  Group               = Group(None)
+    val any                                  = UnapplyByType[Group]
+    def unapply(t: AST): Option[Option[AST]] = Unapply[Group].run(_.body)(t)
+    def apply(body: Option[AST]): Group      = Shape.Group(body)
+    def apply(body: AST): Group              = Group(Some(body))
+    def apply(body: SAST): Group             = Group(body.el)
+    def apply(): Group                       = Group(None)
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -2179,8 +2179,8 @@ object AST {
 
   type Def = ASTOf[Shape.Def]
   object Def {
-    val any = UnapplyByType[Def]
-    def apply(name: Cons):                  Def = Def(name, List())
+    val any                                     = UnapplyByType[Def]
+    def apply(name: Cons): Def                  = Def(name, List())
     def apply(name: Cons, args: List[AST]): Def = Def(name, args, None)
     def apply(name: Cons, args: List[AST], body: Option[AST]): Def =
       Shape.Def(name, args, body)

--- a/engine/runtime/src/main/java/org/enso/interpreter/Language.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/Language.java
@@ -86,7 +86,12 @@ public final class Language extends TruffleLanguage<Context> {
   protected CallTarget parse(ParsingRequest request) {
     RootNode root =
         new ProgramRootNode(
-            this, new LocalScope(), new ModuleScope(), "root", null, request.getSource());
+            this,
+            new LocalScope(),
+            new ModuleScope(),
+            "root",
+            request.getSource().createUnavailableSection(),
+            request.getSource());
 
     return Truffle.getRuntime().createCallTarget(root);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
@@ -67,6 +67,16 @@ public abstract class EnsoRootNode extends RootNode {
   }
 
   /**
+   * Returns a language specific name of this node.
+   *
+   * @return a name of this node
+   */
+  @Override
+  public String getName() {
+    return this.name;
+  }
+
+  /**
    * Sets whether the node is tail-recursive.
    *
    * @param isTail whether or not the node is tail-recursive
@@ -108,5 +118,15 @@ public abstract class EnsoRootNode extends RootNode {
    */
   public ModuleScope getModuleScope() {
     return moduleScope;
+  }
+
+  /**
+   * Marks this node as instrumentable by Truffle instruments API.
+   *
+   * @return {@code true}
+   */
+  @Override
+  protected boolean isInstrumentable() {
+    return true;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/PanicNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/PanicNode.java
@@ -44,4 +44,14 @@ public class PanicNode extends BuiltinRootNode {
         new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE),
         new ArgumentDefinition(1, "value", ArgumentDefinition.ExecutionMode.EXECUTE));
   }
+
+  /**
+   * Returns a language specific name of this node.
+   *
+   * @return the name of this node
+   */
+  @Override
+  public String getName() {
+    return "Panic.throw";
+  }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -38,4 +38,17 @@ public class PanicException extends RuntimeException implements TruffleException
   public Object getExceptionObject() {
     return payload;
   }
+
+  /**
+   * Override recommended by the Truffle documentation for better performance.
+   *
+   * @see <a
+   *     href="https://www.graalvm.org/truffle/javadoc/com/oracle/truffle/api/TruffleException.html">Relevant
+   *     documentation</a>
+   * @return this exception
+   */
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;
+  }
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -7,7 +7,8 @@ import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.{AstExpression, AstModuleScope, EnsoParser}
 import org.enso.compiler.generate.AstToAstExpression
 import org.enso.flexer.Reader
-import org.enso.interpreter.builder.{ExpressionFactory, ModuleScopeExpressionFactory}
+import org.enso.interpreter.builder.ExpressionFactory
+import org.enso.interpreter.builder.ModuleScopeExpressionFactory
 import org.enso.interpreter.node.ExpressionNode
 import org.enso.interpreter.runtime.{Context, Module}
 import org.enso.interpreter.runtime.callable.function.Function
@@ -51,7 +52,7 @@ class Compiler(
       new EnsoParser().parseEnso(source.getCharacters.toString)
     }
 
-    new ModuleScopeExpressionFactory(language, scope).run(expr)
+    new ModuleScopeExpressionFactory(language, source, scope).run(expr)
   }
 
   /**
@@ -108,8 +109,15 @@ class Compiler(
     moduleScope: ModuleScope
   ): ExpressionNode = {
     val parsed = parseInline(source)
-    new ExpressionFactory(language, localScope, "<inline_source>", moduleScope)
-      .run(parsed)
+    new ExpressionFactory(
+      language,
+      Source
+        .newBuilder(Constants.LANGUAGE_ID, source, "<interactive_source>")
+        .build(),
+      localScope,
+      "<inline_source>",
+      moduleScope
+    ).run(parsed)
   }
 
   /**

--- a/engine/runtime/src/main/scala/org/enso/compiler/generate/AstToAstExpression.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/generate/AstToAstExpression.scala
@@ -142,7 +142,7 @@ object AstToAstExpression {
   def translateCallable(application: AST): AstExpression = {
     application match {
       case AstView.ForcedTerm(term) =>
-        AstDesuspend(term.location, translateExpression(term))
+        AstForce(application.location, translateExpression(term))
       case AstView.Application(name, args) =>
         val validArguments = args.filter {
           case AstView.SuspendDefaultsOperator(_) => false

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/CodeLocationsTestInstrument.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/CodeLocationsTestInstrument.java
@@ -1,0 +1,81 @@
+package org.enso.interpreter.test;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.*;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
+
+@TruffleInstrument.Registration(
+    id = CodeLocationsTestInstrument.INSTRUMENT_ID,
+    services = CodeLocationsTestInstrument.class)
+public class CodeLocationsTestInstrument extends TruffleInstrument {
+  public static final String INSTRUMENT_ID = "locations-test";
+  private Env env;
+
+  @Override
+  protected void onCreate(Env env) {
+    env.registerService(this);
+    this.env = env;
+  }
+
+  public static class LocationsEventListener implements ExecutionEventListener {
+    private boolean successful = false;
+    private final int start;
+    private final int length;
+    private final Class<?> type;
+
+    public LocationsEventListener(int start, int length, Class<?> type) {
+      this.start = start;
+      this.length = length;
+      this.type = type;
+    }
+
+    public int getStart() {
+      return start;
+    }
+
+    public int getLength() {
+      return length;
+    }
+
+    public Class<?> getType() {
+      return type;
+    }
+
+    public boolean isSuccessful() {
+      return successful;
+    }
+
+    @Override
+    public void onEnter(EventContext context, VirtualFrame frame) {
+      if (successful) {
+        return;
+      }
+      Node node = context.getInstrumentedNode();
+      if (!type.isInstance(node)) {
+        return;
+      }
+      SourceSection section = node.getSourceSection();
+      if (section == null || !section.hasCharIndex()) {
+        return;
+      }
+      if (section.getCharIndex() == start && section.getCharLength() == length) {
+        successful = true;
+      }
+    }
+
+    @Override
+    public void onReturnValue(EventContext context, VirtualFrame frame, Object result) {}
+
+    @Override
+    public void onReturnExceptional(
+        EventContext context, VirtualFrame frame, Throwable exception) {}
+  }
+
+  public EventBinding<LocationsEventListener> bindTo(int sourceStart, int length, Class<?> type) {
+    return env.getInstrumenter()
+        .attachExecutionEventListener(
+            SourceSectionFilter.newBuilder().build(),
+            new LocationsEventListener(sourceStart, length, type));
+  }
+}

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/CodeLocationsTestInstrument.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/CodeLocationsTestInstrument.java
@@ -5,6 +5,12 @@ import com.oracle.truffle.api.instrumentation.*;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
+/**
+ * A debug instrument used to test code locations.
+ *
+ * <p>Allows to listen for a node with a given type at a given position, and later verify if such a
+ * node was indeed encountered in the course of execution.
+ */
 @TruffleInstrument.Registration(
     id = CodeLocationsTestInstrument.INSTRUMENT_ID,
     services = CodeLocationsTestInstrument.class)
@@ -12,40 +18,76 @@ public class CodeLocationsTestInstrument extends TruffleInstrument {
   public static final String INSTRUMENT_ID = "locations-test";
   private Env env;
 
+  /**
+   * Initializes the instrument. Substitute for a constructor, called by the Truffle framework.
+   *
+   * @param env the instrumentation environment
+   */
   @Override
   protected void onCreate(Env env) {
     env.registerService(this);
     this.env = env;
   }
 
+  /**
+   * An event listener implementing the behavior of verifying whether the currently executed node is
+   * the one expected by the user.
+   */
   public static class LocationsEventListener implements ExecutionEventListener {
     private boolean successful = false;
     private final int start;
     private final int length;
     private final Class<?> type;
 
-    public LocationsEventListener(int start, int length, Class<?> type) {
+    private LocationsEventListener(int start, int length, Class<?> type) {
       this.start = start;
       this.length = length;
       this.type = type;
     }
 
+    /**
+     * Get the start location of the nodes expected by this listener.
+     *
+     * @return the start location for this listener
+     */
     public int getStart() {
       return start;
     }
 
+    /**
+     * Get the source length of the nodes expected by this listener.
+     *
+     * @return the source length for this listener
+     */
     public int getLength() {
       return length;
     }
 
+    /**
+     * Get the type of nodes expected by this listener.
+     *
+     * @return the node type for this listener
+     */
     public Class<?> getType() {
       return type;
     }
 
+    /**
+     * Was a node with parameters specified for this listener encountered in the course of
+     * execution?
+     *
+     * @return {@code true} if the requested node was observed, {@code false} otherwise
+     */
     public boolean isSuccessful() {
       return successful;
     }
 
+    /**
+     * Checks if the node to be executed is the node this listener was created to observe.
+     *
+     * @param context current execution context
+     * @param frame current execution frame
+     */
     @Override
     public void onEnter(EventContext context, VirtualFrame frame) {
       if (successful) {
@@ -72,6 +114,14 @@ public class CodeLocationsTestInstrument extends TruffleInstrument {
         EventContext context, VirtualFrame frame, Throwable exception) {}
   }
 
+  /**
+   * Attach a new listener to observe nodes with given parameters.
+   *
+   * @param sourceStart the source start location of the expected node
+   * @param length the source length of the expected node
+   * @param type the type of the expected node
+   * @return a reference to attached event listener
+   */
   public EventBinding<LocationsEventListener> bindTo(int sourceStart, int length, Class<?> type) {
     return env.getInstrumenter()
         .attachExecutionEventListener(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
@@ -2,12 +2,36 @@ package org.enso.interpreter.test
 
 import java.io.{ByteArrayOutputStream, StringReader}
 
+import com.oracle.truffle.api.instrumentation.EventBinding
 import org.enso.interpreter.Constants
 import org.graalvm.polyglot.{Context, Source, Value}
 import org.enso.interpreter.instrument.ReplDebuggerInstrument
-import org.scalatest.{FlatSpec, Matchers}
+import org.enso.interpreter.test.CodeLocationsTestInstrument.LocationsEventListener
+import org.scalatest.{Assertions, FlatSpec, Matchers}
 
 trait InterpreterRunner {
+  case class LocationsInstrumenter(instrument: CodeLocationsTestInstrument) {
+    var bindings: List[EventBinding[LocationsEventListener]] = List()
+
+    def assertNodeExists(start: Int, length: Int, kind: Class[_]): Unit =
+      bindings ::= instrument.bindTo(start, length, kind)
+
+    def verifyResults(): Unit = {
+      bindings.foreach { binding =>
+        val listener = binding.getElement
+        if (!listener.isSuccessful) {
+          Assertions.fail(
+            s"Node of type ${listener.getType.getSimpleName} at position ${listener.getStart} with length ${listener.getLength} was not found."
+          )
+        }
+      }
+    }
+
+    def close(): Unit = {
+      bindings.foreach(_.dispose)
+    }
+  }
+
   implicit class RichValue(value: Value) {
     def call(l: Long*): Value =
       InterpreterException.rethrowPolyglot(
@@ -16,6 +40,16 @@ trait InterpreterRunner {
   }
   val output = new ByteArrayOutputStream()
   val ctx    = Context.newBuilder(Constants.LANGUAGE_ID).out(output).build()
+
+  def withLocationsInstrumenter(test: LocationsInstrumenter => Unit): Unit = {
+    val instrument = ctx.getEngine.getInstruments
+      .get(CodeLocationsTestInstrument.INSTRUMENT_ID)
+      .lookup(classOf[CodeLocationsTestInstrument])
+    val instrumenter = LocationsInstrumenter(instrument)
+    test(instrumenter)
+    instrumenter.verifyResults()
+    instrumenter.close()
+  }
 
   def evalGeneric(code: String, mimeType: String): Value = {
     output.reset()

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
@@ -1,0 +1,155 @@
+package org.enso.interpreter.test.semantic
+import org.enso.interpreter.node.callable.ApplicationNode
+import org.enso.interpreter.node.callable.function.CreateFunctionNode
+import org.enso.interpreter.node.callable.thunk.ForceNode
+import org.enso.interpreter.node.controlflow.MatchNode
+import org.enso.interpreter.node.expression.literal.IntegerLiteralNode
+import org.enso.interpreter.node.expression.operator.{AddOperatorNode, MultiplyOperatorNode}
+import org.enso.interpreter.node.scope.{AssignmentNode, ReadLocalTargetNode}
+import org.enso.interpreter.test.InterpreterTest
+
+class CodeLocationsTest extends InterpreterTest {
+  def debugPrintCodeLocations(code: String): Unit = {
+    var off = 0
+    code.lines.toList.foreach { line =>
+      val chars = line.toList.map { c =>
+          s" ${if (c == ' ') '_' else c} "
+        } :+ '↵'
+      val ixes = off.until(off + chars.length).map { i =>
+        if (i.toString.length == 1) s" $i " else s"$i "
+      }
+      println(ixes.mkString(""))
+      println(chars.mkString(""))
+      println()
+      off += line.length + 1
+    }
+  }
+
+  "Code Locations" should "be correct in simple arithmetic expressions" in
+  withLocationsInstrumenter { instrumenter =>
+    val code = "2 + 45 * 20"
+    instrumenter.assertNodeExists(0, 11, classOf[AddOperatorNode])
+    instrumenter.assertNodeExists(4, 7, classOf[MultiplyOperatorNode])
+    instrumenter.assertNodeExists(4, 2, classOf[IntegerLiteralNode])
+    eval(code)
+  }
+
+  "Code locations" should "be correct with parenthesized expressions" in
+  withLocationsInstrumenter { instrumenter =>
+    val code = "(2 + 45) * 20"
+    instrumenter.assertNodeExists(0, 13, classOf[MultiplyOperatorNode])
+    instrumenter.assertNodeExists(1, 6, classOf[AddOperatorNode])
+    eval(code)
+  }
+
+  "Code Locations" should "be correct in applications and method calls" in
+  withLocationsInstrumenter { instrumenter =>
+    val code = "(2 - 2).ifZero (Cons 5 6) 0"
+    instrumenter.assertNodeExists(0, 27, classOf[ApplicationNode])
+    instrumenter.assertNodeExists(16, 8, classOf[ApplicationNode])
+    eval(code)
+  }
+
+  "Code Locations" should "be correct in assignments and variable reads" in
+  withLocationsInstrumenter { instrumenter =>
+    val code =
+      """
+        |x = 2 + 2 * 2
+        |y = x * x
+        |IO.println y
+        |""".stripMargin
+    instrumenter.assertNodeExists(1, 13, classOf[AssignmentNode])
+    instrumenter.assertNodeExists(15, 9, classOf[AssignmentNode])
+    instrumenter.assertNodeExists(19, 1, classOf[ReadLocalTargetNode])
+    instrumenter.assertNodeExists(23, 1, classOf[ReadLocalTargetNode])
+    instrumenter.assertNodeExists(36, 1, classOf[ReadLocalTargetNode])
+    eval(code)
+  }
+
+  "Code Locations" should "be correct for deeply nested functions" in
+  withLocationsInstrumenter { instrumenter =>
+    val code =
+      """
+        |Unit.method =
+        |  foo = a b ->
+        |    IO.println a
+        |    add = a -> b -> a + b
+        |    add a b
+        |  foo 10 20
+        |
+        |Unit.method
+        |""".stripMargin
+    instrumenter.assertNodeExists(67, 5, classOf[AddOperatorNode])
+    instrumenter.assertNodeExists(81, 1, classOf[ReadLocalTargetNode])
+    instrumenter.assertNodeExists(77, 7, classOf[ApplicationNode])
+    instrumenter.assertNodeExists(87, 9, classOf[ApplicationNode])
+    eval(code)
+  }
+
+  "Code Locations" should "be correct inside pattern matches" in
+  withLocationsInstrumenter { instrumenter =>
+    val code =
+      """
+        |x = Cons 1 2
+        |y = Nil
+        |
+        |add = a b -> a + b
+        |
+        |foo = x -> case x of
+        |  Cons a b ->
+        |    z = add a b
+        |    x = z * z
+        |    x
+        |  _ -> 5 * 5
+        |
+        |foo x + foo y
+        |""".stripMargin
+    instrumenter.assertNodeExists(54, 73, classOf[MatchNode])
+    instrumenter.assertNodeExists(86, 7, classOf[ApplicationNode])
+    instrumenter.assertNodeExists(98, 9, classOf[AssignmentNode])
+    instrumenter.assertNodeExists(121, 5, classOf[MultiplyOperatorNode])
+    eval(code)
+  }
+
+  "Code locations" should "be correct for lambdas" in
+  withLocationsInstrumenter { instrumenter =>
+    val code =
+      """
+        |f = a b -> a + b
+        |g = x y ->
+        |  z = x * y
+        |  z + z
+        |
+        |f 1 (g 2 3)
+        |""".stripMargin
+    instrumenter.assertNodeExists(5, 12, classOf[CreateFunctionNode])
+    instrumenter.assertNodeExists(22, 27, classOf[CreateFunctionNode])
+    eval(code)
+  }
+
+  "Code locations" should "be correct for defaulted arguments" in
+  withLocationsInstrumenter { instrumenter =>
+    val code =
+      """
+        |bar = x -> x + x * x
+        |foo = x (y = bar x) -> x + y
+        |foo 0
+        |""".stripMargin
+    instrumenter.assertNodeExists(35, 5, classOf[ApplicationNode])
+    instrumenter.assertNodeExists(35, 3, classOf[ReadLocalTargetNode])
+    instrumenter.assertNodeExists(39, 1, classOf[ReadLocalTargetNode])
+    eval(code)
+  }
+
+  "Code locations" should "be correct for lazy arguments" in
+  withLocationsInstrumenter { instrumenter =>
+    val code =
+      """
+        |bar = a ~b ~c -> ifZero a ~b ~c
+        |
+        |bar 0 (IO.println 0) 0
+        |""".stripMargin
+    instrumenter.assertNodeExists(27, 2, classOf[ForceNode])
+    eval(code)
+  }
+}


### PR DESCRIPTION
### Pull Request Description
Truffle nodes are now marked with source locations. That means, instrumentation can use locations as ids, debuggers could attach breakpoints by lines and exceptions print usable stack traces.

### Important Notes
Mostly trivial changes, the only "smart" bit is actually testing it. And the test harness used here actually serves as a PoC for the visualizations server ;)

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
