### PR TITLE
Scala/Rust JSON serialization protocol unification

### DIFF
--- a/common/rust/ast/core/Cargo.toml
+++ b/common/rust/ast/core/Cargo.toml
@@ -8,11 +8,12 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-derive_more              = { version = "0.15.0"                           }
-failure                  = { version = "0.1.5"                            }
-serde                    = { version = "1.0", features = ["derive", "rc"] }
-serde_json               = { version = "1.0"                              }
-shrinkwraprs             = { version = "0.2.1"                            }
+derive_more              = { version = "0.15.0"                             }
+failure                  = { version = "0.1.5"                              }
+serde                    = { version = "1.0", features = ["derive", "rc"]   }
+serde_json               = { version = "1.0"                                }
+shrinkwraprs             = { version = "0.2.1"                              }
+uuid                     = { version  = "0.8.1", features = ["serde", "v4"] }
 
 ast-macros               = { version = "0.1.0", path = "../macros"          }
 prelude                  = { version = "0.1.0", path = "../../prelude"      }

--- a/common/rust/ast/core/src/lib.rs
+++ b/common/rust/ast/core/src/lib.rs
@@ -19,7 +19,7 @@ pub type Stream<T> = Vec<T>;
 /// Exception raised by macro-generated TryFrom methods that try to "downcast"
 /// enum type to its variant subtype if different constructor was used.
 #[derive(Display, Debug, Fail)]
-pub struct WrongEnum { pub expected_con: &'static str }
+pub struct WrongEnum { pub expected_con: String }
 
 // ============
 // === Tree ===
@@ -201,7 +201,7 @@ impl<'de> Visitor<'de> for AstDeserializationVisitor {
                 SHAPE => shape = Some(map.next_value()?),
                 ID    => id    = Some(map.next_value()?),
                 SPAN  => span  = Some(map.next_value()?),
-                _       => {},
+                _     => {},
             }
         }
 

--- a/common/rust/ast/core/src/lib.rs
+++ b/common/rust/ast/core/src/lib.rs
@@ -114,7 +114,7 @@ impl Ast {
     }
 
     pub fn shape(&self) -> &Shape<Ast> {
-        &self.wrapped.wrapped.wrapped
+        self
     }
 
     /// Wraps given shape with an optional ID into Ast. Span will ba
@@ -151,6 +151,7 @@ From<T> for Ast {
 
 // Serialization & Deserialization //
 
+/// Literals used in `Ast` serialization and deserialization.
 pub mod ast_schema {
     pub const STRUCT_NAME: &str      = "Ast";
     pub const SHAPE:       &str      = "shape";
@@ -174,8 +175,10 @@ impl Serialize for Ast {
     }
 }
 
-struct AstDeVisitor;
-impl<'de> Visitor<'de> for AstDeVisitor {
+/// Type to provide serde::de::Visitor to deserialize data into `Ast`.
+struct AstDeserializationVisitor;
+
+impl<'de> Visitor<'de> for AstDeserializationVisitor {
     type Value = Ast;
 
     fn expecting
@@ -213,7 +216,8 @@ impl<'de> Deserialize<'de> for Ast {
     fn deserialize<D>(deserializer: D) -> Result<Ast, D::Error>
     where D: Deserializer<'de> {
         use ast_schema::FIELDS;
-        deserializer.deserialize_struct("AstOf", &FIELDS, AstDeVisitor)
+        let visitor = AstDeserializationVisitor;
+        deserializer.deserialize_struct("AstOf", &FIELDS, visitor)
     }
 }
 

--- a/common/rust/ast/core/src/lib.rs
+++ b/common/rust/ast/core/src/lib.rs
@@ -660,14 +660,16 @@ mod tests {
 
     #[test]
     fn deserialize_var() {
+        let var_name = "foo";
         let uuid_str = "51e74fb9-75a4-499d-9ea3-a90a2663b4a1";
-        let var_ast = r#"
-        {
-            "shape": { "Var":{"name":"foo"}},
-            "id":""#.to_string() + uuid_str + r#"",
-            "span":3
-        }"#;
-        let ast: Ast = serde_json::from_str(&var_ast).unwrap();
+
+        let sample_json = serde_json::json!({
+            "shape": { "Var":{"name": var_name}},
+            "id": uuid_str,
+            "span": var_name.len()
+        });
+        let sample_json_text = sample_json.to_string();
+        let ast: Ast         = serde_json::from_str(&sample_json_text).unwrap();
 
         let expected_uuid = Uuid::parse_str(uuid_str).ok();
         assert_eq!(ast.id, expected_uuid);
@@ -675,10 +677,8 @@ mod tests {
         let expected_span = 3;
         assert_eq!(ast.span, expected_span);
 
-        let expected_shape = Var { name: "foo".into() };
-        match ast.shape() {
-            Shape::Var(var) => assert_eq!(var, &expected_shape),
-            _               => panic!("expected Var"),
-        }
+        let expected_var   = Var { name: var_name.into() };
+        let expected_shape = Shape::from(expected_var);
+        assert_eq!(*ast.shape(), expected_shape);
     }
 }

--- a/common/rust/ast/core/src/lib.rs
+++ b/common/rust/ast/core/src/lib.rs
@@ -4,11 +4,22 @@
 use prelude::*;
 
 use serde::{Serialize, Deserialize};
-
+use serde::ser::{Serializer, SerializeStruct};
+use serde::de::{Deserializer, Visitor};
+use uuid::Uuid;
 use ast_macros::*;
 use shapely::*;
 
 pub type Stream<T> = Vec<T>;
+
+// ==============
+// === Errors ===
+// ==============
+
+/// Exception raised by macro-generated TryFrom methods that try to "downcast"
+/// enum type to its variant subtype if different constructor was used.
+#[derive(Display, Debug, Fail)]
+pub struct WrongEnum { pub expected_con: &'static str }
 
 // ============
 // === Tree ===
@@ -84,13 +95,17 @@ impl<T> Layer<T> for Layered<T> {
 /// to either of the implementation need to be applied to the other one as well.
 ///
 /// Each AST node is annotated with span and an optional ID.
-#[derive(Eq, PartialEq, Debug, Shrinkwrap, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Shrinkwrap)]
 #[shrinkwrap(mutable)]
 pub struct Ast {
-    #[serde(flatten)]
     pub wrapped: Rc<WithID<WithSpan<Shape<Ast>>>>
 }
 
+impl Clone for Ast {
+    fn clone(&self) -> Self {
+        Ast { wrapped: self.wrapped.clone() }
+    }
+}
 
 impl Ast {
     pub fn iter(&self) -> Rc<dyn Iterator<Item = &'_ Shape<Ast>> + '_> {
@@ -102,9 +117,17 @@ impl Ast {
         &self.wrapped.wrapped.wrapped
     }
 
+    /// Wraps given shape with an optional ID into Ast. Span will ba
+    /// automatically calculated based on Shape.
     pub fn new<S: Into<Shape<Ast>>>(shape: S, id: Option<ID>) -> Ast {
+        let shape: Shape<Ast> = shape.into();
+        let span = shape.span();
+        Ast::new_with_span(shape, id, span)
+    }
+
+    pub fn new_with_span<S: Into<Shape<Ast>>>
+    (shape: S, id: Option<ID>, span: usize) -> Ast {
         let shape     = shape.into();
-        let span      = shape.span();
         let with_span = WithSpan { wrapped: shape,     span };
         let with_id   = WithID   { wrapped: with_span, id   };
         Ast { wrapped: Rc::new(with_id) }
@@ -123,6 +146,74 @@ From<T> for Ast {
     fn from(t: T) -> Self {
         let id = None;
         Ast::new(t, id)
+    }
+}
+
+// Serialization & Deserialization //
+
+pub mod ast_schema {
+    pub const STRUCT_NAME: &str      = "Ast";
+    pub const SHAPE:       &str      = "shape";
+    pub const ID:          &str      = "id";
+    pub const SPAN:        &str      = "span";
+    pub const FIELDS:      [&str; 3] = [SHAPE, ID, SPAN];
+    pub const COUNT:       usize     = FIELDS.len();
+}
+
+impl Serialize for Ast {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        use ast_schema::*;
+        let mut state = serializer.serialize_struct(STRUCT_NAME, COUNT)?;
+        state.serialize_field(SHAPE, &self.shape())?;
+        if self.id.is_some() {
+            state.serialize_field(ID, &self.id)?;
+        }
+        state.serialize_field(SPAN,  &self.span)?;
+        state.end()
+    }
+}
+
+struct AstDeVisitor;
+impl<'de> Visitor<'de> for AstDeVisitor {
+    type Value = Ast;
+
+    fn expecting
+    (&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use ast_schema::*;
+        write!(formatter, "an object with `{}` and `{}` fields", SHAPE, SPAN)
+    }
+
+    fn visit_map<A>
+    (self, mut map: A) -> Result<Self::Value, A::Error>
+    where A: serde::de::MapAccess<'de>, {
+        use ast_schema::*;
+
+        let mut shape: Option<Shape<Ast>> = None;
+        let mut id:    Option<Option<ID>> = None;
+        let mut span:  Option<usize>      = None;
+
+        while let Some(key) = map.next_key()? {
+            match key {
+                SHAPE => shape = Some(map.next_value()?),
+                ID    => id    = Some(map.next_value()?),
+                SPAN  => span  = Some(map.next_value()?),
+                _       => {},
+            }
+        }
+
+        let shape = shape.ok_or(serde::de::Error::missing_field(SHAPE))?;
+        let id    = id.unwrap_or(None); // allow missing `id` field
+        let span  = span.ok_or(serde::de::Error::missing_field(SPAN))?;
+        Ok(Ast::new_with_span(shape, id, span))
+    }
+}
+
+impl<'de> Deserialize<'de> for Ast {
+    fn deserialize<D>(deserializer: D) -> Result<Ast, D::Error>
+    where D: Deserializer<'de> {
+        use ast_schema::FIELDS;
+        deserializer.deserialize_struct("AstOf", &FIELDS, AstDeVisitor)
     }
 }
 
@@ -147,7 +238,7 @@ From<T> for Ast {
     Text      (Text<T>),
 
     // === Expressions ===
-    App       { func : T   , off  : usize , arg: T                          },
+    Prefix    { func : T   , off  : usize , arg: T                          },
     Infix     { larg : T   , loff : usize , opr: T , roff: usize , rarg: T  },
     SectLeft  { arg  : T   , off  : usize , opr: T                          },
     SectRight { opr  : T   , off  : usize , arg: T                          },
@@ -211,22 +302,22 @@ pub type TextBlock<T> = Vec<TextLine<T>>;
 // =============
 
 #[ast] pub struct Block<T> {
-    ty          : BlockType,
-    ident       : usize,
-    empty_lines : usize,
-    first_line  : BlockLine<T>,
-    lines       : Vec<BlockLine<Option<T>>>,
-    is_orphan   : bool,
+    pub ty          : BlockType,
+    pub ident       : usize,
+    pub empty_lines : usize,
+    pub first_line  : BlockLine<T>,
+    pub lines       : Vec<BlockLine<Option<T>>>,
+    pub is_orphan   : bool,
 }
 
 #[ast] pub enum   BlockType     { Continuous, Discontinuous }
-#[ast] pub struct BlockLine <T> { elem: T, off: usize }
+#[ast] pub struct BlockLine <T> { pub elem: T, pub off: usize }
 
 // ==============
 // === Module ===
 // ==============
 
-#[ast] pub struct Module<T> { lines: Vec<BlockLine<Option<T>>> }
+#[ast] pub struct Module<T> {  pub lines: Vec<BlockLine<Option<T>>> }
 
 // =============
 // === Macro ===
@@ -397,11 +488,11 @@ impl HasSpan for &str {
 
 // === WithID ===
 
+pub type ID = Uuid;
+
 pub trait HasID {
     fn id(&self) -> Option<ID>;
 }
-
-pub type ID = i32;
 
 #[derive(Eq, PartialEq, Debug, Shrinkwrap, Serialize, Deserialize)]
 #[shrinkwrap(mutable)]
@@ -522,6 +613,15 @@ impl HasSpan for Var {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::de::DeserializeOwned;
+
+    /// Assert that given value round trips JSON serialization.
+    fn round_trips<T>(input_val: &T)
+    where T: Serialize + DeserializeOwned + PartialEq + Debug {
+        let json_str            = serde_json::to_string(&input_val).unwrap();
+        let deserialized_val: T = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(*input_val, deserialized_val);
+    }
 
     #[test]
     fn var_smart_constructor() {
@@ -547,16 +647,38 @@ mod tests {
 
     #[test]
     fn serialization_round_trip() {
-        let var_name = "foo";
-        let v1       = Var { name: var_name.to_string() };
-        let v1_str   = serde_json::to_string(&v1).unwrap();
-        let v2: Var  = serde_json::from_str(&v1_str).unwrap();
-        assert_eq!(v1, v2);
+        let make_var = || Var { name: "foo".into() };
+        round_trips(&make_var());
 
-        let id        = Some(15);
-        let ast1      = Ast::new(v1, id);
-        let ast_str   = serde_json::to_string(&ast1).unwrap();
-        let ast2: Ast = serde_json::from_str(&ast_str).unwrap();
-        assert_eq!(ast1, ast2);
+        let ast_without_id = Ast::new(make_var(), None);
+        round_trips(&ast_without_id);
+
+        let id        = Uuid::parse_str("15").ok();
+        let ast_with_id = Ast::new(make_var(), id);
+        round_trips(&ast_with_id);
+    }
+
+    #[test]
+    fn deserialize_var() {
+        let uuid_str = "51e74fb9-75a4-499d-9ea3-a90a2663b4a1";
+        let var_ast = r#"
+        {
+            "shape": { "Var":{"name":"foo"}},
+            "id":""#.to_string() + uuid_str + r#"",
+            "span":3
+        }"#;
+        let ast: Ast = serde_json::from_str(&var_ast).unwrap();
+
+        let expected_uuid = Uuid::parse_str(uuid_str).ok();
+        assert_eq!(ast.id, expected_uuid);
+
+        let expected_span = 3;
+        assert_eq!(ast.span, expected_span);
+
+        let expected_shape = Var { name: "foo".into() };
+        match ast.shape() {
+            Shape::Var(var) => assert_eq!(var, &expected_shape),
+            _               => panic!("expected Var"),
+        }
     }
 }

--- a/common/rust/ast/macros/src/lib.rs
+++ b/common/rust/ast/macros/src/lib.rs
@@ -143,6 +143,8 @@ fn gen_variant_decl
 
 /// Generate `From` trait implementations converting from each of extracted
 /// types back into primary enumeration.
+/// Generate `TryFrom` implementation from primary enumeration into each
+/// extracted type.
 fn gen_from_impls
 ( ident  : &syn::Ident
 , decl   : &syn::DeriveInput
@@ -150,6 +152,7 @@ fn gen_from_impls
 ) -> TokenStream {
     let sum_label     = &decl.ident;
     let variant_label = &variant.ident;
+    let variant_name = variant_label.to_string();
 
     let sum_params = &decl.generics.params
         .iter().cloned().collect::<Vec<_>>();
@@ -166,6 +169,57 @@ fn gen_from_impls
         for #sum_label<#(#sum_params),*> {
             fn from(t: #variant_label<#(#variant_params),*>) -> Self {
                 #sum_label::#ident(t)
+            }
+        }
+
+
+        // impl<'t, T> TryFrom<&'t Shape<T>> for &'t Infix<T> {
+        //     type Error = WrongEnum;
+        //     fn try_from(value: &'t Shape<T>) -> Result<Self, Self::Error> {
+        //         match value {
+        //             Shape::Infix(elem) => Ok (elem),
+        //             _ => {
+        //                 let error = WrongEnum {
+        //                     expected_con : "Infix" };
+        //                 Err(error)
+        //             },
+        //         }
+        //     }
+        // }
+        impl<'t, #(#sum_params),*> TryFrom<&'t #sum_label<#(#sum_params),*>>
+        for &'t #variant_label<#(#variant_params),*> {
+            type Error = WrongEnum;
+
+            fn try_from
+            (value: &'t #sum_label<#(#sum_params),*>)
+            -> Result<Self, Self::Error> {
+                match value {
+                    #sum_label::#ident(elem) => Ok(elem),
+                    _  => {
+                        let error = WrongEnum {
+                            expected_con: #variant_name};
+                        Err(error)
+                    },
+                }
+            }
+        }
+
+        // same as above but for values
+        impl<#(#sum_params),*> TryFrom<#sum_label<#(#sum_params),*>>
+        for #variant_label<#(#variant_params),*> {
+            type Error = WrongEnum;
+
+            fn try_from
+            (value: #sum_label<#(#sum_params),*>)
+            -> Result<Self, Self::Error> {
+                match value {
+                    #sum_label::#ident(elem) => Ok(elem),
+                    _  => {
+                        let error = WrongEnum {
+                            expected_con: #variant_name};
+                        Err(error)
+                    },
+                }
             }
         }
     }

--- a/common/rust/ast/macros/src/lib.rs
+++ b/common/rust/ast/macros/src/lib.rs
@@ -197,7 +197,7 @@ fn gen_from_impls
                     #sum_label::#ident(elem) => Ok(elem),
                     _  => {
                         let error = WrongEnum {
-                            expected_con: #variant_name};
+                            expected_con: #variant_name.to_string() };
                         Err(error)
                     },
                 }
@@ -216,7 +216,7 @@ fn gen_from_impls
                     #sum_label::#ident(elem) => Ok(elem),
                     _  => {
                         let error = WrongEnum {
-                            expected_con: #variant_name};
+                            expected_con: #variant_name.to_string() };
                         Err(error)
                     },
                 }

--- a/common/rust/parser/Cargo.toml
+++ b/common/rust/parser/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+ast               = { version = "0.1.0", path = "../ast/core"     }
 failure           = "0.1"
 matches           = "0.1"
 prelude           = { version = "0.1.0", path = "../prelude"     }

--- a/common/rust/parser/src/api.rs
+++ b/common/rust/parser/src/api.rs
@@ -1,21 +1,15 @@
 use prelude::*;
 
+pub type Ast = ast::Ast;
+
 // ============
 // == Parser ==
 // ============
 
 /// Entity being able to parse Luna programs into Luna's AST.
 pub trait IsParser {
-    fn parse(&mut self, program: String) -> Result<AST>;
+    fn parse(&mut self, program: String) -> Result<Ast>;
 }
-
-// =========
-// == AST ==
-// =========
-
-// TODO: placeholder until we have real AST, see:
-// https://github.com/luna/enso/issues/296
-pub type AST = String;
 
 // ===========
 // == Error ==

--- a/common/rust/parser/src/jsclient.rs
+++ b/common/rust/parser/src/jsclient.rs
@@ -24,7 +24,7 @@ impl Client {
 }
 
 impl IsParser for Client {
-    fn parse(&mut self, _program: String) -> api::Result<api::AST> {
+    fn parse(&mut self, _program: String) -> api::Result<api::Ast> {
         Err(api::interop_error(Error::NotImplemented))
     }
 }

--- a/common/rust/parser/src/lib.rs
+++ b/common/rust/parser/src/lib.rs
@@ -40,7 +40,7 @@ impl Parser {
 }
 
 impl api::IsParser for Parser {
-    fn parse(&mut self, program: String) -> api::Result<api::AST> {
+    fn parse(&mut self, program: String) -> api::Result<api::Ast> {
         self.deref_mut().parse(program)
     }
 }

--- a/common/rust/parser/tests/parsing.rs
+++ b/common/rust/parser/tests/parsing.rs
@@ -36,6 +36,7 @@ impl TestHelper {
         line.clone()
     }
 
+    // TODO: make generic, should work for all shape subtypes.
     fn parse_shape_var<F>(&mut self, program: &str, tester: F)
         where F: FnOnce(&ast::Var) -> () {
         let ast = self.parse_line(program);
@@ -43,41 +44,24 @@ impl TestHelper {
         tester(shape);
     }
 
-    // TODO: the function above should be generic for all TryFrom<Shape<Ast>>
-    //  types.
-//    fn parse_shape_T<'t, F, T>(&mut self, program: &str, tester: F)
-//        where F: FnOnce(&T) -> (),
-//            &'t Shape<Ast>: TryInto<&'t T>,
-//            T: 'static,
-////             <&'t Shape<Ast> as TryInto<&'t T>>::Error: Debug
-//    {
-//        let ast = self.parse_line(program);
-//        let shape = expect_shape(&ast);
-//        tester(shape);
-////        let shape = ast.shape();
-////        let shape_t = shape.try_into();
-//    }
-
     fn deserialize_blank(&mut self) {
-        let ast = self.parse_line("_");
+        let _ast = self.parse_line("_");
     }
 
     fn deserialize_cons(&mut self) {
-        let ast = self.parse_line("FooBar");
+        let _ast = self.parse_line("FooBar");
     }
 
     fn deserialize_mod(&mut self) {
-        let ast = self.parse_line("+=");
+        let _ast = self.parse_line("+=");
     }
 
     fn deserialize_prefix(&mut self) {
-        let ast = self.parse_line("foo bar");
-        println!("{:?}", ast);
+        let _ast = self.parse_line("foo bar");
     }
 
     fn deserialize_infix(&mut self) {
-        let ast = self.parse_line("foo + bar");
-        println!("{:?}", ast);
+        let _ast = self.parse_line("foo + bar");
     }
 
     fn deserialize_var(&mut self) {

--- a/common/rust/parser/tests/parsing.rs
+++ b/common/rust/parser/tests/parsing.rs
@@ -1,0 +1,109 @@
+use prelude::*;
+use parser::api::IsParser;
+
+use ast::{Ast, Shape};
+
+/// Takes Ast being a module with a single line and returns that line's AST.
+fn expect_single_line(ast: &Ast) -> &Ast {
+    let shape = ast.shape();
+    let module: &ast::Module<Ast> = shape.try_into().unwrap();
+    assert_eq!(module.lines.len(), 1, "module expected to have a single line");
+    let line = module.lines.iter().nth(0).unwrap();
+    line.elem.as_ref().unwrap()
+}
+
+/// "Downcasts" given AST's Shape to `T`.
+fn expect_shape<'t, T>(ast: &'t Ast) -> &'t T
+where &'t Shape<Ast>: TryInto<&'t T> {
+    match ast.shape().try_into() {
+        Ok(shape) => shape,
+        _         => panic!("failed converting shape"),
+    }
+}
+
+/// Persists parser (which is expensive to construct, so we want to reuse it
+/// between tests. Additionally, hosts a number of helper methods.
+struct TestHelper(parser::Parser);
+
+impl TestHelper {
+    fn new() -> TestHelper {
+        TestHelper(parser::Parser::new_or_panic())
+    }
+
+    fn parse_line(&mut self, program: &str) -> Ast {
+        let ast = self.0.parse(program.into()).unwrap();
+        let line = expect_single_line(&ast);
+        line.clone()
+    }
+
+    fn parse_shape_var<F>(&mut self, program: &str, tester: F)
+        where F: FnOnce(&ast::Var) -> () {
+        let ast = self.parse_line(program);
+        let shape = expect_shape(&ast);
+        tester(shape);
+    }
+
+    // TODO: the function above should be generic for all TryFrom<Shape<Ast>>
+    //  types.
+//    fn parse_shape_T<'t, F, T>(&mut self, program: &str, tester: F)
+//        where F: FnOnce(&T) -> (),
+//            &'t Shape<Ast>: TryInto<&'t T>,
+//            T: 'static,
+////             <&'t Shape<Ast> as TryInto<&'t T>>::Error: Debug
+//    {
+//        let ast = self.parse_line(program);
+//        let shape = expect_shape(&ast);
+//        tester(shape);
+////        let shape = ast.shape();
+////        let shape_t = shape.try_into();
+//    }
+
+    fn deserialize_blank(&mut self) {
+        let ast = self.parse_line("_");
+    }
+
+    fn deserialize_cons(&mut self) {
+        let ast = self.parse_line("FooBar");
+    }
+
+    fn deserialize_mod(&mut self) {
+        let ast = self.parse_line("+=");
+    }
+
+    fn deserialize_prefix(&mut self) {
+        let ast = self.parse_line("foo bar");
+        println!("{:?}", ast);
+    }
+
+    fn deserialize_infix(&mut self) {
+        let ast = self.parse_line("foo + bar");
+        println!("{:?}", ast);
+    }
+
+    fn deserialize_var(&mut self) {
+        self.parse_shape_var("foo", |var| {
+            let expected_var = ast::Var { name: "foo".into() };
+            assert_eq!(var, &expected_var);
+        });
+    }
+
+    fn run(&mut self) {
+        self.deserialize_blank();
+        self.deserialize_cons();
+        self.deserialize_mod();
+        self.deserialize_prefix();
+        self.deserialize_infix();
+        self.deserialize_var();
+    }
+}
+
+/// A single entry point for all the tests here using external parser.
+///
+/// Setting up the parser is costly, so we run all tests as a single batch.
+/// Until proper CI solution for calling external parser is devised, this
+/// test is marked with `#[ignore]`.
+#[test]
+#[ignore]
+fn parser_tests() {
+    TestHelper::new().run()
+}

--- a/common/scala/parser-service/src/main/scala/org/enso/parserservice/Protocol.scala
+++ b/common/scala/parser-service/src/main/scala/org/enso/parserservice/Protocol.scala
@@ -13,8 +13,8 @@ object Protocol {
   final case class ParseRequest(program: String) extends Request
 
   sealed trait Response
-  final case class Success(ast: String)   extends Response
-  final case class Error(message: String) extends Response
+  final case class Success(ast_json: String) extends Response
+  final case class Error(message: String)    extends Response
 }
 
 /** Helper for implementing protocol over text-based transport.

--- a/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/common/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -1356,7 +1356,7 @@ object AST {
 
   object ASTOf extends AstImplicits
 
-  trait AstImplicits {
+  trait AstImplicits extends AstImplicits2 {
     implicit def unwrap[T[_]](t: ASTOf[T]): T[AST] = t.shape
     implicit def repr[T[S] <: Shape[S]]: Repr[ASTOf[T]] =
       t => implicitly[Repr[Shape[AST]]].repr(t.shape)
@@ -1365,6 +1365,12 @@ object AST {
       t: T[AST]
     )(implicit ev: HasSpan[T[AST]]): ASTOf[T] = ASTOf(t, ev.span(t))
 
+    implicit def encoder_spec(
+      implicit ev: Encoder[Shape[AST]]
+    ): Encoder[AST] = encoder
+  }
+
+  trait AstImplicits2 {
     // Note: [JSON Schema]
     implicit def encoder[T[S] <: Shape[S]](
       implicit ev: Encoder[Shape[AST]]
@@ -1378,6 +1384,7 @@ object AST {
       Json.fromFields(fields)
     }
   }
+
   /* Note: [JSON Schema]
    * ~~~~~~~~~~~~~~~~~~~
    * Each AST node is serialized to a map with `shape`, `span` and,

--- a/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/common/scala/syntax/specialization/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -237,7 +237,7 @@ class Parser {
     */
   def attachLocations(ast: AST, startOffset: Int): AST = ast match {
     case App.Prefix.any(app) =>
-      val locatedFn = attachLocations(app.fn, startOffset)
+      val locatedFn = attachLocations(app.func, startOffset)
       val locatedArg =
         attachLocations(app.arg, startOffset + locatedFn.span + app.off)
       App.Prefix(locatedFn, app.off, locatedArg)


### PR DESCRIPTION
### Pull Request Description
This PR updates JSON serialization in Scala in Rust, so they are compatible, implementing #297.

Mostly path of least resistance was chosen. Serialized schema was slightly adjusted on both sides, so they work nicely together with manual code only for serialization top-level AST node. Working serialization has been confirmed for several simple types (identifiers, application) in semi-manual testing.

This does not mean that all types can be serialized — this PR fixes schema, however data structures still remain different between Scala and Rust, and this needs to be fixed before Scala/Rust interop is complete. This PR only made a few minor adjustments, to enable simple tests to pass.

The parser wrapper now uses the real AST in API. Still most of non-trivial use-cases will fail. Once #336 is done, it should finally work.

### Important Notes


### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [ ] All code has been tested where possible.
