### PR TITLE
Record Decisions About the Return Value of `=`

### DIFF
--- a/doc/design/semantics/semantics.md
+++ b/doc/design/semantics/semantics.md
@@ -15,6 +15,7 @@ Enso.
 
 - [Strict Evaluation](#strict-evaluation)
     - [Optional Suspension](#optional-suspension)
+- [Bindings](#bindings)
 
 <!-- /MarkdownTOC -->
 
@@ -45,3 +46,19 @@ optional _suspension_, through the built-in `Suspended` type.
 > The actionables for this section are:
 >
 > - Make this far better specified.
+
+## Bindings
+While some expression-based languages with bindings have the binding return the
+value assigned to the binding, we feel that this is far too error prone.
+Consider the following code as a demonstration:
+
+```ruby
+if x = someExprEvaluatingToBool then foo else bar
+```
+
+This is the perennially-discussed C++ bug where you fail to type `==` in an
+if-statement.
+
+Enso, instead, takes the approach where a binding expression returns the
+singleton value of the type `Nothing`, making the above-written code a type
+error.


### PR DESCRIPTION
### Pull Request Description
We had previously made assumptions about the return value of the `=` binding operator. These are now written into the documentation. 

### Important Notes
This PR _purely_ codifies the assumptions made, and has no impact on _functionality_ of the existing interpreter codebase. It does, however, mean that the value returned by the `AssignmentNode` needs to be changed away from `Unit`.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
