### PR TITLE
Node value caching

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/ExactPositionListener.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/ExactPositionListener.java
@@ -17,7 +17,7 @@ import com.oracle.truffle.api.source.SourceSection;
  * position, properly handling recursive calls (fires only in the top frame).
  */
 public class ExactPositionListener implements ExecutionEventListener {
-  private EventBinding<ExactPositionListener> binding;
+  private EventBinding<? extends ExactPositionListener> binding;
   private final int start;
   private final int length;
   private final String funName;
@@ -42,7 +42,7 @@ public class ExactPositionListener implements ExecutionEventListener {
    *
    * @param binding the event binding resulting from attaching this listener.
    */
-  public void setBinding(EventBinding<ExactPositionListener> binding) {
+  public void setBinding(EventBinding<? extends ExactPositionListener> binding) {
     this.binding = binding;
   }
 
@@ -77,6 +77,16 @@ public class ExactPositionListener implements ExecutionEventListener {
     return result == null;
   }
 
+  /**
+   * Checks whether the listener should trigger in the current context.
+   *
+   * <p>The conditions checked are:
+   * <li>Is it not a recursive call?
+   * <li>Is the node at the exact requested source position?
+   *
+   * @param context the current event context.
+   * @return true if the listener should trigger, false otherwise.
+   */
   protected boolean shouldTrigger(EventContext context) {
     if (!isTopFrame()) {
       return false;
@@ -89,6 +99,7 @@ public class ExactPositionListener implements ExecutionEventListener {
     return section.getCharIndex() == start && section.getCharLength() == length;
   }
 
+  /** Detach this listener, ensuring it won't ever trigger. */
   protected void detach() {
     binding.dispose();
   }
@@ -120,7 +131,12 @@ public class ExactPositionListener implements ExecutionEventListener {
     return binding.isDisposed();
   }
 
-  public EventBinding<ExactPositionListener> getBinding() {
+  /**
+   * Get the current binding associated with this listener.
+   *
+   * @return the binding associated with this listener.
+   */
+  public EventBinding<? extends ExactPositionListener> getBinding() {
     return binding;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/FunctionCallExtractorInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/FunctionCallExtractorInstrument.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.instrument;
 
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.*;
 import org.enso.interpreter.node.callable.FunctionCallInstrumentationNode;
 
@@ -30,8 +31,12 @@ public class FunctionCallExtractorInstrument
       Consumer<FunctionCallInstrumentationNode.FunctionCall> callback) {
     return new ExactPositionListener(funName, sourceStart, length) {
       @Override
-      public void handleReturnValue(Object result) {
+      public void onReturnValue(EventContext context, VirtualFrame frame, Object result) {
+        if (!shouldTrigger(context)) {
+          return;
+        }
         if (result instanceof FunctionCallInstrumentationNode.FunctionCall) {
+          detach();
           callback.accept((FunctionCallInstrumentationNode.FunctionCall) result);
         }
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/ValueExtractorInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/ValueExtractorInstrument.java
@@ -4,6 +4,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.*;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
+import org.enso.interpreter.node.callable.FunctionCallInstrumentationNode;
 
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
@@ -34,7 +35,11 @@ public class ValueExtractorInstrument extends ExactPositionInstrument<Object> {
       String funName, int sourceStart, int length, Consumer<Object> callback) {
     return new ExactPositionListener(funName, sourceStart, length) {
       @Override
-      public void handleReturnValue(Object result) {
+      public void onReturnValue(EventContext context, VirtualFrame frame, Object result) {
+        if (!shouldTrigger(context)) {
+          return;
+        }
+        detach();
         callback.accept(result);
       }
     };

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/ValueOverrideInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/ValueOverrideInstrument.java
@@ -1,0 +1,67 @@
+package org.enso.interpreter.instrument;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.*;
+
+@TruffleInstrument.Registration(
+    id = ValueOverrideInstrument.INSTRUMENT_ID,
+    services = ValueOverrideInstrument.class)
+public class ValueOverrideInstrument extends TruffleInstrument {
+  public static final String INSTRUMENT_ID = "value-override";
+
+  private Env env;
+
+  /**
+   * Initializes the instrument. Substitute for a constructor, called by the Truffle framework.
+   *
+   * @param env the instrumentation environment
+   */
+  @Override
+  protected void onCreate(Env env) {
+    env.registerService(this);
+    this.env = env;
+  }
+
+  private static class OverrideUnwind {
+    private final Object value;
+
+    private OverrideUnwind(Object value) {
+      this.value = value;
+    }
+
+    private Object getValue() {
+      return value;
+    }
+  }
+
+  public EventBinding<ExactPositionListener> overrideAt(
+      String funName, int sourceStart, int sourceLength, Object value) {
+    SourceSectionFilter sourceSectionFilter =
+        SourceSectionFilter.newBuilder()
+            .indexIn(sourceStart, sourceLength)
+            .tagIs(StandardTags.ExpressionTag.class)
+            .build();
+    ExactPositionListener positionListener =
+        new ExactPositionListener(funName, sourceStart, sourceLength) {
+          @Override
+          public void onEnter(EventContext context, VirtualFrame frame) {
+            if (shouldTrigger(context)) {
+              throw context.createUnwind(new OverrideUnwind(value), getBinding());
+            }
+          }
+
+          @Override
+          public Object onUnwind(EventContext context, VirtualFrame frame, Object info) {
+            if (info instanceof OverrideUnwind) {
+              detach();
+              return ((OverrideUnwind) info).getValue();
+            }
+            return info;
+          }
+        };
+    EventBinding<ExactPositionListener> binding =
+        env.getInstrumenter().attachExecutionEventListener(sourceSectionFilter, positionListener);
+    positionListener.setBinding(binding);
+    return binding;
+  }
+}

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
@@ -8,7 +8,8 @@ import org.graalvm.polyglot.{Context, Source, Value}
 import org.enso.interpreter.instrument.{
   FunctionCallExtractorInstrument,
   ReplDebuggerInstrument,
-  ValueExtractorInstrument
+  ValueExtractorInstrument,
+  ValueOverrideInstrument
 }
 import org.enso.interpreter.test.CodeLocationsTestInstrument.LocationsEventListener
 import org.enso.polyglot.{ExecutionContext, Function, LanguageInfo}
@@ -106,6 +107,12 @@ trait InterpreterRunner {
     ctx.getEngine.getInstruments
       .get(FunctionCallExtractorInstrument.INSTRUMENT_ID)
       .lookup(classOf[FunctionCallExtractorInstrument])
+  }
+
+  def getValueOverrideInstrument: ValueOverrideInstrument = {
+    ctx.getEngine.getInstruments
+      .get(ValueOverrideInstrument.INSTRUMENT_ID)
+      .lookup(classOf[ValueOverrideInstrument])
   }
 
   // For Enso raw text blocks inside scala multiline strings

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ValueOverrideTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ValueOverrideTest.scala
@@ -1,0 +1,54 @@
+package org.enso.interpreter.test.instrument
+import org.enso.interpreter.test.InterpreterTest
+
+class ValueOverrideTest extends InterpreterTest {
+  val subject = "Value override instrument"
+
+  subject should "allow to inject custom values into node execution flow" in {
+    val code =
+      """
+        |main =
+        |    x = 123 + 456
+        |    y = x * 2
+        |    z = y + x
+        |    z
+        |""".stripMargin
+
+    eval(code) shouldEqual 1737
+
+    val instrument = getValueOverrideInstrument
+    instrument.overrideAt("Test.main", 16, 9, 1L.asInstanceOf[AnyRef])
+    instrument.overrideAt("Test.main", 34, 5, 10L.asInstanceOf[AnyRef])
+
+    eval(code) shouldEqual 11
+  }
+
+  subject should "skip evaluation of side effects when overriding an expression" in {
+    val code =
+      """
+        |foo = arg ->
+        |    IO.println "I'm expensive!"
+        |    arg + 5
+        |
+        |bar = arg ->
+        |    IO.println "I'm more expensive!"
+        |    arg * 5
+        |
+        |main =
+        |    x = 10
+        |    y = here.foo x
+        |    z = here.bar y
+        |    z
+        |""".stripMargin
+
+    eval(code) shouldEqual 75
+    consumeOut shouldEqual List("I'm expensive!", "I'm more expensive!")
+
+    val instrument = getValueOverrideInstrument
+    instrument.overrideAt("Test.main", 148, 10, 15L.asInstanceOf[AnyRef])
+    instrument.overrideAt("Test.main", 167, 10, 75L.asInstanceOf[AnyRef])
+
+    eval(code) shouldEqual 75
+    consumeOut shouldEqual List()
+  }
+}


### PR DESCRIPTION
### Pull Request Description
Introduces an instrument allowing to bypass execution of an arbitrary expression and return a fixed value instead.

### Important Notes
Uses exceptions for trivial control flow, yay. That's the Graal API, I don't see any other way to do it.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
