### PR TITLE
Core Smart Constructors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -312,6 +312,9 @@ lazy val graph = (project in file("common/graph/"))
       "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
     ),
     addCompilerPlugin(
+      "org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full
+    ),
+    addCompilerPlugin (
       "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
     ),
     addCompilerPlugin("io.tryp" % "splain" % "0.5.0" cross CrossVersion.patch),
@@ -394,6 +397,9 @@ lazy val core_definition = (project in file("engine/core-definition"))
     addCompilerPlugin(
       "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
     ),
+    addCompilerPlugin(
+      "org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full
+    ),
     addCompilerPlugin("io.tryp" % "splain" % "0.5.0" cross CrossVersion.patch),
     scalacOptions ++= Seq(
       "-P:splain:infix:true",
@@ -443,6 +449,9 @@ lazy val runtime = (project in file("engine/runtime"))
     ),
     addCompilerPlugin(
       "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
+    ),
+    addCompilerPlugin(
+      "org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full
     ),
     addCompilerPlugin("io.tryp" % "splain" % "0.5.0" cross CrossVersion.patch),
     scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -409,6 +409,7 @@ lazy val core_definition = (project in file("engine/core-definition"))
     )
   )
   .dependsOn(graph)
+  .dependsOn(syntax.jvm)
 
 lazy val runtime = (project in file("engine/runtime"))
   .configs(Benchmark)

--- a/common/graph/src/main/scala/org/enso/graph/Graph.scala
+++ b/common/graph/src/main/scala/org/enso/graph/Graph.scala
@@ -357,8 +357,6 @@ object Graph {
     @newtype
     final case class Ref[G <: Graph, C <: Component](ix: Int)
 
-    // === Refined ===
-
     /** Type refinement for component references.
       *
       * Type refinement is used to add additional information to a [[Component]]
@@ -724,7 +722,8 @@ object Graph {
       ev3: HListTakeUntil.Aux[C, ComponentList, PrevComponentList],
       ev4: hlist.Length.Aux[PrevComponentList, ComponentIndex],
       componentIndexEv: nat.ToInt[ComponentIndex],
-      componentSizeEv: KnownSize[FieldList]
+      componentSizeEv: KnownSize[FieldList],
+      listContainsComponent: Selector[ComponentList, C]
     ): HasComponent[G, C] = new HasComponent[G, C] {
       val componentIndex = componentIndexEv()
       val componentSize  = componentSizeEv.asInt
@@ -744,6 +743,7 @@ object Graph {
     val componentSize: Int
     val fieldOffset: Int
   }
+  // TODO [AA] Does this ever check if FieldList contains the field?
   object HasComponentField {
     implicit def instance[
       G <: Graph,
@@ -754,7 +754,8 @@ object Graph {
       implicit
       ev1: Component.Field.List.Aux[G, C, FieldList],
       evx: HasComponent[G, C],
-      fieldOffsetEv: SizeUntil[F, FieldList]
+      fieldOffsetEv: SizeUntil[F, FieldList],
+      containsField: Selector[FieldList, F]
     ): HasComponentField[G, C, F] = new HasComponentField[G, C, F] {
       val componentIndex = evx.componentIndex
       val componentSize  = evx.componentSize

--- a/common/graph/src/main/scala/org/enso/graph/Graph.scala
+++ b/common/graph/src/main/scala/org/enso/graph/Graph.scala
@@ -370,10 +370,10 @@ object Graph {
       * encoded having the following type `Refined[Shape, App, Node]`.
       */
     @newtype
-    final case class Refined[C <: Component.Field, Spec, T](wrapped: T)
+    final case class Refined[F <: Component.Field, Spec, T](wrapped: T)
     object Refined {
-      implicit def unwrap[C <: Component.Field, S, T](
-        t: Refined[C, S, T]
+      implicit def unwrap[F <: Component.Field, S, T](
+        t: Refined[F, S, T]
       ): T = { t.wrapped }
     }
 

--- a/common/graph/src/main/scala/org/enso/graph/Graph.scala
+++ b/common/graph/src/main/scala/org/enso/graph/Graph.scala
@@ -743,7 +743,6 @@ object Graph {
     val componentSize: Int
     val fieldOffset: Int
   }
-  // TODO [AA] Does this ever check if FieldList contains the field?
   object HasComponentField {
     implicit def instance[
       G <: Graph,

--- a/common/graph/src/main/scala/org/enso/graph/Graph.scala
+++ b/common/graph/src/main/scala/org/enso/graph/Graph.scala
@@ -375,6 +375,8 @@ object Graph {
       implicit def unwrap[F <: Component.Field, S, T](
         t: Refined[F, S, T]
       ): T = { t.wrapped }
+
+      def wrap[F <: Component.Field, S, T](t: T): Refined[F, S, T] = Refined(t)
     }
 
     // === List ===

--- a/common/graph/src/main/scala/org/enso/graph/Graph.scala
+++ b/common/graph/src/main/scala/org/enso/graph/Graph.scala
@@ -372,11 +372,12 @@ object Graph {
     @newtype
     final case class Refined[F <: Component.Field, Spec, T](wrapped: T)
     object Refined {
-      implicit def unwrap[F <: Component.Field, S, T](
+      implicit def unwrap[F <: Component.Field, S <: F, T](
         t: Refined[F, S, T]
       ): T = { t.wrapped }
 
-      def wrap[F <: Component.Field, S, T](t: T): Refined[F, S, T] = Refined(t)
+      def wrap[F <: Component.Field, S <: F, T](t: T): Refined[F, S, T] =
+        Refined(t)
     }
 
     // === List ===

--- a/common/graph/src/main/scala/org/enso/graph/Graph.scala
+++ b/common/graph/src/main/scala/org/enso/graph/Graph.scala
@@ -19,6 +19,8 @@ import shapeless.nat._
  *    as much as possible.
  *  - Basic equality testing (that should be overridden as needed).
  *  - An ability to define fields that store complex data such as `String`.
+ *  - Add a `Default` typeclass, and ensure that all component fields are
+ *    instances of it. Fields should then be initialised using it.
  */
 
 /** This file contains the implementation of an incredibly generic graph.

--- a/common/graph/src/main/scala/org/enso/graph/definition/Macro.scala
+++ b/common/graph/src/main/scala/org/enso/graph/definition/Macro.scala
@@ -277,7 +277,7 @@ object Macro {
               $graphTermName.Component.Ref(
                 graph.unsafeReadFieldByIndex[C, $enclosingTypeName](
                   $graphTermName.Component.Refined.unwrap(node),
-                  $index
+                  ${index + 1}
                 )
               )
             }
@@ -334,7 +334,7 @@ object Macro {
               $graphTermName.Component.Ref(
                 graph.unsafeReadFieldByIndex[C, $enclosingTypeName](
                   $graphTermName.Component.Refined.unwrap(node).ix,
-                  $index
+                  ${index + 1}
                 )
               )
             }
@@ -343,7 +343,7 @@ object Macro {
         }
       }
 
-      /** Generates a setter for an element of a non-variant field.
+      /** Generates a setter for an element of field.
         *
         * @param paramDef the definition of the subfield
         * @param enclosingTypeName the name of the field type
@@ -388,7 +388,7 @@ object Macro {
             ): Unit = {
               graph.unsafeWriteFieldByIndex[C, $enclosingTypeName](
                 $graphTermName.Component.Refined.unwrap(node).ix,
-                $index,
+                ${index + 1},
                 value
               )
             }
@@ -441,7 +441,7 @@ object Macro {
             ): Unit = {
               graph.unsafeWriteFieldByIndex[C, $enclosingTypeName](
                 $graphTermName.Component.Refined.unwrap(node).ix,
-                $index,
+                ${index + 1},
                 value.ix
               )
             }

--- a/common/graph/src/main/scala/org/enso/graph/definition/Macro.scala
+++ b/common/graph/src/main/scala/org/enso/graph/definition/Macro.scala
@@ -230,7 +230,11 @@ object Macro {
         }
       }
 
-      /** Generates a getter for an element of a non-variant field.
+      /** Generates a getter for an element of a field.
+        *
+        * In the case where the field is _not_ simple, the subfield offsets are
+        * all incremented by one, to account for the fact that the first index
+        * in a non-simple (variant) field encodes the variant branch.
         *
         * @param paramDef the definition of the subfield
         * @param enclosingTypeName the name of the field type
@@ -344,6 +348,10 @@ object Macro {
       }
 
       /** Generates a setter for an element of field.
+        *
+        * In the case where the field is _not_ simple, the subfield offsets are
+        * all incremented by one, to account for the fact that the first index
+        * in a non-simple (variant) field encodes the variant branch.
         *
         * @param paramDef the definition of the subfield
         * @param enclosingTypeName the name of the field type
@@ -459,12 +467,6 @@ object Macro {
         */
       def makeTypeAccessorName(fieldName: TypeName): String = {
         StringUtils.uncapitalize(fieldName.toString)
-//        val matcher = "([A-Z])(.*)".r
-//
-//        matcher.findFirstMatchIn(fieldName.toString) match {
-//          case Some(t) => s"${t.group(1).toLowerCase()}${t.group(2)}"
-//          case None    => fieldName.toString.toLowerCase
-//        }
       }
 
       /** Generates accessor methods for the 'value class', the one that can
@@ -527,7 +529,7 @@ object Macro {
       }
 
       /** Determines whether the parameter definition is defining an opaque
-        * type. An opaque type is one not stored in the graph represntation.
+        * type. An opaque type is one not stored in the graph representation.
         *
         * @param paramDef the definition to check
         * @return `true` if `paramDef` defines an opauqe type, otherwise `false`

--- a/common/graph/src/test/scala/org/enso/graph/GraphTest.scala
+++ b/common/graph/src/test/scala/org/enso/graph/GraphTest.scala
@@ -95,7 +95,7 @@ class GraphTest extends FlatSpec with Matchers {
       case GraphImpl.Node.Shape.App.any(n1) => n1.fn
     }
 
-    refinedResult shouldEqual 1
+    refinedResult shouldEqual 0
   }
 
   "Component fields" can "be accessed properly" in {

--- a/common/graph/src/test/scala/org/enso/graph/GraphTestDefinition.scala
+++ b/common/graph/src/test/scala/org/enso/graph/GraphTestDefinition.scala
@@ -175,7 +175,7 @@ object GraphTestDefinition {
 //              PrimGraph.Component.Ref(
 //                graph.primUnsafeReadFieldByIndex[C, Shape](
 //                  PrimGraph.Component.Refined.unwrap(node).ix,
-//                  0
+//                  1
 //                )
 //              )
 //
@@ -185,7 +185,7 @@ object GraphTestDefinition {
 //            ): Unit =
 //              graph.primUnsafeWriteFieldByIndex[C, Shape](
 //                PrimGraph.Component.Refined.unwrap(node).ix,
-//                0,
+//                1,
 //                value.ix
 //              )
 //
@@ -196,7 +196,7 @@ object GraphTestDefinition {
 //              PrimGraph.Component.Ref(
 //                graph.primUnsafeReadFieldByIndex[C, Shape](
 //                  PrimGraph.Component.Refined.unwrap(node).ix,
-//                  1
+//                  2
 //                )
 //              )
 //
@@ -206,7 +206,7 @@ object GraphTestDefinition {
 //            ): Unit =
 //              graph.primUnsafeWriteFieldByIndex[C, Shape](
 //                PrimGraph.Component.Refined.unwrap(node).ix,
-//                1,
+//                2,
 //                value.ix
 //              )
 //
@@ -267,7 +267,7 @@ object GraphTestDefinition {
 //              PrimGraph.Component.Ref(
 //                graph.primUnsafeReadFieldByIndex[C, Shape](
 //                  PrimGraph.Component.Refined.unwrap(node).ix,
-//                  0
+//                  1
 //                )
 //              )
 //
@@ -277,7 +277,7 @@ object GraphTestDefinition {
 //            ): Unit =
 //              graph.primUnsafeWriteFieldByIndex[C, Shape](
 //                PrimGraph.Component.Refined.unwrap(node).ix,
-//                0,
+//                2,
 //                value.ix
 //              )
 //
@@ -286,11 +286,7 @@ object GraphTestDefinition {
 //              ev: PrimGraph.HasComponentField[G, C, Shape]
 //            ): CentreVal[G] = {
 //              CentreVal(
-//                PrimGraph.Component.Ref(
-//                  graph.primUnsafeReadFieldByIndex[C, Shape](
-//                    PrimGraph.Component.Refined.unwrap(node).ix,
-//                    0
-//                  )
+//                this.fn
 //                )
 //              )
 //            }
@@ -299,11 +295,7 @@ object GraphTestDefinition {
 //              implicit graph: PrimGraph.GraphData[G],
 //              ev: PrimGraph.HasComponentField[G, C, Shape]
 //            ): Unit = {
-//              graph.primUnsafeWriteFieldByIndex[C, Shape](
-//                PrimGraph.Component.Refined.unwrap(node).ix,
-//                0,
-//                value.fn.ix
-//              )
+//              this.fn = value.fn
 //            }
 //          }
 //        }
@@ -364,7 +356,7 @@ object GraphTestDefinition {
 //              PrimGraph.Component.Ref(
 //                graph.primUnsafeReadFieldByIndex[C, Shape](
 //                  PrimGraph.Component.Refined.unwrap(node).ix,
-//                  0 // as the other field is opaque
+//                  1 // as the other field is opaque
 //                )
 //              )
 //            }
@@ -375,7 +367,7 @@ object GraphTestDefinition {
 //            ): Unit = {
 //              graph.primUnsafeWriteFieldByIndex[C, Shape](
 //                PrimGraph.Component.Refined.unwrap(node).ix,
-//                0,
+//                1,
 //                value.ix
 //              )
 //            }

--- a/common/graph/src/test/scala/org/enso/graph/GraphTestDefinition.scala
+++ b/common/graph/src/test/scala/org/enso/graph/GraphTestDefinition.scala
@@ -173,7 +173,7 @@ object GraphTestDefinition {
 //              ev: PrimGraph.HasComponentField[G, C, Shape]
 //            ): Edge[G] =
 //              PrimGraph.Component.Ref(
-//                graph.primUnsafeReadField[C, Shape](
+//                graph.primUnsafeReadFieldByIndex[C, Shape](
 //                  PrimGraph.Component.Refined.unwrap(node).ix,
 //                  0
 //                )
@@ -183,7 +183,7 @@ object GraphTestDefinition {
 //              implicit graph: PrimGraph.GraphData[G],
 //              ev: PrimGraph.HasComponentField[G, C, Shape]
 //            ): Unit =
-//              graph.primUnsafeWriteField[C, Shape](
+//              graph.primUnsafeWriteFieldByIndex[C, Shape](
 //                PrimGraph.Component.Refined.unwrap(node).ix,
 //                0,
 //                value.ix
@@ -194,7 +194,7 @@ object GraphTestDefinition {
 //              ev: PrimGraph.HasComponentField[G, C, Shape]
 //            ): Edge[G] =
 //              PrimGraph.Component.Ref(
-//                graph.primUnsafeReadField[C, Shape](
+//                graph.primUnsafeReadFieldByIndex[C, Shape](
 //                  PrimGraph.Component.Refined.unwrap(node).ix,
 //                  1
 //                )
@@ -204,7 +204,7 @@ object GraphTestDefinition {
 //              implicit graph: PrimGraph.GraphData[G],
 //              ev: PrimGraph.HasComponentField[G, C, Shape]
 //            ): Unit =
-//              graph.primUnsafeWriteField[C, Shape](
+//              graph.primUnsafeWriteFieldByIndex[C, Shape](
 //                PrimGraph.Component.Refined.unwrap(node).ix,
 //                1,
 //                value.ix
@@ -265,7 +265,7 @@ object GraphTestDefinition {
 //              ev: PrimGraph.HasComponentField[G, C, Shape]
 //            ): Edge[G] =
 //              PrimGraph.Component.Ref(
-//                graph.primUnsafeReadField[C, Shape](
+//                graph.primUnsafeReadFieldByIndex[C, Shape](
 //                  PrimGraph.Component.Refined.unwrap(node).ix,
 //                  0
 //                )
@@ -275,7 +275,7 @@ object GraphTestDefinition {
 //              implicit graph: PrimGraph.GraphData[G],
 //              ev: PrimGraph.HasComponentField[G, C, Shape]
 //            ): Unit =
-//              graph.primUnsafeWriteField[C, Shape](
+//              graph.primUnsafeWriteFieldByIndex[C, Shape](
 //                PrimGraph.Component.Refined.unwrap(node).ix,
 //                0,
 //                value.ix
@@ -287,7 +287,7 @@ object GraphTestDefinition {
 //            ): CentreVal[G] = {
 //              CentreVal(
 //                PrimGraph.Component.Ref(
-//                  graph.primUnsafeReadField[C, Shape](
+//                  graph.primUnsafeReadFieldByIndex[C, Shape](
 //                    PrimGraph.Component.Refined.unwrap(node).ix,
 //                    0
 //                  )
@@ -299,7 +299,7 @@ object GraphTestDefinition {
 //              implicit graph: PrimGraph.GraphData[G],
 //              ev: PrimGraph.HasComponentField[G, C, Shape]
 //            ): Unit = {
-//              graph.primUnsafeWriteField[C, Shape](
+//              graph.primUnsafeWriteFieldByIndex[C, Shape](
 //                PrimGraph.Component.Refined.unwrap(node).ix,
 //                0,
 //                value.fn.ix
@@ -362,7 +362,7 @@ object GraphTestDefinition {
 //              ev: PrimGraph.HasComponentField[G, C, Shape]
 //            ): Edge[G] = {
 //              PrimGraph.Component.Ref(
-//                graph.primUnsafeReadField[C, Shape](
+//                graph.primUnsafeReadFieldByIndex[C, Shape](
 //                  PrimGraph.Component.Refined.unwrap(node).ix,
 //                  0 // as the other field is opaque
 //                )
@@ -373,7 +373,7 @@ object GraphTestDefinition {
 //              implicit graph: PrimGraph.GraphData[G],
 //              ev: PrimGraph.HasComponentField[G, C, Shape]
 //            ): Unit = {
-//              graph.primUnsafeWriteField[C, Shape](
+//              graph.primUnsafeWriteFieldByIndex[C, Shape](
 //                PrimGraph.Component.Refined.unwrap(node).ix,
 //                0,
 //                value.ix
@@ -422,7 +422,7 @@ object GraphTestDefinition {
       //            ev: PrimGraph.HasComponentField[G, C, ParentLink]
       //          ): Edge[G] = {
       //            PrimGraph.Component.Ref(
-      //              graph.unsafeReadField[C, ParentLink](node.ix, 0)
+      //              graph.unsafeReadFieldByIndex[C, ParentLink](node.ix, 0)
       //            )
       //          }
       //
@@ -430,7 +430,7 @@ object GraphTestDefinition {
       //            implicit graph: PrimGraph.GraphData[G],
       //            ev: PrimGraph.HasComponentField[G, C, ParentLink]
       //          ): Unit = {
-      //            graph.unsafeWriteField[C, ParentLink](node.ix, 0, value.ix)
+      //            graph.unsafeWriteFieldByIndex[C, ParentLink](node.ix, 0, value.ix)
       //          }
       //
       //          def parentLink(
@@ -480,18 +480,18 @@ object GraphTestDefinition {
 //          def line_=(value: Int)(
 //            implicit graph: PrimGraph.GraphData[G],
 //            ev: PrimGraph.HasComponentField[G, C, Location]
-//          ): Unit = graph.unsafeWriteField[C, Location](node.ix, 0, value)
+//          ): Unit = graph.unsafeWriteFieldByIndex[C, Location](node.ix, 0, value)
 //
 //          def column(
 //            implicit graph: PrimGraph.GraphData[G],
 //            ev: PrimGraph.HasComponentField[G, C, Location]
 //          ): Int =
-//            graph.unsafeReadField[C, Location](node.ix, 1)
+//            graph.unsafeReadFieldByIndex[C, Location](node.ix, 1)
 //
 //          def column_=(value: Int)(
 //            implicit graph: PrimGraph.GraphData[G],
 //            ev: PrimGraph.HasComponentField[G, C, Location]
-//          ): Unit = graph.unsafeWriteField[C, Location](node.ix, 1, value)
+//          ): Unit = graph.unsafeWriteFieldByIndex[C, Location](node.ix, 1, value)
 //
 //          def location(
 //            implicit graph: PrimGraph.GraphData[G],
@@ -593,26 +593,28 @@ object GraphTestDefinition {
 //            ev: PrimGraph.HasComponentField[G, C, Shape]
 //          ): Node[G] =
 //            PrimGraph.Component.Ref(
-//              graph.unsafeReadField[C, Shape](node.ix, 0)
+//              graph.unsafeReadFieldByIndex[C, Shape](node.ix, 0)
 //            )
 //
 //          def source_=(value: Node[G])(
 //            implicit graph: PrimGraph.GraphData[G],
 //            ev: PrimGraph.HasComponentField[G, C, Shape]
-//          ): Unit = graph.unsafeWriteField[C, Shape](node.ix, 0, value.ix)
+//          ): Unit =
+//            graph.unsafeWriteFieldByIndex[C, Shape](node.ix, 0, value.ix)
 //
 //          def target(
 //            implicit graph: PrimGraph.GraphData[G],
 //            ev: PrimGraph.HasComponentField[G, C, Shape]
 //          ): Node[G] =
 //            PrimGraph.Component.Ref(
-//              graph.unsafeReadField[C, Shape](node.ix, 1)
+//              graph.unsafeReadFieldByIndex[C, Shape](node.ix, 1)
 //            )
 //
 //          def target_=(value: Node[G])(
 //            implicit graph: PrimGraph.GraphData[G],
 //            ev: PrimGraph.HasComponentField[G, C, Shape]
-//          ): Unit = graph.unsafeWriteField[C, Shape](node.ix, 1, value.ix)
+//          ): Unit =
+//            graph.unsafeWriteFieldByIndex[C, Shape](node.ix, 1, value.ix)
 //
 //          def shape(
 //            implicit graph: PrimGraph.GraphData[G],

--- a/common/syntax/specialization/shared/src/test/scala/org/enso/syntax/text/DocParserTests.scala
+++ b/common/syntax/specialization/shared/src/test/scala/org/enso/syntax/text/DocParserTests.scala
@@ -18,7 +18,6 @@ class DocParserTests extends FlatSpec with Matchers {
     val output = DocParser.run(input)
     output match {
       case Result(_, Result.Success(value)) =>
-        pprint.pprintln(value)
         assert(value == result)
         assert(value.show() == new Reader(input).toString())
       case _ =>

--- a/engine/core-definition/src/main/scala/org/enso/core/CoreGraph.scala
+++ b/engine/core-definition/src/main/scala/org/enso/core/CoreGraph.scala
@@ -4,7 +4,6 @@ import org.enso.graph.definition.Macro.{component, field, genGraph, opaque}
 import org.enso.graph.{Sized, VariantIndexed, Graph => PrimGraph}
 import shapeless.{::, HNil}
 
-// TODO [AA] More detailed semantic descriptions for each node shape in future.
 object CoreGraph {
   @genGraph object Definition {
 
@@ -512,6 +511,44 @@ object CoreGraph {
       // ======================================================================
       // === Utility Functions ================================================
       // ======================================================================
+
+      /** Adds a link as a parent of the provided node.
+        *
+        * This should _only_ be used when the [[target]] field of [[link]]
+        * points to [[node]].
+        *
+        * @param node the node to add a parent to
+        * @param link the link to add as a parent
+        * @param graph the graph in which this takes place
+        * @param map the graph's parent storage
+        */
+      def addParent(
+        node: Node[CoreGraph],
+        link: Link[CoreGraph]
+      )(
+        implicit graph: PrimGraph.GraphData[CoreGraph],
+        map: ParentStorage
+      ): Unit = {
+        import Node.ParentLinks._
+        node.parents = node.parents :+ link.ix
+      }
+
+      /** Adds a node to the graph with its shape already set to a given shape.
+        *
+        * @param graph the graph to add the node to
+        * @param ev evidence that the variant field is indexed
+        * @tparam V the shape to set the node to
+        * @return a refined node reference
+        */
+      def addRefined[V <: Node.Shape](
+        implicit graph: PrimGraph.GraphData[CoreGraph],
+        ev: VariantIndexed[Node.Shape, V]
+      ): PrimGraph.Component.Refined[Node.Shape, V, Node[CoreGraph]] = {
+        val node = graph.addNode()
+
+        setShape[V](node)
+        PrimGraph.Component.Refined(node)
+      }
 
       /** Sets the shape of the provided [[node]] to [[Shape]].
         *

--- a/engine/core-definition/src/main/scala/org/enso/core/CoreGraph.scala
+++ b/engine/core-definition/src/main/scala/org/enso/core/CoreGraph.scala
@@ -540,6 +540,7 @@ object CoreGraph {
         map: ParentStorage
       ): Unit = {
         import Node.ParentLinks._
+
         node.parents = node.parents :+ link.ix
       }
 
@@ -557,7 +558,7 @@ object CoreGraph {
         val node = graph.addNode()
 
         setShape[V](node)
-        PrimGraph.Component.Refined(node)
+        PrimGraph.Component.Refined[Node.Shape, V, Node[CoreGraph]](node)
       }
 
       /** Sets the shape of the provided [[node]] to [[Shape]].

--- a/engine/core-definition/src/main/scala/org/enso/core/CoreGraph.scala
+++ b/engine/core-definition/src/main/scala/org/enso/core/CoreGraph.scala
@@ -175,7 +175,7 @@ object CoreGraph {
         /** An import statement.
           *
           * @param segments the segments of the import path, represented as a
-          *                 [[NameLiteral]].
+          *                 [[MetaList]].
           */
         case class Import(segments: Link[G])
 
@@ -198,7 +198,8 @@ object CoreGraph {
         /** An expanded-form type definition, with a body.
           *
           * @param name the name of the aggregate type
-          * @param typeParams the type parameters to the definition
+          * @param typeParams the type parameters to the definition, as a
+          *                   [[MetaList]] of bindings
           * @param body       the body of the type definition, represented as a
           *                   [[MetaList]] of bindings
           */
@@ -210,7 +211,7 @@ object CoreGraph {
 
         // === Typing =========================================================
 
-        /** A type signature.
+        /** The ascription of a type to a value.
           *
           * @param typed the expression being ascribed a type
           * @param sig the signature being ascribed to [[typed]]

--- a/engine/core-definition/src/main/scala/org/enso/core/CoreGraph.scala
+++ b/engine/core-definition/src/main/scala/org/enso/core/CoreGraph.scala
@@ -506,7 +506,12 @@ object CoreGraph {
           */
         case class SyntaxError(errorNode: Link[G])
 
-        // TODO [AA] Fill in the error types as they become evident
+        /** Returned on an attempt to construct erroneous core.
+          *
+          * @param erroneousCore a [[MetaList]] containing the one-or-more core
+          *                      nodes that were in an incorrect format
+          */
+        case class ConstructionError(erroneousCore: Link[G])
       }
 
       // ======================================================================
@@ -576,8 +581,9 @@ object CoreGraph {
         node: Node[CoreGraph]
       )(implicit graph: PrimGraph.GraphData[CoreGraph]): Boolean = {
         node match {
-          case Shape.SyntaxError.any(_) => true
-          case _                        => false
+          case Shape.SyntaxError.any(_)       => true
+          case Shape.ConstructionError.any(_) => true
+          case _                              => false
         }
       }
 

--- a/engine/core-definition/src/main/scala/org/enso/core/CoreGraph.scala
+++ b/engine/core-definition/src/main/scala/org/enso/core/CoreGraph.scala
@@ -3,6 +3,7 @@ package org.enso.core
 import org.enso.graph.definition.Macro.{component, field, genGraph, opaque}
 import org.enso.graph.{Sized, VariantIndexed, Graph => PrimGraph}
 import shapeless.{::, HNil}
+import org.enso.syntax.text.AST
 
 object CoreGraph {
   @genGraph object Definition {
@@ -36,6 +37,9 @@ object CoreGraph {
       * that has the containing node as its `target` field.
       */
     @opaque case class Parent(opaque: Vector[Int])
+
+    /** Storage for raw AST nodes. */
+    @opaque case class Ast(opaque: AST)
 
     // ========================================================================
     // === Node ===============================================================
@@ -446,7 +450,7 @@ object CoreGraph {
         /** A case branch.
           *
           * All case patterns will initially be desugared to a
-          * [[StructuralMatch]] and will be refined during further desugaring
+          * [[StructuralPattern]] and will be refined during further desugaring
           * passes, some of which may depend on type checking.
           *
           * @param pattern the pattern to match the scrutinee against
@@ -459,7 +463,7 @@ object CoreGraph {
           * @param matchExpression the expression representing the possible
           *                        structure of the scrutinee
           */
-        case class StructuralMatch(matchExpression: Link[G])
+        case class StructuralPattern(matchExpression: Link[G])
 
         /** A pattern that matches on the scrutinee purely based on a type
           * subsumption judgement.
@@ -467,7 +471,7 @@ object CoreGraph {
           * @param matchExpression the expression representing the possible type
           *                        of the scrutinee
           */
-        case class TypeMatch(matchExpression: Link[G])
+        case class TypePattern(matchExpression: Link[G])
 
         /** A pattern that matches on the scrutinee based on a type subsumption
           * judgement and assigns a new name to it for use in the branch.
@@ -475,10 +479,10 @@ object CoreGraph {
           * @param matchExpression the expression representing the possible type
           *                        of the scrutinee, and its new name
           */
-        case class NamedMatch(matchExpression: Link[G])
+        case class NamedPattern(matchExpression: Link[G])
 
         /** A pattern that matches on any scrutinee. */
-        case class FallbackMatch()
+        case class FallbackPattern()
 
         // === Comments =======================================================
 
@@ -502,9 +506,9 @@ object CoreGraph {
 
         /** A syntax error.
           *
-          * @param errorNode the node representation of the syntax error
+          * @param errorAst the raw AST representation of the syntax error
           */
-        case class SyntaxError(errorNode: Link[G])
+        case class SyntaxError(errorAst: OpaqueData[AST, AstStorage])
 
         /** Returned on an attempt to construct erroneous core.
           *

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
@@ -142,8 +142,7 @@ object Core {
           CoreDef.Node.addParent(head, headLink)
           CoreDef.Node.addParent(tail, tailLink)
 
-          // Clobbering the variant field
-//          node.head     = headLink
+          node.head     = headLink
           node.tail     = tailLink
           node.location = Constants.invalidLocation
           node.parents  = Vector()

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
@@ -393,7 +393,7 @@ object Core {
 
           Right(node)
         } else {
-          val errList = Utility.coreListFrom(NonEmptyList(segments, List()))
+          val errList = Utility.coreListFrom(segments)
           val errNode = constructionError(errList, segments.location)
 
           Left(errNode)
@@ -1595,13 +1595,6 @@ object Core {
       }
     }
 
-    /** Exceptions used by the core graph. */
-    object Exception {
-      class InvalidListConstruction(val message: String) extends Throwable
-      class NotValidList(val message: String)            extends Throwable
-      class NotBinding(val message: String)              extends Throwable
-    }
-
     /** Useful conversions between types that are used for Core nodes. */
     object Conversions {
 
@@ -1671,7 +1664,7 @@ object Core {
 
         // Note [Unsafety in List Construction]
         val unrefinedMetaList =
-          nodesWithNil.reduceLeft(
+          nodesWithNil.toList.reduceRight(
             (l, r) => New.metaList(l, r).right.get.wrapped
           )
 
@@ -1680,7 +1673,7 @@ object Core {
       }
 
       /* Note [Unsafety in List Construction]
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      * This makes use of internal implementation details to know that calling
      * `right` here is always safe. The error condition for the `metaList`
      * constructor occurs when the `tail` argument doesn't point to a valid
@@ -1690,6 +1683,11 @@ object Core {
      * Furthermore, we can unconditionally refine the type as we know that the
      * node we get back must be a MetaList, and we know that the input is not
      * empty.
+     *
+     * It also bears noting that for this to be safe we _must_ use a right
+     * reduce, rather than a left reduce, otherwise the elements will not be
+     * constructed properly. This does, however, mean that this can stack
+     * overflow when provided with too many elements.
      */
     }
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
@@ -19,12 +19,10 @@ import scala.util.{Failure, Success, Try}
   */
 class Core {
   // TODO [AA] Need to present a nice interface
-  //  - Assignment to children must update parent links for children.
-  //  - Smart Constructors must handle the awful creation dance.
-  //  - Accessors should look _through_ the edge, but there should still be a
-  //    way to get the edge
   //  - Copy subsection of graph
   //  - Check equality for subsection of graph
+  //  - Improve the way construction errors are handled (use Either and an err
+  //    node on failure)
 
   import CoreDef.Link.Shape._
   import CoreDef.Node.Location._
@@ -320,6 +318,429 @@ class Core {
         }
       }
 
+      /** Creates a node representing an import statement.
+        *
+        * @param segments the segments of the import path
+        * @param location the source location of the import statement
+        * @return a node representing the import statement
+        */
+      def `import`(
+        segments: CoreNode,
+        location: AstLocation
+      ): Try[RefinedNode[NodeShape.Import]] = {
+        if (Utility.isListNode(segments)) {
+          val node = CoreDef.Node.addRefined[NodeShape.Import]
+
+          val segmentsLink = Link.make(node, segments)
+
+          CoreDef.Node.addParent(segments, segmentsLink)
+
+          node.segments = segmentsLink
+          node.location = location
+
+          Success(node)
+        } else {
+          Failure(
+            new Exception.NotValidList(
+              s"Import segments must be a valid meta list but node " +
+              s"at index ${segments.ix} is not."
+            )
+          )
+        }
+      }
+
+      /** Creates a node representing a top-level binding.
+        *
+        * This node does not represent the binding itself, but only serves to
+        * represent the connection between the binding and its containing
+        * module.
+        *
+        * @param module the module in which [[binding]] is defined
+        * @param binding the binding itself
+        * @param location the source location of the binding
+        * @return a node representing the top-level binding
+        */
+      def topLevelBinding(
+        module: CoreNode,
+        binding: CoreNode,
+        location: AstLocation
+      ): Try[RefinedNode[NodeShape.TopLevelBinding]] = {
+        binding match {
+          case NodeShape.Binding.any(_) =>
+            val node = CoreDef.Node.addRefined[NodeShape.TopLevelBinding]
+
+            val moduleLink  = Link.make(node, module)
+            val bindingLink = Link.make(node, binding)
+
+            CoreDef.Node.addParent(module, moduleLink)
+            CoreDef.Node.addParent(binding, bindingLink)
+
+            node.module   = moduleLink
+            node.binding  = bindingLink
+            node.location = location
+
+            Success(node)
+          case _ =>
+            Failure(
+              new Exception.NotBinding(
+                s"Node passed as `binding` must have" +
+                s"binding shape but node at ${binding.ix} does not."
+              )
+            )
+        }
+      }
+
+      // === Type Definitions =================================================
+
+      /** Creates a node representing an atom definition.
+        *
+        * @param name the atom's name
+        * @param args the atom's arguments
+        * @param location the source location of the atom
+        * @return a node representing an atom definition for [[name]]
+        */
+      def atomDef(
+        name: CoreNode,
+        args: CoreNode,
+        location: AstLocation
+      ): Try[RefinedNode[NodeShape.AtomDef]] = {
+        if (Utility.isListNode(name)) {
+          val node = CoreDef.Node.addRefined[NodeShape.AtomDef]
+
+          val nameLink = Link.make(node, name)
+          val argsLink = Link.make(node, args)
+
+          CoreDef.Node.addParent(name, nameLink)
+          CoreDef.Node.addParent(args, argsLink)
+
+          node.name     = nameLink
+          node.args     = argsLink
+          node.location = location
+
+          Success(node)
+        } else {
+          Failure(
+            new Exception.NotValidList(
+              s"Args must be provided as a valid list, but the node at " +
+              s"${args.ix} is not."
+            )
+          )
+        }
+      }
+
+      /** Creates a node representing a complex type definition.
+        *
+        * @param name the name of the type definition
+        * @param typeParams the type parameters
+        * @param body the body of the definition
+        * @param location the source location of the definition
+        * @return a node representing the type definition for [[name]]
+        */
+      def typeDef(
+        name: CoreNode,
+        typeParams: CoreNode,
+        body: CoreNode,
+        location: AstLocation
+      ): Try[RefinedNode[NodeShape.TypeDef]] = {
+        if (Utility.isListNode(typeParams) && Utility.isListNode(body)) {
+          val node = CoreDef.Node.addRefined[NodeShape.TypeDef]
+
+          val nameLink       = Link.make(node, name)
+          val typeParamsLink = Link.make(node, typeParams)
+          val bodyLink       = Link.make(node, body)
+
+          CoreDef.Node.addParent(name, nameLink)
+          CoreDef.Node.addParent(typeParams, typeParamsLink)
+          CoreDef.Node.addParent(body, bodyLink)
+
+          node.name       = nameLink
+          node.typeParams = typeParamsLink
+          node.body       = bodyLink
+          node.location   = location
+
+          Success(node)
+        } else {
+          Failure(
+            new Exception.NotValidList(
+              s"Type params and body must both be valid meta lists, but the " +
+              s"node at ${typeParams.ix} or ${body.ix} is not."
+            )
+          )
+        }
+      }
+
+      // === Typing ===========================================================
+
+      /** Creates a node representing the ascription of a type to a value.
+        *
+        * The signature is an entirely arbitrary Enso expression, as required by
+        * the language's syntactic unification.
+        *
+        * @param typed the expression being ascribed a type
+        * @param sig the type being ascribed to [[typed]]
+        * @param location the source location of the ascription
+        * @return a node representing the ascription of the type represented by
+        *         [[sig]] to [[typed]]
+        */
+      def typeAscription(
+        typed: CoreNode,
+        sig: CoreNode,
+        location: AstLocation
+      ): RefinedNode[NodeShape.TypeAscription] = {
+        val node = CoreDef.Node.addRefined[NodeShape.TypeAscription]
+
+        val typedLink = Link.make(node, typed)
+        val sigLink   = Link.make(node, sig)
+
+        CoreDef.Node.addParent(typed, typedLink)
+        CoreDef.Node.addParent(sig, sigLink)
+
+        node.typed    = typedLink
+        node.sig      = sigLink
+        node.location = location
+
+        node
+      }
+
+      /** Creates a node representing the ascription of a monadic context to a
+        * value (using the `in` keyword).
+        *
+        * @param typed the expression being ascribed a context
+        * @param context the context being ascribed to [[typed]]
+        * @param location the source location of the ascription
+        * @return a node representing the ascription of the context [[context]]
+        *         to the expression [[typed]]
+        */
+      def contextAscription(
+        typed: CoreNode,
+        context: CoreNode,
+        location: AstLocation
+      ): RefinedNode[NodeShape.ContextAscription] = {
+        val node = CoreDef.Node.addRefined[NodeShape.ContextAscription]
+
+        val typedLink   = Link.make(node, typed)
+        val contextLink = Link.make(node, context)
+
+        CoreDef.Node.addParent(typed, typedLink)
+        CoreDef.Node.addParent(context, contextLink)
+
+        node.typed    = typedLink
+        node.context  = contextLink
+        node.location = location
+
+        node
+      }
+
+      /** Creates a node representing a typeset member.
+        *
+        * At most two of [[label]], [[memberType]] and [[value]] may be
+        * [[NodeShape.Empty]].
+        *
+        * @param label the label of the member, if provided
+        * @param memberType the type of the member, if provided
+        * @param value the value of the member, if provided
+        * @param location the source location of the member definition
+        * @return a node representing a typeset member called [[label]] with
+        *         type [[memberType]] and default value [[value]]
+        */
+      def typesetMember(
+        label: CoreNode,
+        memberType: CoreNode,
+        value: CoreNode,
+        location: AstLocation
+      ): RefinedNode[NodeShape.TypesetMember] = {
+        val node = CoreDef.Node.addRefined[NodeShape.TypesetMember]
+
+        val labelLink      = Link.make(node, label)
+        val memberTypeLink = Link.make(node, memberType)
+        val valueLink      = Link.make(node, value)
+
+        CoreDef.Node.addParent(label, labelLink)
+        CoreDef.Node.addParent(memberType, memberTypeLink)
+        CoreDef.Node.addParent(value, valueLink)
+
+        node.label      = labelLink
+        node.memberType = memberTypeLink
+        node.value      = valueLink
+        node.location   = location
+
+        node
+      }
+
+      /** Creates a node representing the typeset subsumption operator `<:`.
+        *
+        * This construct does not represent a user-facing language element at
+        * this time.
+        *
+        * @param left the left operand
+        * @param right the right operand
+        * @param location the location in the source to which the operator
+        *                 corresponds
+        * @return a node representing the judgement that [[left]] `<:` [[right]]
+        */
+      def typesetSubsumption(
+        left: CoreNode,
+        right: CoreNode,
+        location: AstLocation
+      ): RefinedNode[NodeShape.TypesetSubsumption] = {
+        val node = CoreDef.Node.addRefined[NodeShape.TypesetSubsumption]
+
+        val leftLink  = Link.make(node, left)
+        val rightLink = Link.make(node, right)
+
+        CoreDef.Node.addParent(left, leftLink)
+        CoreDef.Node.addParent(right, rightLink)
+
+        node.left     = leftLink
+        node.right    = rightLink
+        node.location = location
+
+        node
+      }
+
+      /** Creates a node representing the typeset equality operator `~`.
+        *
+        * This construct does not represent a user-facing language element at
+        * this time.
+        *
+        * @param left the left operand
+        * @param right the right operand
+        * @param location the location in the source to which the operator
+        *                 corresponds
+        * @return a node representing the judgement that [[left]] `~` [[right]]
+        */
+      def typesetEquality(
+        left: CoreNode,
+        right: CoreNode,
+        location: AstLocation
+      ): RefinedNode[NodeShape.TypesetEquality] = {
+        val node = CoreDef.Node.addRefined[NodeShape.TypesetEquality]
+
+        val leftLink  = Link.make(node, left)
+        val rightLink = Link.make(node, right)
+
+        CoreDef.Node.addParent(left, leftLink)
+        CoreDef.Node.addParent(right, rightLink)
+
+        node.left     = leftLink
+        node.right    = rightLink
+        node.location = location
+
+        node
+      }
+
+      /** Creates a node representing the typeset concatenation operator `,`.
+        *
+        * @param left the left operand
+        * @param right the right operand
+        * @param location the location in the source to which the operator
+        *                 corresponds
+        * @return a node representing the judgement of [[left]] `,` [[right]]
+        */
+      def typesetConcat(
+        left: CoreNode,
+        right: CoreNode,
+        location: AstLocation
+      ): RefinedNode[NodeShape.TypesetConcat] = {
+        val node = CoreDef.Node.addRefined[NodeShape.TypesetConcat]
+
+        val leftLink  = Link.make(node, left)
+        val rightLink = Link.make(node, right)
+
+        CoreDef.Node.addParent(left, leftLink)
+        CoreDef.Node.addParent(right, rightLink)
+
+        node.left     = leftLink
+        node.right    = rightLink
+        node.location = location
+
+        node
+      }
+
+      /** Creates a node representing the typeset union operator `|`.
+        *
+        * @param left the left operand
+        * @param right the right operand
+        * @param location the location in the source to which the operator
+        *                 corresponds
+        * @return a node representing the judgement of [[left]] `|` [[right]]
+        */
+      def typesetUnion(
+        left: CoreNode,
+        right: CoreNode,
+        location: AstLocation
+      ): RefinedNode[NodeShape.TypesetUnion] = {
+        val node = CoreDef.Node.addRefined[NodeShape.TypesetUnion]
+
+        val leftLink  = Link.make(node, left)
+        val rightLink = Link.make(node, right)
+
+        CoreDef.Node.addParent(left, leftLink)
+        CoreDef.Node.addParent(right, rightLink)
+
+        node.left     = leftLink
+        node.right    = rightLink
+        node.location = location
+
+        node
+      }
+
+      /** Creates a node representing the typeset intersection operator `&`.
+        *
+        * @param left the left operand
+        * @param right the right operand
+        * @param location the location in the source to which the operator
+        *                 corresponds
+        * @return a node representing the judgement of [[left]] `&` [[right]]
+        */
+      def typesetIntersection(
+        left: CoreNode,
+        right: CoreNode,
+        location: AstLocation
+      ): RefinedNode[NodeShape.TypesetIntersection] = {
+        val node = CoreDef.Node.addRefined[NodeShape.TypesetIntersection]
+
+        val leftLink  = Link.make(node, left)
+        val rightLink = Link.make(node, right)
+
+        CoreDef.Node.addParent(left, leftLink)
+        CoreDef.Node.addParent(right, rightLink)
+
+        node.left     = leftLink
+        node.right    = rightLink
+        node.location = location
+
+        node
+      }
+
+      /** Creates a node representing the typeset subtraction operator `\`.
+        *
+        * @param left the left operand
+        * @param right the right operand
+        * @param location the location in the source to which the operator
+        *                 corresponds
+        * @return a node representing the judgement of [[left]] `\` [[right]]
+        */
+      def typesetSubtraction(
+        left: CoreNode,
+        right: CoreNode,
+        location: AstLocation
+      ): RefinedNode[NodeShape.TypesetSubtraction] = {
+        val node = CoreDef.Node.addRefined[NodeShape.TypesetSubtraction]
+
+        val leftLink  = Link.make(node, left)
+        val rightLink = Link.make(node, right)
+
+        CoreDef.Node.addParent(left, leftLink)
+        CoreDef.Node.addParent(right, rightLink)
+
+        node.left     = leftLink
+        node.right    = rightLink
+        node.location = location
+
+        node
+      }
+
       // === Function =========================================================
 
       /** Creates a node representing a lambda expression, the `->` function
@@ -351,12 +772,45 @@ class Core {
 
         node
       }
+
+      def functionDef(
+        name: CoreNode,
+        args: CoreNode,
+        body: CoreNode,
+        location: AstLocation
+      ): Try[RefinedNode[NodeShape.FunctionDef]] = {
+        if (Utility.isListNode(args)) {
+          val node = CoreDef.Node.addRefined[NodeShape.FunctionDef]
+
+          val nameLink = Link.make(node, name)
+          val argsLink = Link.make(node, args)
+          val bodyLink = Link.make(node, body)
+
+          CoreDef.Node.addParent(name, nameLink)
+          CoreDef.Node.addParent(args, argsLink)
+          CoreDef.Node.addParent(body, bodyLink)
+
+          node.name     = nameLink
+          node.args     = argsLink
+          node.body     = bodyLink
+          node.location = location
+
+          Success(node)
+        } else {
+          Failure(
+            new Exception.NotValidList(
+              s"Args must be a valid meta list, but node at ${args.ix} is not."
+            )
+          )
+        }
+      }
     }
 
     /** Exceptions used by the core graph. */
     object Exception {
       class InvalidListConstruction(val message: String) extends Throwable
       class NotValidList(val message: String)            extends Throwable
+      class NotBinding(val message: String)              extends Throwable
     }
 
     /** Useful conversions between types that are used for Core nodes. */

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
@@ -68,7 +68,6 @@ class Core {
     /** Smart constructors to create nodes of various shapes. */
     //noinspection DuplicatedCode
     object Make {
-      import Node.Conversions._
 
       // === Base Shapes ======================================================
 
@@ -822,7 +821,7 @@ class Core {
         */
       def constructionError(
         erroneousCore: CoreNode,
-        location: AstLocation
+        location: Location
       ): RefinedNode[NodeShape.ConstructionError] = {
         val node = CoreDef.Node.addRefined[NodeShape.ConstructionError]
 
@@ -857,18 +856,6 @@ class Core {
         location: AstLocation
       ): CoreDef.Node.LocationVal[CoreGraph] = {
         CoreDef.Node.LocationVal(location.start, location.end)
-      }
-
-      /** Converts the location representation from [[Core]] into the one used
-        * by the parser.
-        *
-        * @param location the location from [[Core]]
-        * @return the parser representation of [[location]]
-        */
-      implicit def nodeLocationToAstLocation(
-        location: CoreDef.Node.LocationVal[CoreGraph]
-      ): AstLocation = {
-        AstLocation(location.sourceStart, location.sourceEnd)
       }
     }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
@@ -12,8 +12,12 @@ import org.enso.syntax.text.{AST, Location => AstLocation}
 import scala.annotation.tailrec
 
 // TODO [AA] Detailed semantic descriptions for each node shape in future.
+// TODO [AA] Refactor over time to remove as much boilerplate as possible.
 // TODO [AA] Eventually refactor graph macro generation so as to allow the
 //  trait-extension based approach to implicit imports.
+// TODO [AA] Need to present a nice interface
+//  - Copy subsection of graph
+//  - Check equality for subsection of graph
 
 /** [[Core]] is the sophisticated internal representation supported by the
   * compiler.
@@ -41,9 +45,6 @@ import scala.annotation.tailrec
   * using upper-case so as to signify that they construct a value.
   */
 class Core {
-  // TODO [AA] Need to present a nice interface
-  //  - Copy subsection of graph
-  //  - Check equality for subsection of graph
 
   // ==========================================================================
   // === Graph Storage ========================================================
@@ -156,9 +157,6 @@ object Core {
 
           val headLink = Link.New.Connected(node, head)
           val tailLink = Link.New.Connected(node, tail)
-
-          CoreDef.Node.addParent(head, headLink)
-          CoreDef.Node.addParent(tail, tailLink)
 
           node.head     = headLink
           node.tail     = tailLink
@@ -382,10 +380,6 @@ object Core {
           val importsLink     = Link.New.Connected(node, imports)
           val definitionsLink = Link.New.Connected(node, definitions)
 
-          CoreDef.Node.addParent(name, nameLink)
-          CoreDef.Node.addParent(imports, importsLink)
-          CoreDef.Node.addParent(definitions, definitionsLink)
-
           node.name        = nameLink
           node.imports     = importsLink
           node.definitions = definitionsLink
@@ -411,8 +405,6 @@ object Core {
           val node = CoreDef.Node.addRefined[NodeShape.Import]
 
           val segmentsLink = Link.New.Connected(node, segments)
-
-          CoreDef.Node.addParent(segments, segmentsLink)
 
           node.segments = segmentsLink
           node.location = location
@@ -451,9 +443,6 @@ object Core {
             val moduleLink  = Link.New.Connected(node, module)
             val bindingLink = Link.New.Connected(node, binding)
 
-            CoreDef.Node.addParent(module, moduleLink)
-            CoreDef.Node.addParent(binding, bindingLink)
-
             node.module   = moduleLink
             node.binding  = bindingLink
             node.location = location
@@ -487,9 +476,6 @@ object Core {
 
           val nameLink = Link.New.Connected(node, name)
           val argsLink = Link.New.Connected(node, args)
-
-          CoreDef.Node.addParent(name, nameLink)
-          CoreDef.Node.addParent(args, argsLink)
 
           node.name     = nameLink
           node.args     = argsLink
@@ -537,10 +523,6 @@ object Core {
           val typeParamsLink = Link.New.Connected(node, typeParams)
           val bodyLink       = Link.New.Connected(node, body)
 
-          CoreDef.Node.addParent(name, nameLink)
-          CoreDef.Node.addParent(typeParams, typeParamsLink)
-          CoreDef.Node.addParent(body, bodyLink)
-
           node.name       = nameLink
           node.typeParams = typeParamsLink
           node.body       = bodyLink
@@ -575,9 +557,6 @@ object Core {
         val typedLink = Link.New.Connected(node, typed)
         val sigLink   = Link.New.Connected(node, sig)
 
-        CoreDef.Node.addParent(typed, typedLink)
-        CoreDef.Node.addParent(sig, sigLink)
-
         node.typed    = typedLink
         node.sig      = sigLink
         node.location = location
@@ -605,9 +584,6 @@ object Core {
 
         val typedLink   = Link.New.Connected(node, typed)
         val contextLink = Link.New.Connected(node, context)
-
-        CoreDef.Node.addParent(typed, typedLink)
-        CoreDef.Node.addParent(context, contextLink)
 
         node.typed    = typedLink
         node.context  = contextLink
@@ -642,10 +618,6 @@ object Core {
         val memberTypeLink = Link.New.Connected(node, memberType)
         val valueLink      = Link.New.Connected(node, value)
 
-        CoreDef.Node.addParent(label, labelLink)
-        CoreDef.Node.addParent(memberType, memberTypeLink)
-        CoreDef.Node.addParent(value, valueLink)
-
         node.label      = labelLink
         node.memberType = memberTypeLink
         node.value      = valueLink
@@ -677,9 +649,6 @@ object Core {
         val leftLink  = Link.New.Connected(node, left)
         val rightLink = Link.New.Connected(node, right)
 
-        CoreDef.Node.addParent(left, leftLink)
-        CoreDef.Node.addParent(right, rightLink)
-
         node.left     = leftLink
         node.right    = rightLink
         node.location = location
@@ -710,9 +679,6 @@ object Core {
         val leftLink  = Link.New.Connected(node, left)
         val rightLink = Link.New.Connected(node, right)
 
-        CoreDef.Node.addParent(left, leftLink)
-        CoreDef.Node.addParent(right, rightLink)
-
         node.left     = leftLink
         node.right    = rightLink
         node.location = location
@@ -739,9 +705,6 @@ object Core {
 
         val leftLink  = Link.New.Connected(node, left)
         val rightLink = Link.New.Connected(node, right)
-
-        CoreDef.Node.addParent(left, leftLink)
-        CoreDef.Node.addParent(right, rightLink)
 
         node.left     = leftLink
         node.right    = rightLink
@@ -770,9 +733,6 @@ object Core {
         val leftLink  = Link.New.Connected(node, left)
         val rightLink = Link.New.Connected(node, right)
 
-        CoreDef.Node.addParent(left, leftLink)
-        CoreDef.Node.addParent(right, rightLink)
-
         node.left     = leftLink
         node.right    = rightLink
         node.location = location
@@ -800,9 +760,6 @@ object Core {
         val leftLink  = Link.New.Connected(node, left)
         val rightLink = Link.New.Connected(node, right)
 
-        CoreDef.Node.addParent(left, leftLink)
-        CoreDef.Node.addParent(right, rightLink)
-
         node.left     = leftLink
         node.right    = rightLink
         node.location = location
@@ -829,9 +786,6 @@ object Core {
 
         val leftLink  = Link.New.Connected(node, left)
         val rightLink = Link.New.Connected(node, right)
-
-        CoreDef.Node.addParent(left, leftLink)
-        CoreDef.Node.addParent(right, rightLink)
 
         node.left     = leftLink
         node.right    = rightLink
@@ -864,9 +818,6 @@ object Core {
         val argLink  = Link.New.Connected(node, arg)
         val bodyLink = Link.New.Connected(node, body)
 
-        CoreDef.Node.addParent(arg, argLink)
-        CoreDef.Node.addParent(body, bodyLink)
-
         node.arg      = argLink
         node.body     = bodyLink
         node.location = location
@@ -896,10 +847,6 @@ object Core {
           val nameLink = Link.New.Connected(node, name)
           val argsLink = Link.New.Connected(node, args)
           val bodyLink = Link.New.Connected(node, body)
-
-          CoreDef.Node.addParent(name, nameLink)
-          CoreDef.Node.addParent(args, argsLink)
-          CoreDef.Node.addParent(body, bodyLink)
 
           node.name     = nameLink
           node.args     = argsLink
@@ -944,10 +891,6 @@ object Core {
           val targetPathLink = Link.New.Connected(node, targetPath)
           val nameLink       = Link.New.Connected(node, name)
           val functionLink   = Link.New.Connected(node, function)
-
-          CoreDef.Node.addParent(targetPath, targetPathLink)
-          CoreDef.Node.addParent(name, nameLink)
-          CoreDef.Node.addParent(function, functionLink)
 
           node.targetPath = targetPathLink
           node.name       = nameLink
@@ -1010,10 +953,6 @@ object Core {
           val suspendedLink = Link.New.Connected(node, suspended)
           val defaultLink   = Link.New.Connected(node, default)
 
-          CoreDef.Node.addParent(name, nameLink)
-          CoreDef.Node.addParent(suspended, suspendedLink)
-          CoreDef.Node.addParent(default, defaultLink)
-
           node.name      = nameLink
           node.suspended = suspendedLink
           node.default   = defaultLink
@@ -1053,9 +992,6 @@ object Core {
         val functionLink = Link.New.Connected(node, function)
         val argumentLink = Link.New.Connected(node, argument)
 
-        CoreDef.Node.addParent(function, functionLink)
-        CoreDef.Node.addParent(argument, argumentLink)
-
         node.function = functionLink
         node.argument = argumentLink
         node.location = location
@@ -1086,10 +1022,6 @@ object Core {
         val operatorLink = Link.New.Connected(node, operator)
         val rightLink    = Link.New.Connected(node, right)
 
-        CoreDef.Node.addParent(left, leftLink)
-        CoreDef.Node.addParent(operator, operatorLink)
-        CoreDef.Node.addParent(right, rightLink)
-
         node.left     = leftLink
         node.operator = operatorLink
         node.right    = rightLink
@@ -1118,9 +1050,6 @@ object Core {
         val argLink      = Link.New.Connected(node, arg)
         val operatorLink = Link.New.Connected(node, operator)
 
-        CoreDef.Node.addParent(arg, argLink)
-        CoreDef.Node.addParent(operator, operatorLink)
-
         node.arg      = argLink
         node.operator = operatorLink
         node.location = location
@@ -1148,9 +1077,6 @@ object Core {
         val operatorLink = Link.New.Connected(node, operator)
         val argLink      = Link.New.Connected(node, arg)
 
-        CoreDef.Node.addParent(operator, operatorLink)
-        CoreDef.Node.addParent(arg, argLink)
-
         node.operator = operatorLink
         node.arg      = argLink
         node.location = location
@@ -1173,8 +1099,6 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.CentreSection]
 
         val operatorLink = Link.New.Connected(node, operator)
-
-        CoreDef.Node.addParent(operator, operatorLink)
 
         node.operator = operatorLink
         node.location = location
@@ -1204,8 +1128,6 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.ForcedTerm]
 
         val expressionLink = Link.New.Connected(node, expression)
-
-        CoreDef.Node.addParent(expression, expressionLink)
 
         node.expression = expressionLink
         node.location   = location
@@ -1259,9 +1181,6 @@ object Core {
         val expressionLink = Link.New.Connected(node, expression)
         val nameLink       = Link.New.Connected(node, name)
 
-        CoreDef.Node.addParent(expression, expressionLink)
-        CoreDef.Node.addParent(name, nameLink)
-
         node.expression = expressionLink
         node.name       = nameLink
         node.location   = location
@@ -1311,9 +1230,6 @@ object Core {
           val expressionsLink = Link.New.Connected(node, expressions)
           val returnValLink   = Link.New.Connected(node, returnVal)
 
-          CoreDef.Node.addParent(expressions, expressionsLink)
-          CoreDef.Node.addParent(returnVal, returnValLink)
-
           node.expressions = expressionsLink
           node.returnVal   = returnValLink
           node.location    = location
@@ -1347,9 +1263,6 @@ object Core {
         val nameLink       = Link.New.Connected(node, name)
         val expressionLink = Link.New.Connected(node, expression)
 
-        CoreDef.Node.addParent(name, nameLink)
-        CoreDef.Node.addParent(expression, expressionLink)
-
         node.name       = nameLink
         node.expression = expressionLink
         node.location   = location
@@ -1379,9 +1292,6 @@ object Core {
 
           val scrutineeLink = Link.New.Connected(node, scrutinee)
           val branchesLink  = Link.New.Connected(node, branches)
-
-          CoreDef.Node.addParent(scrutinee, scrutineeLink)
-          CoreDef.Node.addParent(branches, branchesLink)
 
           node.scrutinee = scrutineeLink
           node.branches  = branchesLink
@@ -1415,9 +1325,6 @@ object Core {
 
         val patternLink    = Link.New.Connected(node, pattern)
         val expressionLink = Link.New.Connected(node, expression)
-
-        CoreDef.Node.addParent(pattern, patternLink)
-        CoreDef.Node.addParent(expression, expressionLink)
 
         node.pattern    = patternLink
         node.expression = expressionLink
@@ -1475,8 +1382,6 @@ object Core {
 
         val matchExpressionLink = Link.New.Connected(node, matchExpression)
 
-        CoreDef.Node.addParent(matchExpression, matchExpressionLink)
-
         node.matchExpression = matchExpressionLink
         node.location        = location
         node.parents         = Vector()
@@ -1502,8 +1407,6 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.NamedPattern]
 
         val matchExpressionLink = Link.New.Connected(node, matchExpression)
-
-        CoreDef.Node.addParent(matchExpression, matchExpressionLink)
 
         node.matchExpression = matchExpressionLink
         node.location        = location
@@ -1554,9 +1457,6 @@ object Core {
         val commentedLink = Link.New.Connected(node, commented)
         val docLink       = Link.New.Connected(node, doc)
 
-        CoreDef.Node.addParent(commented, commentedLink)
-        CoreDef.Node.addParent(doc, docLink)
-
         node.commented = commentedLink
         node.doc       = docLink
         node.location  = location
@@ -1587,9 +1487,6 @@ object Core {
 
             val languageLink = Link.New.Connected(node, language)
             val codeLink     = Link.New.Connected(node, code)
-
-            CoreDef.Node.addParent(language, languageLink)
-            CoreDef.Node.addParent(code, codeLink)
 
             node.language = languageLink
             node.code     = codeLink
@@ -1652,8 +1549,6 @@ object Core {
 
         val erroneousCoreLink =
           Link.New.Connected(node, erroneousCoreList)
-
-        CoreDef.Node.addParent(erroneousCoreList, erroneousCoreLink)
 
         node.erroneousCore = erroneousCoreLink
         node.location      = location
@@ -1838,6 +1733,8 @@ object Core {
         link.source = source
         link.target = target
 
+        CoreDef.Node.addParent(target, link)
+
         link
       }
 
@@ -1855,6 +1752,8 @@ object Core {
 
         link.source = source
         link.target = emptyNode
+
+        CoreDef.Node.addParent(emptyNode, link)
 
         link
       }

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
@@ -1,6 +1,13 @@
 package org.enso.compiler.core
 
 import org.enso.graph.{Graph => PrimGraph}
+import org.enso.core.CoreGraph.{DefinitionGen => CoreDef}
+import org.enso.core.CoreGraph.DefinitionGen.Node.{Shape => NodeShape}
+import org.enso.syntax.text.{Location => AstLocation}
+
+import scala.util.{Failure, Success, Try}
+
+// TODO [AA] Detailed semantic descriptions for each node shape in future.
 
 /** [[Core]] is the sophisticated internal representation supported by the
   * compiler.
@@ -8,7 +15,426 @@ import org.enso.graph.{Graph => PrimGraph}
   * It is a structure designed to be amenable to program analysis and
   * transformation and features:
   * - High performance on a mutable graph structure.
-  * - High levels of type-safety to reduce the incidence of bugs.
   * - Mutable links to represent program structure.
   */
-class Core {}
+class Core {
+  // TODO [AA] Need to present a nice interface
+  //  - Assignment to children must update parent links for children.
+  //  - Smart Constructors must handle the awful creation dance.
+  //  - Accessors should look _through_ the edge, but there should still be a
+  //    way to get the edge
+  //  - Copy subsection of graph
+  //  - Check equality for subsection of graph
+
+  import CoreDef.Link.Shape._
+  import CoreDef.Node.Location._
+  import CoreDef.Node.ParentLinks._
+  import CoreDef.Node.Shape._
+  import PrimGraph.Component.Refined._
+
+  // ==========================================================================
+  // === Useful Type Aliases ==================================================
+  // ==========================================================================
+
+  type CoreGraph = CoreDef.CoreGraph
+  type GraphData = PrimGraph.GraphData[CoreGraph]
+  type CoreNode  = CoreDef.Node[CoreGraph]
+  type CoreLink  = CoreDef.Link[CoreGraph]
+  type RefinedNode[V <: CoreDef.Node.Shape] =
+    PrimGraph.Component.Refined[NodeShape, V, CoreNode]
+
+  // ==========================================================================
+  // === Graph Storage ========================================================
+  // ==========================================================================
+
+  implicit val graph: GraphData = PrimGraph[CoreGraph]()
+
+  implicit val literalStorage = CoreDef.LiteralStorage()
+  implicit val nameStorage    = CoreDef.NameStorage()
+  implicit val parentStorage  = CoreDef.ParentStorage()
+
+  // ==========================================================================
+  // === Node =================================================================
+  // ==========================================================================
+
+  /** Functionality for working with nodes. */
+  object Node {
+
+    /** Smart constructors to create nodes of various shapes. */
+    //noinspection DuplicatedCode
+    object Make {
+      import Node.Conversions._
+
+      // === Base Shapes ======================================================
+
+      /** Creates a node that has no particular shape.
+        *
+        * @return an empty node
+        */
+      def empty(): RefinedNode[NodeShape.Empty] = {
+        val node = CoreDef.Node.addRefined[NodeShape.Empty]
+
+        node.location = Constants.invalidLocation
+
+        node
+      }
+
+      /** Creates a representation of a cons cell for building linked lists on
+        * the core graph.
+        *
+        * These should be used _very_ sparingly, if at all, but they provide a
+        * way to store dynamically-sized core components providing they can be
+        * broken down into statically sized components.
+        *
+        * The [[tail]] parameter should always point to either another node
+        * with shape [[MetaList]] or a node with shape [[MetaNil]].
+        *
+        * It should be noted that, given that each [[Node]] contains a field
+        * of [[ParentLinks]], that constructing this properly provides a
+        * doubly-linked list, as no [[MetaList]] or [[MetaNil]] should have
+        * more than one parent.
+        *
+        * The location contained in this node is _invalid_ as it does not
+        * represent any location in the program source.
+        *
+        * @param head the current, arbitrary, element in the list
+        * @param tail the rest of the list
+        * @return a node representing an on-graph meta list
+        */
+      def metaList(
+        head: CoreNode,
+        tail: CoreNode
+      ): Try[RefinedNode[NodeShape.MetaList]] = {
+        if (Utility.isListNode(tail)) {
+          val node = CoreDef.Node.addRefined[NodeShape.MetaList]
+
+          val headLink = Link.make(node, head)
+          val tailLink = Link.make(node, tail)
+
+          CoreDef.Node.addParent(head, headLink)
+          CoreDef.Node.addParent(tail, tailLink)
+
+          node.head     = headLink
+          node.tail     = tailLink
+          node.location = Constants.invalidLocation
+
+          Success(node)
+        } else {
+          Failure(
+            new Exception.InvalidListConstruction(
+              s"Provided tail with index ${tail.ix} is not a valid list cell."
+            )
+          )
+        }
+      }
+
+      /** Creates a representation of the end of a linked-list on the core
+        * graph.
+        *
+        * This should _only_ be used in conjunction with [[NodeShape.MetaList]].
+        *
+        * The location contained in this node is _invalid_ as it does not
+        * represent any location in the program source.
+        *
+        * @return a node representing the end of an on-graph meta list
+        */
+      def metaNil(): RefinedNode[NodeShape.MetaNil] = {
+        val node = CoreDef.Node.addRefined[NodeShape.MetaNil]
+
+        node.location = Constants.invalidLocation
+        node
+      }
+
+      /** Creates a representation of a meta-value `true` in the core graph.
+        *
+        * The location contained in this node is _invalid_ as it does not
+        * represent any location in the program source.
+        *
+        * @return a node representing the on-graph metavalue `true`
+        */
+      def metaTrue(): RefinedNode[NodeShape.MetaTrue] = {
+        val node = CoreDef.Node.addRefined[NodeShape.MetaTrue]
+
+        node.location = Constants.invalidLocation
+        node
+      }
+
+      /** Creates a representation of the meta-value `false` in the core graph.
+        *
+        * The location contained in this node is _invalid_ as it does not
+        * represent any location in the program source.
+        *
+        * @return a node representing the on-graph metavalue `false`
+        */
+      def metaFalse(): RefinedNode[NodeShape.MetaFalse] = {
+        val node = CoreDef.Node.addRefined[NodeShape.MetaFalse]
+
+        node.location = Constants.invalidLocation
+        node
+      }
+
+      // === Literals =========================================================
+
+      /** Creates a node containing a numeric literal.
+        *
+        * @param number the literal number
+        * @param location the source location for the literal
+        * @return a numeric literal node representing [[number]]
+        */
+      def numericLiteral(
+        number: String,
+        location: AstLocation
+      ): RefinedNode[NodeShape.NumericLiteral] = {
+        val node = CoreDef.Node.addRefined[NodeShape.NumericLiteral]
+
+        node.number   = number
+        node.location = location
+
+        node
+      }
+
+      /** Creates a node containing a textual literal.
+        *
+        * @param text the literal text
+        * @param location the source location for the literal
+        * @return a textual literal node representing [[text]]
+        */
+      def textLiteral(
+        text: String,
+        location: AstLocation
+      ): RefinedNode[NodeShape.TextLiteral] = {
+        val node = CoreDef.Node.addRefined[NodeShape.TextLiteral]
+
+        node.text     = text
+        node.location = location
+
+        node
+      }
+
+      /** Creates a node containing a foreign code literal.
+        *
+        * @param code the foreign code
+        * @param location the source location for the literal
+        * @return a foreign code literal node representing [[code]]
+        */
+      def foreignCodeLiteral(
+        code: String,
+        location: AstLocation
+      ): RefinedNode[NodeShape.ForeignCodeLiteral] = {
+        val node = CoreDef.Node.addRefined[NodeShape.ForeignCodeLiteral]
+
+        node.code     = code
+        node.location = location
+
+        node
+      }
+
+      // === Names ============================================================
+
+      /** Creates a node representing a name.
+        *
+        * @param nameLiteral the literal representation of the name
+        * @param location the source location for the name
+        * @return a node representing the name [[nameLiteral]]
+        */
+      def name(
+        nameLiteral: String,
+        location: AstLocation
+      ): RefinedNode[NodeShape.Name] = {
+        val node = CoreDef.Node.addRefined[NodeShape.Name]
+
+        node.nameLiteral = nameLiteral
+        node.location    = location
+
+        node
+      }
+
+      /** Creates a node representing a usage of `this`.
+        *
+        * @param location the source location of the `this` usage
+        * @return a node representing the `this` usage at [[location]]
+        */
+      def thisName(location: AstLocation): RefinedNode[NodeShape.ThisName] = {
+        val node = CoreDef.Node.addRefined[NodeShape.ThisName]
+
+        node.location = location
+
+        node
+      }
+
+      /** Creates a node representing a usage of `here`.
+        *
+        * @param location the source location of the `here` usage
+        * @return a node representing the `here` usage at [[location]]
+        */
+      def hereName(location: AstLocation): RefinedNode[NodeShape.HereName] = {
+        val node = CoreDef.Node.addRefined[NodeShape.HereName]
+
+        node.location = location
+
+        node
+      }
+
+      // === Module ===========================================================
+
+      /** Creates a node representing a module definition.
+        *
+        * @param name the name of the module
+        * @param imports the list of imports for the module, as a valid meta
+        *                list
+        * @param definitions the list of definitions in the module, as a valid
+        *                    meta list
+        * @param location the source location of the module definition
+        * @return a node representing the module definition
+        */
+      def moduleDef(
+        name: CoreNode,
+        imports: CoreNode,
+        definitions: CoreNode,
+        location: AstLocation
+      ): Try[RefinedNode[NodeShape.ModuleDef]] = {
+        if (Utility.isListNode(imports) && Utility.isListNode(definitions)) {
+          val node = CoreDef.Node.addRefined[NodeShape.ModuleDef]
+
+          val nameLink        = Link.make(node, name)
+          val importsLink     = Link.make(node, imports)
+          val definitionsLink = Link.make(node, definitions)
+
+          CoreDef.Node.addParent(name, nameLink)
+          CoreDef.Node.addParent(imports, importsLink)
+          CoreDef.Node.addParent(definitions, definitionsLink)
+
+          node.name        = nameLink
+          node.imports     = importsLink
+          node.definitions = definitionsLink
+          node.location    = location
+
+          Success(node)
+        } else {
+          Failure(
+            new Exception.NotValidList(
+              s"Imports and definitions must be a valid meta list but node " +
+              s"at index ${definitions.ix} or ${imports.ix} is not."
+            )
+          )
+        }
+      }
+
+      // === Function =========================================================
+
+      /** Creates a node representing a lambda expression, the `->` function
+        * arrow.
+        *
+        * Please note that all lambdas in Enso are explicitly single-argument.
+        *
+        * @param arg the argument to the lambda
+        * @param body the body of the lambda
+        * @param location the location of this node in the program source
+        * @return a lambda node with [[arg]] and [[body]] as its children
+        */
+      def lambda(
+        arg: CoreNode,
+        body: CoreNode,
+        location: AstLocation
+      ): RefinedNode[NodeShape.Lambda] = {
+        val node = CoreDef.Node.addRefined[NodeShape.Lambda]
+
+        val argLink  = Link.make(node, arg)
+        val bodyLink = Link.make(node, body)
+
+        CoreDef.Node.addParent(arg, argLink)
+        CoreDef.Node.addParent(body, bodyLink)
+
+        node.arg      = argLink
+        node.body     = bodyLink
+        node.location = location
+
+        node
+      }
+    }
+
+    /** Exceptions used by the core graph. */
+    object Exception {
+      class InvalidListConstruction(val message: String) extends Throwable
+      class NotValidList(val message: String)            extends Throwable
+    }
+
+    /** Useful conversions between types that are used for Core nodes. */
+    object Conversions {
+
+      /** Converts the parser's location representation into Core's location
+        * representation.
+        *
+        * @param location a location from the parser
+        * @return the core representation of [[location]]
+        */
+      implicit def astLocationToNodeLocation(
+        location: AstLocation
+      ): CoreDef.Node.LocationVal[CoreGraph] = {
+        CoreDef.Node.LocationVal(location.start, location.end)
+      }
+    }
+
+    /** Constants for working with nodes. */
+    object Constants {
+
+      /** An invalid location in the pogram source. */
+      val invalidSourceIndex: Int = -1
+      val invalidLocation: CoreDef.Node.LocationVal[CoreGraph] =
+        CoreDef.Node.LocationVal(invalidSourceIndex, invalidSourceIndex)
+    }
+
+    /** Utility functions for working with nodes. */
+    object Utility {
+
+      /** Checks if the provided node is a meta-level list node.
+        *
+        * A node is considered to be a list node when it has either the shape
+        * [[NodeShape.MetaList]] or the shape [[NodeShape.MetaNil]].
+        *
+        * @param node the node to check
+        * @return `true` if [[node]] is a list node, otherwise `false`
+        */
+      def isListNode(node: CoreNode): Boolean = {
+        node match {
+          case NodeShape.MetaList.any(_) => true
+          case NodeShape.MetaNil.any(_)  => true
+          case _                         => false
+        }
+      }
+    }
+  }
+
+  // ==========================================================================
+  // === Link =================================================================
+  // ==========================================================================
+
+  /** Functionality for working with links. */
+  object Link {
+
+    /**
+      *
+      * @param source
+      * @param target
+      * @return
+      */
+    def make(source: CoreNode, target: CoreNode): CoreLink = {
+      val link = graph.addLink()
+
+      link.source = source
+      link.target = target
+
+      link
+    }
+
+    def make(source: CoreNode): CoreLink = {
+      val link      = graph.addLink()
+      val emptyNode = Node.Make.empty()
+
+      link.source = source
+      link.target = emptyNode
+
+      link
+    }
+  }
+}

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
@@ -37,6 +37,20 @@ class Core {
   //  - Copy subsection of graph
   //  - Check equality for subsection of graph
 
+  // ==========================================================================
+  // === Graph Storage ========================================================
+  // ==========================================================================
+
+  implicit val graph: Core.GraphData = PrimGraph[Core.Graph]()
+
+  implicit val literalStorage: Core.LiteralStorage = CoreDef.LiteralStorage()
+  implicit val nameStorage: Core.NameStorage       = CoreDef.NameStorage()
+  implicit val parentStorage: Core.ParentStorage   = CoreDef.ParentStorage()
+  implicit val astStorage: Core.AstStorage         = CoreDef.AstStorage()
+
+}
+object Core {
+
   import CoreDef.Link.Shape._
   import CoreDef.Node.Location._
   import CoreDef.Node.ParentLinks._
@@ -68,17 +82,6 @@ class Core {
   type AstStorage     = CoreDef.AstStorage
 
   // ==========================================================================
-  // === Graph Storage ========================================================
-  // ==========================================================================
-
-  implicit val graph: GraphData = PrimGraph[Graph]()
-
-  implicit val literalStorage: LiteralStorage = CoreDef.LiteralStorage()
-  implicit val nameStorage: NameStorage       = CoreDef.NameStorage()
-  implicit val parentStorage: ParentStorage   = CoreDef.ParentStorage()
-  implicit val astStorage: AstStorage         = CoreDef.AstStorage()
-
-  // ==========================================================================
   // === Node =================================================================
   // ==========================================================================
 
@@ -95,7 +98,7 @@ class Core {
         *
         * @return an empty node
         */
-      def empty(): RefinedNode[NodeShape.Empty] = {
+      def empty()(implicit core: Core): RefinedNode[NodeShape.Empty] = {
         val node = CoreDef.Node.addRefined[NodeShape.Empty]
 
         node.location = Constants.invalidLocation
@@ -128,7 +131,7 @@ class Core {
       def metaList(
         head: Node,
         tail: Node
-      ): ConsErrOrT[NodeShape.MetaList] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.MetaList] = {
         if (Utility.isListNode(tail)) {
           val node = CoreDef.Node.addRefined[NodeShape.MetaList]
 
@@ -161,7 +164,7 @@ class Core {
         *
         * @return a node representing the end of an on-graph meta list
         */
-      def metaNil(): RefinedNode[NodeShape.MetaNil] = {
+      def metaNil()(implicit core: Core): RefinedNode[NodeShape.MetaNil] = {
         val node = CoreDef.Node.addRefined[NodeShape.MetaNil]
 
         node.location = Constants.invalidLocation
@@ -175,7 +178,7 @@ class Core {
         *
         * @return a node representing the on-graph metavalue `true`
         */
-      def metaTrue(): RefinedNode[NodeShape.MetaTrue] = {
+      def metaTrue()(implicit core: Core): RefinedNode[NodeShape.MetaTrue] = {
         val node = CoreDef.Node.addRefined[NodeShape.MetaTrue]
 
         node.location = Constants.invalidLocation
@@ -189,7 +192,7 @@ class Core {
         *
         * @return a node representing the on-graph metavalue `false`
         */
-      def metaFalse(): RefinedNode[NodeShape.MetaFalse] = {
+      def metaFalse()(implicit core: Core): RefinedNode[NodeShape.MetaFalse] = {
         val node = CoreDef.Node.addRefined[NodeShape.MetaFalse]
 
         node.location = Constants.invalidLocation
@@ -207,7 +210,7 @@ class Core {
       def numericLiteral(
         number: String,
         location: Location
-      ): RefinedNode[NodeShape.NumericLiteral] = {
+      )(implicit core: Core): RefinedNode[NodeShape.NumericLiteral] = {
         val node = CoreDef.Node.addRefined[NodeShape.NumericLiteral]
 
         node.number   = number
@@ -225,7 +228,7 @@ class Core {
       def textLiteral(
         text: String,
         location: Location
-      ): RefinedNode[NodeShape.TextLiteral] = {
+      )(implicit core: Core): RefinedNode[NodeShape.TextLiteral] = {
         val node = CoreDef.Node.addRefined[NodeShape.TextLiteral]
 
         node.text     = text
@@ -243,7 +246,7 @@ class Core {
       def foreignCodeLiteral(
         code: String,
         location: Location
-      ): RefinedNode[NodeShape.ForeignCodeLiteral] = {
+      )(implicit core: Core): RefinedNode[NodeShape.ForeignCodeLiteral] = {
         val node = CoreDef.Node.addRefined[NodeShape.ForeignCodeLiteral]
 
         node.code     = code
@@ -263,7 +266,7 @@ class Core {
       def name(
         nameLiteral: String,
         location: Location
-      ): RefinedNode[NodeShape.Name] = {
+      )(implicit core: Core): RefinedNode[NodeShape.Name] = {
         val node = CoreDef.Node.addRefined[NodeShape.Name]
 
         node.nameLiteral = nameLiteral
@@ -277,7 +280,9 @@ class Core {
         * @param location the source location of the `this` usage
         * @return a node representing the `this` usage at [[location]]
         */
-      def thisName(location: Location): RefinedNode[NodeShape.ThisName] = {
+      def thisName(
+        location: Location
+      )(implicit core: Core): RefinedNode[NodeShape.ThisName] = {
         val node = CoreDef.Node.addRefined[NodeShape.ThisName]
 
         node.location = location
@@ -290,7 +295,9 @@ class Core {
         * @param location the source location of the `here` usage
         * @return a node representing the `here` usage at [[location]]
         */
-      def hereName(location: Location): RefinedNode[NodeShape.HereName] = {
+      def hereName(
+        location: Location
+      )(implicit core: Core): RefinedNode[NodeShape.HereName] = {
         val node = CoreDef.Node.addRefined[NodeShape.HereName]
 
         node.location = location
@@ -315,7 +322,7 @@ class Core {
         imports: Node,
         definitions: Node,
         location: Location
-      ): ConsErrOrT[NodeShape.ModuleDef] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.ModuleDef] = {
         if (Utility.isListNode(imports) && Utility.isListNode(definitions)) {
           val node = CoreDef.Node.addRefined[NodeShape.ModuleDef]
 
@@ -357,7 +364,7 @@ class Core {
       def `import`(
         segments: Node,
         location: Location
-      ): ConsErrOrT[NodeShape.Import] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.Import] = {
         if (Utility.isListNode(segments)) {
           val node = CoreDef.Node.addRefined[NodeShape.Import]
 
@@ -392,7 +399,7 @@ class Core {
         module: Node,
         binding: Node,
         location: Location
-      ): ConsErrOrT[NodeShape.TopLevelBinding] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.TopLevelBinding] = {
         binding match {
           case NodeShape.Binding.any(_) =>
             val node = CoreDef.Node.addRefined[NodeShape.TopLevelBinding]
@@ -426,7 +433,7 @@ class Core {
         name: Node,
         args: Node,
         location: Location
-      ): ConsErrOrT[NodeShape.AtomDef] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.AtomDef] = {
         if (Utility.isListNode(args)) {
           val node = CoreDef.Node.addRefined[NodeShape.AtomDef]
 
@@ -462,7 +469,7 @@ class Core {
         typeParams: Node,
         body: Node,
         location: Location
-      ): ConsErrOrT[NodeShape.TypeDef] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.TypeDef] = {
         if (Utility.isListNode(typeParams) && Utility.isListNode(body)) {
           val node = CoreDef.Node.addRefined[NodeShape.TypeDef]
 
@@ -512,7 +519,7 @@ class Core {
         typed: Node,
         sig: Node,
         location: Location
-      ): RefinedNode[NodeShape.TypeAscription] = {
+      )(implicit core: Core): RefinedNode[NodeShape.TypeAscription] = {
         val node = CoreDef.Node.addRefined[NodeShape.TypeAscription]
 
         val typedLink = Link.New.connected(node, typed)
@@ -541,7 +548,7 @@ class Core {
         typed: Node,
         context: Node,
         location: Location
-      ): RefinedNode[NodeShape.ContextAscription] = {
+      )(implicit core: Core): RefinedNode[NodeShape.ContextAscription] = {
         val node = CoreDef.Node.addRefined[NodeShape.ContextAscription]
 
         val typedLink   = Link.New.connected(node, typed)
@@ -574,7 +581,7 @@ class Core {
         memberType: Node,
         value: Node,
         location: Location
-      ): RefinedNode[NodeShape.TypesetMember] = {
+      )(implicit core: Core): RefinedNode[NodeShape.TypesetMember] = {
         val node = CoreDef.Node.addRefined[NodeShape.TypesetMember]
 
         val labelLink      = Link.New.connected(node, label)
@@ -608,7 +615,7 @@ class Core {
         left: Node,
         right: Node,
         location: Location
-      ): RefinedNode[NodeShape.TypesetSubsumption] = {
+      )(implicit core: Core): RefinedNode[NodeShape.TypesetSubsumption] = {
         val node = CoreDef.Node.addRefined[NodeShape.TypesetSubsumption]
 
         val leftLink  = Link.New.connected(node, left)
@@ -639,7 +646,7 @@ class Core {
         left: Node,
         right: Node,
         location: Location
-      ): RefinedNode[NodeShape.TypesetEquality] = {
+      )(implicit core: Core): RefinedNode[NodeShape.TypesetEquality] = {
         val node = CoreDef.Node.addRefined[NodeShape.TypesetEquality]
 
         val leftLink  = Link.New.connected(node, left)
@@ -667,7 +674,7 @@ class Core {
         left: Node,
         right: Node,
         location: Location
-      ): RefinedNode[NodeShape.TypesetConcat] = {
+      )(implicit core: Core): RefinedNode[NodeShape.TypesetConcat] = {
         val node = CoreDef.Node.addRefined[NodeShape.TypesetConcat]
 
         val leftLink  = Link.New.connected(node, left)
@@ -695,7 +702,7 @@ class Core {
         left: Node,
         right: Node,
         location: Location
-      ): RefinedNode[NodeShape.TypesetUnion] = {
+      )(implicit core: Core): RefinedNode[NodeShape.TypesetUnion] = {
         val node = CoreDef.Node.addRefined[NodeShape.TypesetUnion]
 
         val leftLink  = Link.New.connected(node, left)
@@ -723,7 +730,7 @@ class Core {
         left: Node,
         right: Node,
         location: Location
-      ): RefinedNode[NodeShape.TypesetIntersection] = {
+      )(implicit core: Core): RefinedNode[NodeShape.TypesetIntersection] = {
         val node = CoreDef.Node.addRefined[NodeShape.TypesetIntersection]
 
         val leftLink  = Link.New.connected(node, left)
@@ -751,7 +758,7 @@ class Core {
         left: Node,
         right: Node,
         location: Location
-      ): RefinedNode[NodeShape.TypesetSubtraction] = {
+      )(implicit core: Core): RefinedNode[NodeShape.TypesetSubtraction] = {
         val node = CoreDef.Node.addRefined[NodeShape.TypesetSubtraction]
 
         val leftLink  = Link.New.connected(node, left)
@@ -783,7 +790,7 @@ class Core {
         arg: Node,
         body: Node,
         location: Location
-      ): RefinedNode[NodeShape.Lambda] = {
+      )(implicit core: Core): RefinedNode[NodeShape.Lambda] = {
         val node = CoreDef.Node.addRefined[NodeShape.Lambda]
 
         val argLink  = Link.New.connected(node, arg)
@@ -812,7 +819,7 @@ class Core {
         args: Node,
         body: Node,
         location: Location
-      ): ConsErrOrT[NodeShape.FunctionDef] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.FunctionDef] = {
         if (Utility.isListNode(args)) {
           val node = CoreDef.Node.addRefined[NodeShape.FunctionDef]
 
@@ -852,7 +859,7 @@ class Core {
         name: Node,
         function: Node,
         location: Location
-      ): ConsErrOrT[NodeShape.MethodDef] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.MethodDef] = {
         val bodyIsValid = function match {
           case NodeShape.FunctionDef.any(_) => true
           case NodeShape.Lambda.any(_)      => true
@@ -896,7 +903,7 @@ class Core {
         */
       def ignoredArgument(
         location: Location
-      ): RefinedNode[NodeShape.IgnoredArgument] = {
+      )(implicit core: Core): RefinedNode[NodeShape.IgnoredArgument] = {
         val node = CoreDef.Node.addRefined[NodeShape.IgnoredArgument]
 
         node.location = location
@@ -919,7 +926,7 @@ class Core {
         suspended: Node,
         default: Node,
         location: Location
-      ): ConsErrOrT[NodeShape.DefinitionArgument] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.DefinitionArgument] = {
         val suspendedIsBool = suspended match {
           case NodeShape.MetaTrue.any(_)  => true
           case NodeShape.MetaFalse.any(_) => true
@@ -968,7 +975,7 @@ class Core {
         function: Node,
         argument: Node,
         location: Location
-      ): RefinedNode[NodeShape.Application] = {
+      )(implicit core: Core): RefinedNode[NodeShape.Application] = {
         val node = CoreDef.Node.addRefined[NodeShape.Application]
 
         val functionLink = Link.New.connected(node, function)
@@ -998,7 +1005,7 @@ class Core {
         operator: Node,
         right: Node,
         location: Location
-      ): RefinedNode[NodeShape.InfixApplication] = {
+      )(implicit core: Core): RefinedNode[NodeShape.InfixApplication] = {
         val node = CoreDef.Node.addRefined[NodeShape.InfixApplication]
 
         val leftLink     = Link.New.connected(node, left)
@@ -1029,7 +1036,7 @@ class Core {
         arg: Node,
         operator: Node,
         location: Location
-      ): RefinedNode[NodeShape.LeftSection] = {
+      )(implicit core: Core): RefinedNode[NodeShape.LeftSection] = {
         val node = CoreDef.Node.addRefined[NodeShape.LeftSection]
 
         val argLink      = Link.New.connected(node, arg)
@@ -1057,7 +1064,7 @@ class Core {
         operator: Node,
         arg: Node,
         location: Location
-      ): RefinedNode[NodeShape.RightSection] = {
+      )(implicit core: Core): RefinedNode[NodeShape.RightSection] = {
         val node = CoreDef.Node.addRefined[NodeShape.RightSection]
 
         val operatorLink = Link.New.connected(node, operator)
@@ -1082,7 +1089,7 @@ class Core {
       def centreSection(
         operator: Node,
         location: Location
-      ): RefinedNode[NodeShape.CentreSection] = {
+      )(implicit core: Core): RefinedNode[NodeShape.CentreSection] = {
         val node = CoreDef.Node.addRefined[NodeShape.CentreSection]
 
         val operatorLink = Link.New.connected(node, operator)
@@ -1111,7 +1118,7 @@ class Core {
       def forcedTerm(
         expression: Node,
         location: Location
-      ): RefinedNode[NodeShape.ForcedTerm] = {
+      )(implicit core: Core): RefinedNode[NodeShape.ForcedTerm] = {
         val node = CoreDef.Node.addRefined[NodeShape.ForcedTerm]
 
         val expressionLink = Link.New.connected(node, expression)
@@ -1137,7 +1144,7 @@ class Core {
         */
       def lambdaShorthandArgument(
         location: Location
-      ): RefinedNode[NodeShape.LambdaShorthandArgument] = {
+      )(implicit core: Core): RefinedNode[NodeShape.LambdaShorthandArgument] = {
         val node = CoreDef.Node.addRefined[NodeShape.LambdaShorthandArgument]
 
         node.location = location
@@ -1160,7 +1167,7 @@ class Core {
         expression: Node,
         name: Node,
         location: Location
-      ): RefinedNode[NodeShape.CallSiteArgument] = {
+      )(implicit core: Core): RefinedNode[NodeShape.CallSiteArgument] = {
         val node = CoreDef.Node.addRefined[NodeShape.CallSiteArgument]
 
         val expressionLink = Link.New.connected(node, expression)
@@ -1184,7 +1191,7 @@ class Core {
         */
       def suspendDefaultsOperator(
         location: Location
-      ): RefinedNode[NodeShape.SuspendDefaultsOperator] = {
+      )(implicit core: Core): RefinedNode[NodeShape.SuspendDefaultsOperator] = {
         val node = CoreDef.Node.addRefined[NodeShape.SuspendDefaultsOperator]
 
         node.location = location
@@ -1207,7 +1214,7 @@ class Core {
         expressions: Node,
         returnVal: Node,
         location: Location
-      ): ConsErrOrT[NodeShape.Block] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.Block] = {
         if (Utility.isListNode(expressions)) {
           val node = CoreDef.Node.addRefined[NodeShape.Block]
 
@@ -1242,7 +1249,7 @@ class Core {
         name: Node,
         expression: Node,
         location: Location
-      ): RefinedNode[NodeShape.Binding] = {
+      )(implicit core: Core): RefinedNode[NodeShape.Binding] = {
         val node = CoreDef.Node.addRefined[NodeShape.Binding]
 
         val nameLink       = Link.New.connected(node, name)
@@ -1272,7 +1279,7 @@ class Core {
         scrutinee: Node,
         branches: Node,
         location: Location
-      ): ConsErrOrT[NodeShape.CaseExpr] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.CaseExpr] = {
         if (Utility.isListNode(branches)) {
           val node = CoreDef.Node.addRefined[NodeShape.CaseExpr]
 
@@ -1307,7 +1314,7 @@ class Core {
         pattern: Node,
         expression: Node,
         location: Location
-      ): RefinedNode[NodeShape.CaseBranch] = {
+      )(implicit core: Core): RefinedNode[NodeShape.CaseBranch] = {
         val node = CoreDef.Node.addRefined[NodeShape.CaseBranch]
 
         val patternLink    = Link.New.connected(node, pattern)
@@ -1337,7 +1344,7 @@ class Core {
       def structuralPattern(
         matchExpression: Node,
         location: Location
-      ): RefinedNode[NodeShape.StructuralPattern] = {
+      )(implicit core: Core): RefinedNode[NodeShape.StructuralPattern] = {
         val node = CoreDef.Node.addRefined[NodeShape.StructuralPattern]
 
         val matchExpressionLink = Link.New.connected(node, matchExpression)
@@ -1363,7 +1370,7 @@ class Core {
       def typePattern(
         matchExpression: Node,
         location: Location
-      ): RefinedNode[NodeShape.TypePattern] = {
+      )(implicit core: Core): RefinedNode[NodeShape.TypePattern] = {
         val node = CoreDef.Node.addRefined[NodeShape.TypePattern]
 
         val matchExpressionLink = Link.New.connected(node, matchExpression)
@@ -1389,7 +1396,7 @@ class Core {
       def namedPattern(
         matchExpression: Node,
         location: Location
-      ): RefinedNode[NodeShape.NamedPattern] = {
+      )(implicit core: Core): RefinedNode[NodeShape.NamedPattern] = {
         val node = CoreDef.Node.addRefined[NodeShape.NamedPattern]
 
         val matchExpressionLink = Link.New.connected(node, matchExpression)
@@ -1412,7 +1419,7 @@ class Core {
         */
       def fallbackPattern(
         location: Location
-      ): RefinedNode[NodeShape.FallbackPattern] = {
+      )(implicit core: Core): RefinedNode[NodeShape.FallbackPattern] = {
         val node = CoreDef.Node.addRefined[NodeShape.FallbackPattern]
 
         node.location = location
@@ -1435,7 +1442,7 @@ class Core {
         commented: Node,
         doc: Node,
         location: Location
-      ): RefinedNode[NodeShape.DocComment] = {
+      )(implicit core: Core): RefinedNode[NodeShape.DocComment] = {
         val node = CoreDef.Node.addRefined[NodeShape.DocComment]
 
         val commentedLink = Link.New.connected(node, commented)
@@ -1465,7 +1472,7 @@ class Core {
         language: Node,
         code: Node,
         location: Location
-      ): ConsErrOrT[NodeShape.ForeignDefinition] = {
+      )(implicit core: Core): ConsErrOrT[NodeShape.ForeignDefinition] = {
         code match {
           case NodeShape.ForeignCodeLiteral.any(_) =>
             val node = CoreDef.Node.addRefined[NodeShape.ForeignDefinition]
@@ -1496,7 +1503,9 @@ class Core {
         * @param errorAst the AST that is syntactically invalid
         * @return a node representing the syntax error described by [[errorAst]]
         */
-      def syntaxError(errorAst: AST): RefinedNode[NodeShape.SyntaxError] = {
+      def syntaxError(
+        errorAst: AST
+      )(implicit core: Core): RefinedNode[NodeShape.SyntaxError] = {
         val node = CoreDef.Node.addRefined[NodeShape.SyntaxError]
         val errLocation: Location =
           errorAst.location
@@ -1519,7 +1528,7 @@ class Core {
       def constructionError(
         erroneousCore: Node,
         location: Location
-      ): RefinedNode[NodeShape.ConstructionError] = {
+      )(implicit core: Core): RefinedNode[NodeShape.ConstructionError] = {
         val node = CoreDef.Node.addRefined[NodeShape.ConstructionError]
 
         val erroneousCoreLink = Link.New.connected(node, erroneousCore)
@@ -1576,7 +1585,7 @@ class Core {
         * @param node the node to check
         * @return `true` if [[node]] is a list node, otherwise `false`
         */
-      def isListNode(node: Node): Boolean = {
+      def isListNode(node: Node)(implicit core: Core): Boolean = {
         node match {
           case NodeShape.MetaList.any(_) => true
           case NodeShape.MetaNil.any(_)  => true
@@ -1590,7 +1599,9 @@ class Core {
         * @param node the expression to turn into a valid list
         * @return a node representing the head of a meta-level list
         */
-      def coreListFrom(node: Node): RefinedNode[NodeShape.MetaList] = {
+      def coreListFrom(
+        node: Node
+      )(implicit core: Core): RefinedNode[NodeShape.MetaList] = {
         coreListFrom(NonEmptyList(node, List()))
       }
 
@@ -1602,7 +1613,7 @@ class Core {
         */
       def coreListFrom(
         nodes: NonEmptyList[Node]
-      ): RefinedNode[NodeShape.MetaList] = {
+      )(implicit core: Core): RefinedNode[NodeShape.MetaList] = {
         val nodesWithNil = nodes :+ New.metaNil().wrapped
 
         // Note [Unsafety in List Construction]
@@ -1644,8 +1655,8 @@ class Core {
         * @param target the end of the link
         * @return a link from [[source]] to [[target]]
         */
-      def connected(source: Node, target: Node): Link = {
-        val link = graph.addLink()
+      def connected(source: Node, target: Node)(implicit core: Core): Link = {
+        val link = core.graph.addLink()
 
         link.source = source
         link.target = target
@@ -1660,8 +1671,8 @@ class Core {
         * @param source the start of the link
         * @return a link from [[source]] to a new [[NodeShape.Empty]] node
         */
-      def disconnected(source: Node): Link = {
-        val link      = graph.addLink()
+      def disconnected(source: Node)(implicit core: Core): Link = {
+        val link      = core.graph.addLink()
         val emptyNode = Node.New.empty()
 
         link.source = source
@@ -1671,9 +1682,6 @@ class Core {
       }
     }
   }
-}
-object Core {
-
   // ==========================================================================
   // === Implicits ============================================================
   // ==========================================================================
@@ -1697,7 +1705,7 @@ object Core {
     * @param core the core instance to convert
     * @return the graph data stored in [[core]]
     */
-  implicit def getGraphData(implicit core: Core): core.GraphData = core.graph
+  implicit def getGraphData(implicit core: Core): GraphData = core.graph
 
   /** Implicitly converts an implicit instance of core to the associated storage
     * for literals.
@@ -1705,7 +1713,7 @@ object Core {
     * @param core the core instance to convert
     * @return the literal storage stored in [[core]]
     */
-  implicit def getLiteralStorage(implicit core: Core): core.LiteralStorage =
+  implicit def getLiteralStorage(implicit core: Core): LiteralStorage =
     core.literalStorage
 
   /** Implicitly converts an implicit instance of core to the associated storage
@@ -1714,7 +1722,7 @@ object Core {
     * @param core the core instance to convert
     * @return the name storage stored in [[core]]
     */
-  implicit def getNameStorage(implicit core: Core): core.NameStorage =
+  implicit def getNameStorage(implicit core: Core): NameStorage =
     core.nameStorage
 
   /** Implicitly converts an implicit instance of core to the associated storage
@@ -1723,7 +1731,7 @@ object Core {
     * @param core the core instance to convert
     * @return the parent link storage stored in [[core]]
     */
-  implicit def getParentStorage(implicit core: Core): core.ParentStorage =
+  implicit def getParentStorage(implicit core: Core): ParentStorage =
     core.parentStorage
 
   /** Implicitly converts an implicit instance of core to the associated storage
@@ -1732,7 +1740,7 @@ object Core {
     * @param core the core instance to convert
     * @return the ast storage stored in [[core]]
     */
-  implicit def getAstStorage(implicit core: Core): core.AstStorage =
+  implicit def getAstStorage(implicit core: Core): AstStorage =
     core.astStorage
 
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
@@ -33,6 +33,9 @@ import scala.annotation.tailrec
   *   import org.enso.graph.{Graph => PrimGraph}
   *   import PrimGraph.Component.Refined._
   * }}}
+  *
+  * Please note that the smart constructor functions are _intentionally_ named
+  * using upper-case so as to signify that they construct a value.
   */
 class Core {
   // TODO [AA] Need to present a nice interface
@@ -966,6 +969,7 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.IgnoredArgument]
 
         node.location = location
+        node.parents = Vector()
 
         node
       }
@@ -997,8 +1001,8 @@ object Core {
           val node = CoreDef.Node.addRefined[NodeShape.DefinitionArgument]
 
           val nameLink      = Link.New.Connected(node, name)
-          val suspendedLink = Link.New.Connected(node, name)
-          val defaultLink   = Link.New.Connected(node, name)
+          val suspendedLink = Link.New.Connected(node, suspended)
+          val defaultLink   = Link.New.Connected(node, default)
 
           CoreDef.Node.addParent(name, nameLink)
           CoreDef.Node.addParent(suspended, suspendedLink)

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/Core.scala
@@ -102,6 +102,7 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.Empty]
 
         node.location = Constants.invalidLocation
+        node.parents  = Vector()
 
         node
       }
@@ -141,9 +142,11 @@ object Core {
           CoreDef.Node.addParent(head, headLink)
           CoreDef.Node.addParent(tail, tailLink)
 
-          node.head     = headLink
+          // Clobbering the variant field
+//          node.head     = headLink
           node.tail     = tailLink
           node.location = Constants.invalidLocation
+          node.parents  = Vector()
 
           Right(node)
         } else {
@@ -168,6 +171,8 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.MetaNil]
 
         node.location = Constants.invalidLocation
+        node.parents  = Vector()
+
         node
       }
 
@@ -182,6 +187,8 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.MetaTrue]
 
         node.location = Constants.invalidLocation
+        node.parents  = Vector()
+
         node
       }
 
@@ -196,6 +203,8 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.MetaFalse]
 
         node.location = Constants.invalidLocation
+        node.parents  = Vector()
+
         node
       }
 
@@ -215,6 +224,7 @@ object Core {
 
         node.number   = number
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -233,6 +243,7 @@ object Core {
 
         node.text     = text
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -251,6 +262,7 @@ object Core {
 
         node.code     = code
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -271,6 +283,7 @@ object Core {
 
         node.nameLiteral = nameLiteral
         node.location    = location
+        node.parents     = Vector()
 
         node
       }
@@ -286,6 +299,7 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.ThisName]
 
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -301,6 +315,7 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.HereName]
 
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -338,6 +353,7 @@ object Core {
           node.imports     = importsLink
           node.definitions = definitionsLink
           node.location    = location
+          node.parents     = Vector()
 
           Right(node)
         } else {
@@ -374,6 +390,7 @@ object Core {
 
           node.segments = segmentsLink
           node.location = location
+          node.parents  = Vector()
 
           Right(node)
         } else {
@@ -413,6 +430,7 @@ object Core {
             node.module   = moduleLink
             node.binding  = bindingLink
             node.location = location
+            node.parents  = Vector()
 
             Right(node)
           case _ =>
@@ -446,6 +464,7 @@ object Core {
           node.name     = nameLink
           node.args     = argsLink
           node.location = location
+          node.parents  = Vector()
 
           Right(node)
         } else {
@@ -485,6 +504,7 @@ object Core {
           node.typeParams = typeParamsLink
           node.body       = bodyLink
           node.location   = location
+          node.parents    = Vector()
 
           Right(node)
         } else {
@@ -531,6 +551,7 @@ object Core {
         node.typed    = typedLink
         node.sig      = sigLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -560,6 +581,7 @@ object Core {
         node.typed    = typedLink
         node.context  = contextLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -596,6 +618,7 @@ object Core {
         node.memberType = memberTypeLink
         node.value      = valueLink
         node.location   = location
+        node.parents    = Vector()
 
         node
       }
@@ -627,6 +650,7 @@ object Core {
         node.left     = leftLink
         node.right    = rightLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -658,6 +682,7 @@ object Core {
         node.left     = leftLink
         node.right    = rightLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -686,6 +711,7 @@ object Core {
         node.left     = leftLink
         node.right    = rightLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -714,6 +740,7 @@ object Core {
         node.left     = leftLink
         node.right    = rightLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -742,6 +769,7 @@ object Core {
         node.left     = leftLink
         node.right    = rightLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -770,6 +798,7 @@ object Core {
         node.left     = leftLink
         node.right    = rightLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -802,6 +831,7 @@ object Core {
         node.arg      = argLink
         node.body     = bodyLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -835,6 +865,7 @@ object Core {
           node.args     = argsLink
           node.body     = bodyLink
           node.location = location
+          node.parents  = Vector()
 
           Right(node)
         } else {
@@ -881,6 +912,7 @@ object Core {
           node.name       = nameLink
           node.function   = functionLink
           node.location   = location
+          node.parents    = Vector()
 
           Right(node)
         } else {
@@ -948,6 +980,7 @@ object Core {
           node.suspended = suspendedLink
           node.default   = defaultLink
           node.location  = location
+          node.parents   = Vector()
 
           Right(node)
         } else {
@@ -987,6 +1020,7 @@ object Core {
         node.function = functionLink
         node.argument = argumentLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -1020,6 +1054,7 @@ object Core {
         node.operator = operatorLink
         node.right    = rightLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -1048,6 +1083,7 @@ object Core {
         node.arg      = argLink
         node.operator = operatorLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -1076,6 +1112,7 @@ object Core {
         node.operator = operatorLink
         node.arg      = argLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -1098,6 +1135,7 @@ object Core {
 
         node.operator = operatorLink
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -1127,6 +1165,7 @@ object Core {
 
         node.expression = expressionLink
         node.location   = location
+        node.parents    = Vector()
 
         node
       }
@@ -1148,6 +1187,7 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.LambdaShorthandArgument]
 
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -1179,6 +1219,7 @@ object Core {
         node.expression = expressionLink
         node.name       = nameLink
         node.location   = location
+        node.parents    = Vector()
 
         node
       }
@@ -1195,6 +1236,7 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.SuspendDefaultsOperator]
 
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -1227,6 +1269,7 @@ object Core {
           node.expressions = expressionsLink
           node.returnVal   = returnValLink
           node.location    = location
+          node.parents     = Vector()
 
           Right(node)
         } else {
@@ -1261,6 +1304,7 @@ object Core {
         node.name       = nameLink
         node.expression = expressionLink
         node.location   = location
+        node.parents    = Vector()
 
         node
       }
@@ -1292,6 +1336,7 @@ object Core {
           node.scrutinee = scrutineeLink
           node.branches  = branchesLink
           node.location  = location
+          node.parents   = Vector()
 
           Right(node)
         } else {
@@ -1326,6 +1371,7 @@ object Core {
         node.pattern    = patternLink
         node.expression = expressionLink
         node.location   = location
+        node.parents    = Vector()
 
         node
       }
@@ -1353,6 +1399,7 @@ object Core {
 
         node.matchExpression = matchExpressionLink
         node.location        = location
+        node.parents         = Vector()
 
         node
       }
@@ -1379,6 +1426,7 @@ object Core {
 
         node.matchExpression = matchExpressionLink
         node.location        = location
+        node.parents         = Vector()
 
         node
       }
@@ -1405,6 +1453,7 @@ object Core {
 
         node.matchExpression = matchExpressionLink
         node.location        = location
+        node.parents         = Vector()
 
         node
       }
@@ -1423,6 +1472,7 @@ object Core {
         val node = CoreDef.Node.addRefined[NodeShape.FallbackPattern]
 
         node.location = location
+        node.parents  = Vector()
 
         node
       }
@@ -1454,6 +1504,7 @@ object Core {
         node.commented = commentedLink
         node.doc       = docLink
         node.location  = location
+        node.parents   = Vector()
 
         node
       }
@@ -1486,6 +1537,7 @@ object Core {
             node.language = languageLink
             node.code     = codeLink
             node.location = location
+            node.parents  = Vector()
 
             Right(node)
           case _ =>
@@ -1514,6 +1566,7 @@ object Core {
 
         node.errorAst = errorAst
         node.location = errLocation
+        node.parents  = Vector()
 
         node
       }
@@ -1537,6 +1590,7 @@ object Core {
 
         node.erroneousCore = erroneousCoreLink
         node.location      = location
+        node.parents       = Vector()
 
         node
       }
@@ -1587,8 +1641,8 @@ object Core {
         */
       def isListNode(node: Node)(implicit core: Core): Boolean = {
         node match {
-          case NodeShape.MetaList.any(_) => true
           case NodeShape.MetaNil.any(_)  => true
+          case NodeShape.MetaList.any(_) => true
           case _                         => false
         }
       }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/CorePrimTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/CorePrimTest.scala
@@ -139,9 +139,9 @@ class CorePrimTest extends CompilerTest with BeforeAndAfterEach {
     consNode.location = LocationVal[CoreGraph](20, 30)
     consNode.parents  = Vector()
 
-    // Intentional re-assignment to check for clobbering
-    consNode.head     = emptyLink
+    // Intentional re-assignment in reverse order to check for clobbering
     consNode.tail     = nilLink
+    consNode.head     = emptyLink
 
     consNode.head shouldEqual emptyLink
     consNode.tail shouldEqual nilLink

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/CorePrimTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/CorePrimTest.scala
@@ -1,6 +1,7 @@
 package org.enso.compiler.test.core
 
 import org.enso.compiler.test.CompilerTest
+import org.enso.core.CoreGraph.DefinitionGen.Node.LocationVal
 import org.enso.core.CoreGraph.DefinitionGen.{
   AstStorage,
   Link,
@@ -24,7 +25,7 @@ import org.enso.syntax.text.AST
 class CorePrimTest extends CompilerTest with BeforeAndAfterEach {
 
   // === Test Setup ===========================================================
-  import org.enso.core.CoreGraph.DefinitionGen.CoreGraph
+  import org.enso.core.CoreGraph.DefinitionGen._
   import org.enso.core.CoreGraph.DefinitionGen.Link.Shape._
   import org.enso.core.CoreGraph.DefinitionGen.Node.Shape._
   import org.enso.core.CoreGraph.DefinitionGen.Node.Location._
@@ -127,6 +128,34 @@ class CorePrimTest extends CompilerTest with BeforeAndAfterEach {
       case _ => fail
     }
   }
+
+  node should "be able to be constructed without clobbering its fields" in {
+    val emptyLink = graph.addLink()
+    val nilLink   = graph.addLink()
+    val consNode  = Node.addRefined[MetaList]
+
+    consNode.head     = emptyLink
+    consNode.tail     = nilLink
+    consNode.location = LocationVal[CoreGraph](20, 30)
+    consNode.parents  = Vector()
+
+    // Intentional re-assignment to check for clobbering
+    consNode.head     = emptyLink
+    consNode.tail     = nilLink
+
+    consNode.head shouldEqual emptyLink
+    consNode.tail shouldEqual nilLink
+    consNode.sourceStart shouldEqual 20
+    consNode.sourceEnd shouldEqual 30
+    consNode.parents shouldEqual Vector()
+
+    consNode.wrapped match {
+      case MetaList.any(_) => succeed
+      case _               => fail
+    }
+  }
+
+  // === Tests for Node Shapes ================================================
 
   nodeShape should "be able to be empty" in {
     val n1 = graph.addNode()

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/CorePrimTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/CorePrimTest.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.test.core
 
 import org.enso.compiler.test.CompilerTest
 import org.enso.core.CoreGraph.DefinitionGen.{
+  AstStorage,
   Link,
   LiteralStorage,
   NameStorage,
@@ -10,6 +11,7 @@ import org.enso.core.CoreGraph.DefinitionGen.{
 }
 import org.scalatest.BeforeAndAfterEach
 import org.enso.graph.{Graph => PrimGraph}
+import org.enso.syntax.text.AST
 
 /** This file tests the primitive, low-level operations on core.
   *
@@ -33,12 +35,14 @@ class CorePrimTest extends CompilerTest with BeforeAndAfterEach {
   implicit var literalStorage: LiteralStorage        = _
   implicit var parentStorage: ParentStorage          = _
   implicit var nameStorage: NameStorage              = _
+  implicit var astStorage: AstStorage                = _
 
   override def beforeEach(): Unit = {
     graph          = PrimGraph[CoreGraph]()
     literalStorage = LiteralStorage()
     parentStorage  = ParentStorage()
     nameStorage    = NameStorage()
+    astStorage     = AstStorage()
   }
 
   // === Tests for Links ======================================================
@@ -807,13 +811,13 @@ class CorePrimTest extends CompilerTest with BeforeAndAfterEach {
     val n1 = graph.addNode()
     val l1 = graph.addLink()
 
-    Node.setShape[StructuralMatch](n1)
+    Node.setShape[StructuralPattern](n1)
 
     n1 match {
-      case StructuralMatch.any(n1) =>
+      case StructuralPattern.any(n1) =>
         n1.matchExpression = l1
 
-        n1.structuralMatch shouldEqual StructuralMatchVal(l1)
+        n1.structuralPattern shouldEqual StructuralPatternVal(l1)
       case _ => fail
     }
   }
@@ -822,13 +826,13 @@ class CorePrimTest extends CompilerTest with BeforeAndAfterEach {
     val n1 = graph.addNode()
     val l1 = graph.addLink()
 
-    Node.setShape[TypeMatch](n1)
+    Node.setShape[TypePattern](n1)
 
     n1 match {
-      case TypeMatch.any(n1) =>
+      case TypePattern.any(n1) =>
         n1.matchExpression = l1
 
-        n1.typeMatch shouldEqual TypeMatchVal(l1)
+        n1.typePattern shouldEqual TypePatternVal(l1)
       case _ => fail
     }
   }
@@ -837,13 +841,13 @@ class CorePrimTest extends CompilerTest with BeforeAndAfterEach {
     val n1 = graph.addNode()
     val l1 = graph.addLink()
 
-    Node.setShape[NamedMatch](n1)
+    Node.setShape[NamedPattern](n1)
 
     n1 match {
-      case NamedMatch.any(n1) =>
+      case NamedPattern.any(n1) =>
         n1.matchExpression = l1
 
-        n1.namedMatch shouldEqual NamedMatchVal(l1)
+        n1.namedPattern shouldEqual NamedPatternVal(l1)
       case _ => fail
     }
   }
@@ -851,11 +855,11 @@ class CorePrimTest extends CompilerTest with BeforeAndAfterEach {
   nodeShape should "be able to represent fallback patterns" in {
     val n1 = graph.addNode()
 
-    Node.setShape[FallbackMatch](n1)
+    Node.setShape[FallbackPattern](n1)
 
     n1 match {
-      case FallbackMatch.any(_) => succeed
-      case _                    => fail
+      case FallbackPattern.any(_) => succeed
+      case _                      => fail
     }
   }
 
@@ -894,17 +898,31 @@ class CorePrimTest extends CompilerTest with BeforeAndAfterEach {
   }
 
   nodeShape should "be able to represent syntax errors" in {
-    val n1 = graph.addNode()
-    val l1 = graph.addLink()
+    val n1  = graph.addNode()
+    val ast = AST.Blank()
 
     Node.setShape[SyntaxError](n1)
 
     n1 match {
       case SyntaxError.any(n1) =>
-        n1.errorNode = l1
+        n1.errorAst = ast
 
-        n1.syntaxError shouldEqual SyntaxErrorVal(l1)
+        n1.syntaxError shouldEqual SyntaxErrorVal(ast)
       case _ => fail
+    }
+  }
+
+  nodeShape should "be able to represent construction errors" in {
+    val n1 = graph.addNode()
+    val l1 = graph.addLink()
+
+    Node.setShape[ConstructionError](n1)
+
+    n1 match {
+      case ConstructionError.any(n1) =>
+        n1.erroneousCore = l1
+
+        n1.constructionError shouldEqual ConstructionErrorVal(l1)
     }
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/CoreTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/CoreTest.scala
@@ -10,6 +10,4 @@ import org.enso.compiler.test.CompilerTest
 //  - Linked List
 //  - Parent Link walk to same place
 //  - etc.
-class CoreTest extends CompilerTest {
-
-}
+class CoreTest extends CompilerTest {}

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
@@ -30,10 +30,10 @@ class SmartConstructorsTest extends CompilerTest with BeforeAndAfterEach {
   // === Tests for Link Smart Constructors ====================================
 
   "Links" should "be able to be made with a source and target" in {
-    val n1 = core.Node.New.empty()
-    val n2 = core.Node.New.empty()
+    val n1 = Core.Node.New.empty()
+    val n2 = Core.Node.New.empty()
 
-    val link = core.Link.New.connected(n1, n2)
+    val link = Core.Link.New.connected(n1, n2)
 
     link.source shouldEqual n1
     link.target shouldEqual n2

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
@@ -1431,30 +1431,42 @@ class SmartConstructorsTest
 
   // === Tests for Link Smart Constructors ====================================
 
-  "Links" should {
+  "Connected links" should {
     implicit val core: Core = new Core()
 
+    val n1 = Node.New.Empty()
+    val n2 = Node.New.Empty()
+
+    val link = Link.New.Connected(n1, n2)
+
     "be able to be made with a source and target" in {
-      val n1 = Node.New.Empty()
-      val n2 = Node.New.Empty()
-
-      val link = Link.New.Connected(n1, n2)
-
       link.source shouldEqual n1
       link.target shouldEqual n2
     }
 
+    "be a parent of their target" in {
+      n2.parents should contain(link.ix)
+    }
+  }
+
+  "Disconnected links" should {
+    implicit val core: Core = new Core()
+
+    val sourceNode = Node.New.MetaNil()
+
+    val link = Link.New.Disconnected(sourceNode)
+
     "be able to be made with only a source" in {
-      val sourceNode = Node.New.MetaNil()
-
-      val link = Link.New.Disconnected(sourceNode)
-
       link.source shouldEqual sourceNode
 
       link.target match {
         case NodeShape.Empty.any(_) => succeed
         case _                      => fail
       }
+    }
+
+    "be a parent of their empty target" in {
+      link.target.parents should contain(link.ix)
     }
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
@@ -2,11 +2,11 @@ package org.enso.compiler.test.core
 
 import cats.data.NonEmptyList
 import org.enso.compiler.core.Core
-import org.enso.compiler.core.Core.Node.Utility
+import org.enso.compiler.core.Core.Node.{Constants, Utility}
 import org.enso.core.CoreGraph.DefinitionGen.Node.{Shape => NodeShape}
 import org.enso.core.CoreGraph.{DefinitionGen => CoreDef}
 import org.enso.graph.{Graph => PrimGraph}
-import org.enso.syntax.text.{Location => AstLocation}
+import org.enso.syntax.text.{AST, Location => AstLocation}
 import org.scalatest.{Assertion, BeforeAndAfterEach, Matchers, WordSpec}
 
 class SmartConstructorsTest
@@ -31,33 +31,43 @@ class SmartConstructorsTest
 
   // === Utilities ============================================================
 
-  /** Expresses that a node should fail to construct, and provide the erroneous
-    * core structures in [[errList]].
+  /** Embodies the notion that a given node construction should fail with a
+    * provided result.
     *
-    * @param maybeErr the value coming out of the smart constructor being tested
-    * @param errList a meta list (on the core graph) containing the erroneous
-    *                core
-    * @param core an implicit core instance
-    * @tparam T the particular node shape being tested
-    * @return a success if [[maybeErr]] is a failure and the contained error
-    *         matches [[errList]], otherwise a failure
+    * @param maybeErr the result of the possibly-erroring node construction
+    * @param core an implicit instance of core
+    * @tparam T the type of the node construction when it succeeds
     */
-  def shouldFailWith[T <: CoreDef.Node.Shape](
-    maybeErr: Core.ConsErrOr[T],
-    errList: RefinedNode[MetaList]
-  )(implicit core: Core): Assertion = {
-    maybeErr match {
-      case Left(err) =>
-        err.erroneousCore.target match {
-          case NodeShape.MetaList.any(xs) =>
-            if (Utility.listsAreEqual(xs, errList)) {
-              succeed
-            } else {
-              fail
-            }
-          case _ => fail
-        }
-      case Right(_) => fail
+  implicit class ShouldFailWithResult[T <: CoreDef.Node.Shape](
+    maybeErr: Core.ConsErrOr[T]
+  )(
+    implicit core: Core
+  ) {
+
+    /** Expresses that a node should fail to construct, and provide the
+      * erroneous core structures in [[errList]].
+      *
+      * @param errList a meta list (on the core graph) containing the erroneous
+      *                core
+      * @return a success if [[maybeErr]] is a failure and the contained error
+      *         matches [[errList]], otherwise a failure
+      */
+    def shouldFailWithResult[T <: CoreDef.Node.Shape](
+      errList: RefinedNode[MetaList]
+    ): Assertion = {
+      maybeErr match {
+        case Left(err) =>
+          err.erroneousCore.target match {
+            case NodeShape.MetaList.any(xs) =>
+              if (Utility.listsAreEqual(xs, errList)) {
+                succeed
+              } else {
+                fail
+              }
+            case _ => fail
+          }
+        case Right(_) => fail
+      }
     }
   }
 
@@ -97,9 +107,9 @@ class SmartConstructorsTest
     }
 
     "fail to construct if tail isn't a valid meta list" in {
-      val failNode = Node.New.MetaList(emptyNode, emptyNode)
+      val node = Node.New.MetaList(emptyNode, emptyNode)
 
-      shouldFailWith(failNode, Utility.coreListFrom(emptyNode))
+      node shouldFailWithResult Utility.coreListFrom(emptyNode)
     }
   }
 
@@ -237,13 +247,13 @@ class SmartConstructorsTest
     }
 
     "fail to construct if imports isn't a meta list" in {
-      val failNode = Node.New.ModuleDef(name, name, defNil, dummyLocation)
-      shouldFailWith(failNode, Utility.coreListFrom(name))
+      val node = Node.New.ModuleDef(name, name, defNil, dummyLocation)
+      node shouldFailWithResult Utility.coreListFrom(name)
     }
 
     "fail if construct definitions isn't a meta list" in {
-      val failNode = Node.New.ModuleDef(name, importNil, name, dummyLocation)
-      shouldFailWith(failNode, Utility.coreListFrom(name))
+      val node = Node.New.ModuleDef(name, importNil, name, dummyLocation)
+      node shouldFailWithResult Utility.coreListFrom(name)
     }
   }
 
@@ -269,9 +279,9 @@ class SmartConstructorsTest
     }
 
     "fail to construct if segments isn't a valid meta list" in {
-      val errNode = Node.New.Import(empty, dummyLocation)
+      val node = Node.New.Import(empty, dummyLocation)
 
-      shouldFailWith(errNode, Utility.coreListFrom(empty))
+      node shouldFailWithResult Utility.coreListFrom(empty)
     }
   }
 
@@ -303,10 +313,10 @@ class SmartConstructorsTest
     }
 
     "fail to construct if binding isn't a valid binding" in {
-      val errNode =
+      val node =
         Node.New.TopLevelBinding(emptyModule, bindingSrc, dummyLocation)
 
-      shouldFailWith(errNode, Utility.coreListFrom(bindingSrc))
+      node shouldFailWithResult Utility.coreListFrom(bindingSrc)
     }
   }
 
@@ -339,8 +349,9 @@ class SmartConstructorsTest
     }
 
     "fail to construct if args is not a valid meta list" in {
-      val errNode = Node.New.AtomDef(name, argName, dummyLocation)
-      shouldFailWith(errNode, Utility.coreListFrom(argName))
+      val node = Node.New.AtomDef(name, argName, dummyLocation)
+
+      node shouldFailWithResult Utility.coreListFrom(argName)
     }
   }
 
@@ -377,12 +388,12 @@ class SmartConstructorsTest
     }
 
     "fail to construct of the type params are not a valid meta list" in {
-      val errNode = Node.New.TypeDef(name, name, body, dummyLocation)
-      shouldFailWith(errNode, Utility.coreListFrom(name))
+      val node = Node.New.TypeDef(name, name, body, dummyLocation)
+      node shouldFailWithResult Utility.coreListFrom(name)
     }
     "fail to construct if the body is not a valid meta list" in {
-      val errNode = Node.New.TypeDef(name, tParams, name, dummyLocation)
-      shouldFailWith(errNode, Utility.coreListFrom(name))
+      val node = Node.New.TypeDef(name, tParams, name, dummyLocation)
+      node shouldFailWithResult Utility.coreListFrom(name)
     }
   }
 
@@ -685,8 +696,8 @@ class SmartConstructorsTest
     }
 
     "fail to construct if args is not a meta list" in {
-      val errNode = Node.New.FunctionDef(name, name, body, dummyLocation)
-      shouldFailWith(errNode, Utility.coreListFrom(name))
+      val node = Node.New.FunctionDef(name, name, body, dummyLocation)
+      node shouldFailWithResult Utility.coreListFrom(name)
     }
   }
 
@@ -723,19 +734,605 @@ class SmartConstructorsTest
     }
 
     "fail to construct if function is not a valid function representation" in {
-      val errNode = Node.New.MethodDef(targetPath, name, name, dummyLocation)
-      shouldFailWith(errNode, Utility.coreListFrom(name))
+      val node = Node.New.MethodDef(targetPath, name, name, dummyLocation)
+      node shouldFailWithResult Utility.coreListFrom(name)
     }
   }
 
   // === Tests for Node Smart Constructors (Def-Site Args) ====================
 
+  "Ignored argument nodes" should {
+    implicit val core: Core = new Core()
+
+    val ignored = Node.New.IgnoredArgument(dummyLocation)
+
+    "have valid fields" in {
+      ignored.location shouldEqual dummyLocation
+      ignored.parents shouldEqual Vector()
+    }
+  }
+
+  "Definition argument nodes" should {
+    implicit val core: Core = new Core()
+
+    val name      = Node.New.Empty()
+    val suspended = Node.New.MetaTrue()
+    val default   = Node.New.Empty()
+
+    val arg = Node.New
+      .DefinitionArgument(name, suspended, default, dummyLocation)
+      .right
+      .get
+
+    "have valid fields" in {
+      arg.location shouldEqual dummyLocation
+      arg.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      arg.name.source shouldEqual arg
+      arg.name.target shouldEqual name
+      arg.suspended.source shouldEqual arg
+      arg.suspended.target shouldEqual suspended
+      arg.default.source shouldEqual arg
+      arg.default.target shouldEqual default
+    }
+
+    "have children parented to the node" in {
+      name.parents should contain(arg.name.ix)
+      suspended.parents should contain(arg.suspended.ix)
+      default.parents should contain(arg.default.ix)
+    }
+
+    "fail to construct if suspended is not a meta boolean" in {
+      val node = Node.New.DefinitionArgument(name, name, default, dummyLocation)
+      node shouldFailWithResult Utility.coreListFrom(name)
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Applications) =====================
+
+  "Application nodes" should {
+    implicit val core: Core = new Core()
+
+    val function = Node.New.Empty()
+    val argument = Node.New.Empty()
+
+    val application = Node.New.Application(function, argument, dummyLocation)
+
+    "have valid fields" in {
+      application.location shouldEqual dummyLocation
+      application.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      application.function.source shouldEqual application
+      application.function.target shouldEqual function
+      application.argument.source shouldEqual application
+      application.argument.target shouldEqual argument
+    }
+
+    "have children parented to the node" in {
+      function.parents should contain(application.function.ix)
+      argument.parents should contain(application.argument.ix)
+    }
+  }
+
+  "Infix application nodes" should {
+    implicit val core: Core = new Core()
+
+    val left     = Node.New.Empty()
+    val operator = Node.New.Empty()
+    val right    = Node.New.Empty()
+
+    val app = Node.New.InfixApplication(left, operator, right, dummyLocation)
+
+    "have valid fields" in {
+      app.location shouldEqual dummyLocation
+      app.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      app.left.source shouldEqual app
+      app.left.target shouldEqual left
+      app.operator.source shouldEqual app
+      app.operator.target shouldEqual operator
+      app.right.source shouldEqual app
+      app.right.target shouldEqual right
+    }
+
+    "have children parented to the node" in {
+      left.parents should contain(app.left.ix)
+      operator.parents should contain(app.operator.ix)
+      right.parents should contain(app.right.ix)
+    }
+  }
+
+  "Left section nodes" should {
+    implicit val core: Core = new Core()
+
+    val arg      = Node.New.Empty()
+    val operator = Node.New.Empty()
+
+    val sec = Node.New.LeftSection(arg, operator, dummyLocation)
+
+    "have valid fields" in {
+      sec.location shouldEqual dummyLocation
+      sec.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      sec.arg.source shouldEqual sec
+      sec.arg.target shouldEqual arg
+      sec.operator.source shouldEqual sec
+      sec.operator.target shouldEqual operator
+    }
+
+    "have children parented to the node" in {
+      arg.parents should contain(sec.arg.ix)
+      operator.parents should contain(sec.operator.ix)
+    }
+  }
+
+  "Right section nodes" should {
+    implicit val core: Core = new Core()
+
+    val operator = Node.New.Empty()
+    val arg      = Node.New.Empty()
+
+    val sec = Node.New.RightSection(operator, arg, dummyLocation)
+
+    "have valid fields" in {
+      sec.location shouldEqual dummyLocation
+      sec.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      sec.operator.source shouldEqual sec
+      sec.operator.target shouldEqual operator
+      sec.arg.source shouldEqual sec
+      sec.arg.target shouldEqual arg
+    }
+
+    "have children parented to the node" in {
+      operator.parents should contain(sec.operator.ix)
+      arg.parents should contain(sec.arg.ix)
+    }
+  }
+
+  "Centre section nodes" should {
+    implicit val core: Core = new Core()
+
+    val operator = Node.New.Empty()
+
+    val sec = Node.New.CentreSection(operator, dummyLocation)
+
+    "have valid fields" in {
+      sec.location shouldEqual dummyLocation
+      sec.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      sec.operator.source shouldEqual sec
+      sec.operator.target shouldEqual operator
+    }
+
+    "have children parented to the node" in {
+      operator.parents should contain(sec.operator.ix)
+    }
+  }
+
+  "Forced term nodes" should {
+    implicit val core: Core = new Core()
+
+    val expression = Node.New.Empty()
+
+    val forcedTerm = Node.New.ForcedTerm(expression, dummyLocation)
+
+    "have valid fields" in {
+      forcedTerm.location shouldEqual dummyLocation
+      forcedTerm.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      forcedTerm.expression.source shouldEqual forcedTerm
+      forcedTerm.expression.target shouldEqual expression
+    }
+
+    "have children parented to the node" in {
+      expression.parents should contain(forcedTerm.expression.ix)
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Call-Site Args) ===================
+
+  "Lambda shorthand argument nodes" should {
+    implicit val core: Core = new Core()
+
+    val arg = Node.New.LambdaShorthandArgument(dummyLocation)
+
+    "have valid fields" in {
+      arg.location shouldEqual dummyLocation
+      arg.parents shouldEqual Vector()
+    }
+  }
+
+  "Call-site argument nodes" should {
+    implicit val core: Core = new Core()
+
+    val expression = Node.New.Empty()
+    val name       = Node.New.Empty()
+
+    val arg = Node.New.CallSiteArgument(expression, name, dummyLocation)
+
+    "have valid fields" in {
+      arg.location shouldEqual dummyLocation
+      arg.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      arg.expression.source shouldEqual arg
+      arg.expression.target shouldEqual expression
+      arg.name.source shouldEqual arg
+      arg.name.target shouldEqual name
+    }
+
+    "have children parented to the node" in {
+      expression.parents should contain(arg.expression.ix)
+      name.parents should contain(arg.name.ix)
+    }
+  }
+
+  "Default suspension operator nodes" should {
+    implicit val core: Core = new Core()
+
+    val suspend = Node.New.SuspendDefaultsOperator(dummyLocation)
+
+    "have valid fields" in {
+      suspend.location shouldEqual dummyLocation
+      suspend.parents shouldEqual Vector()
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Structure) ========================
+
+  "Block nodes" should {
+    implicit val core: Core = new Core()
+
+    val expressions = Utility.coreListFrom(Node.New.Empty())
+    val returnVal   = Node.New.Empty()
+
+    val block = Node.New.Block(expressions, returnVal, dummyLocation).right.get
+
+    "have valid fields" in {
+      block.location shouldEqual dummyLocation
+      block.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      block.expressions.source shouldEqual block
+      block.expressions.target shouldEqual expressions
+      block.returnVal.source shouldEqual block
+      block.returnVal.target shouldEqual returnVal
+    }
+
+    "have children parented to the node" in {
+      expressions.parents should contain(block.expressions.ix)
+      returnVal.parents should contain(block.returnVal.ix)
+    }
+
+    "fail to construct if expressions is not a valid meta list" in {
+      val node = Node.New.Block(returnVal, returnVal, dummyLocation)
+      node shouldFailWithResult Utility.coreListFrom(returnVal)
+    }
+  }
+
+  "Binding nodes" should {
+    implicit val core: Core = new Core()
+
+    val name       = Node.New.Empty()
+    val expression = Node.New.Empty()
+
+    val binding = Node.New.Binding(name, expression, dummyLocation)
+
+    "have valid fields" in {
+      binding.location shouldEqual dummyLocation
+      binding.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      binding.name.source shouldEqual binding
+      binding.name.target shouldEqual name
+      binding.expression.source shouldEqual binding
+      binding.expression.target shouldEqual expression
+    }
+
+    "have children parented to the node" in {
+      name.parents should contain(binding.name.ix)
+      expression.parents should contain(binding.expression.ix)
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Case Expression) ==================
+
+  "Case expression nodes" should {
+    implicit val core: Core = new Core()
+
+    val scrutinee = Node.New.Empty()
+    val branches  = Utility.coreListFrom(Node.New.Empty())
+
+    val caseExpr =
+      Node.New.CaseExpr(scrutinee, branches, dummyLocation).right.get
+
+    "have valid fields" in {
+      caseExpr.location shouldEqual dummyLocation
+      caseExpr.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      caseExpr.scrutinee.source shouldEqual caseExpr
+      caseExpr.scrutinee.target shouldEqual scrutinee
+      caseExpr.branches.source shouldEqual caseExpr
+      caseExpr.branches.target shouldEqual branches
+    }
+
+    "have children parented to the node" in {
+      scrutinee.parents should contain(caseExpr.scrutinee.ix)
+      branches.parents should contain(caseExpr.branches.ix)
+    }
+
+    "fail to construct if branches is not a valid meta list" in {
+      val node = Node.New.CaseExpr(scrutinee, scrutinee, dummyLocation)
+      node shouldFailWithResult Utility.coreListFrom(scrutinee)
+    }
+  }
+
+  "Case branch nodes" should {
+    implicit val core: Core = new Core()
+
+    val pattern    = Node.New.Empty()
+    val expression = Node.New.Empty()
+
+    val caseBranch = Node.New.CaseBranch(pattern, expression, dummyLocation)
+
+    "have valid fields" in {
+      caseBranch.location shouldEqual dummyLocation
+      caseBranch.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      caseBranch.pattern.source shouldEqual caseBranch
+      caseBranch.pattern.target shouldEqual pattern
+      caseBranch.expression.source shouldEqual caseBranch
+      caseBranch.expression.target shouldEqual expression
+    }
+
+    "have children parented to the node" in {
+      pattern.parents should contain(caseBranch.pattern.ix)
+      expression.parents should contain(caseBranch.expression.ix)
+    }
+  }
+
+  "Structural pattern nodes" should {
+    implicit val core: Core = new Core()
+
+    val matchExpression = Node.New.Empty()
+
+    val pattern = Node.New.StructuralPattern(matchExpression, dummyLocation)
+
+    "have valid fields" in {
+      pattern.location shouldEqual dummyLocation
+      pattern.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      pattern.matchExpression.source shouldEqual pattern
+      pattern.matchExpression.target shouldEqual matchExpression
+    }
+
+    "have children parented to the node" in {
+      matchExpression.parents should contain(pattern.matchExpression.ix)
+    }
+  }
+
+  "Type pattern nodes" should {
+    implicit val core: Core = new Core()
+
+    val matchExpression = Node.New.Empty()
+
+    val pattern = Node.New.TypePattern(matchExpression, dummyLocation)
+
+    "have valid fields" in {
+      pattern.location shouldEqual dummyLocation
+      pattern.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      pattern.matchExpression.source shouldEqual pattern
+      pattern.matchExpression.target shouldEqual matchExpression
+    }
+
+    "have children parented to the node" in {
+      matchExpression.parents should contain(pattern.matchExpression.ix)
+    }
+  }
+
+  "Named pattern nodes" should {
+    implicit val core: Core = new Core()
+
+    val matchExpression = Node.New.Empty()
+
+    val pattern = Node.New.NamedPattern(matchExpression, dummyLocation)
+
+    "have valid fields" in {
+      pattern.location shouldEqual dummyLocation
+      pattern.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      pattern.matchExpression.source shouldEqual pattern
+      pattern.matchExpression.target shouldEqual matchExpression
+    }
+
+    "have children parented to the node" in {
+      matchExpression.parents should contain(pattern.matchExpression.ix)
+    }
+  }
+
+  "Fallback pattern nodes" should {
+    implicit val core: Core = new Core()
+
+    val pattern = Node.New.FallbackPattern(dummyLocation)
+
+    "have valid fields" in {
+      pattern.location shouldEqual dummyLocation
+      pattern.parents shouldEqual Vector()
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Comments) =========================
+
+  "Doc comment nodes" should {
+    implicit val core: Core = new Core()
+
+    val commented = Node.New.Empty()
+    val doc       = Node.New.Empty()
+
+    val docComment = Node.New.DocComment(commented, doc, dummyLocation)
+
+    "have valid fields" in {
+      docComment.location shouldEqual dummyLocation
+      docComment.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      docComment.commented.source shouldEqual docComment
+      docComment.commented.target shouldEqual commented
+      docComment.doc.source shouldEqual docComment
+      docComment.doc.target shouldEqual doc
+    }
+
+    "have children parented to the node" in {
+      commented.parents should contain(docComment.commented.ix)
+      doc.parents should contain(docComment.doc.ix)
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Foreign) ==========================
+
+  "Foreign definition nodes" should {
+    implicit val core: Core = new Core()
+
+    val language = Node.New.Empty()
+    val code =
+      Node.New.ForeignCodeLiteral("lambda x: x + 1", dummyLocation)
+
+    val foreignDefinition =
+      Node.New.ForeignDefinition(language, code, dummyLocation).right.get
+
+    "have valid fields" in {
+      foreignDefinition.location shouldEqual dummyLocation
+      foreignDefinition.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      foreignDefinition.language.source shouldEqual foreignDefinition
+      foreignDefinition.language.target shouldEqual language
+      foreignDefinition.code.source shouldEqual foreignDefinition
+      foreignDefinition.code.target shouldEqual code
+    }
+
+    "have children parented to the node" in {
+      language.parents should contain(foreignDefinition.language.ix)
+      code.parents should contain(foreignDefinition.code.ix)
+    }
+
+    "fail to construct of code is not a valid foreign code literal" in {
+      val node = Node.New.ForeignDefinition(language, language, dummyLocation)
+      node shouldFailWithResult Utility.coreListFrom(language)
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Errors) ===========================
+
+  "Syntax error nodes" should {
+    implicit val core: Core = new Core()
+
+    val astWithLocation: AST = AST
+      .Blank()
+      .setLocation(
+        AstLocation(dummyLocation.sourceStart, dummyLocation.sourceEnd)
+      )
+    val astNoLocation: AST = AST.Blank()
+
+    val syntaxError = Node.New.SyntaxError(astWithLocation)
+
+    "have valid fields" in {
+      syntaxError.parents shouldEqual Vector()
+    }
+
+    "inherit the location from the AST" in {
+      syntaxError.location shouldEqual dummyLocation
+    }
+
+    "default to an invalid location if the AST does not provide any" in {
+      val errorNoLocation = Node.New.SyntaxError(astNoLocation)
+      errorNoLocation.location shouldEqual Constants.invalidLocation
+    }
+  }
+
+  "Construction error nodes" should {
+    implicit val core: Core = new Core()
+
+    val errNode = Node.New.Empty()
+    val errList = Utility.coreListFrom(errNode)
+    val error   = Node.New.ConstructionError(errList, dummyLocation)
+
+    "have valid fields" in {
+      error.location shouldEqual dummyLocation
+      error.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      error.erroneousCore.source shouldEqual error
+      error.erroneousCore.target shouldEqual errList
+    }
+
+    "have children parented to the node" in {
+      errList.parents should contain(error.erroneousCore.ix)
+    }
+
+    "use a passed-in meta list unchanged" in {
+      error.erroneousCore.target shouldEqual errList
+    }
+
+    "contain a meta-list if passed a single node" in {
+      import PrimGraph.VariantCast
+      val input = errNode
+      val err   = Node.New.ConstructionError(input, dummyLocation)
+
+      input.wrapped.is[NodeShape.Empty] shouldEqual true
+
+      Utility.isListNode(input) should not equal true
+      Utility.isListNode(err.erroneousCore.target) shouldEqual true
+
+      // The only element in that list should be the single node
+      err.erroneousCore.target.unsafeAs[MetaList].head.target shouldEqual input
+      err.erroneousCore.target
+        .unsafeAs[MetaList]
+        .tail
+        .target
+        .is[MetaNil] shouldBe true
+    }
+  }
+
   // === Tests for Node Utility Functions =====================================
 
   "Lists" should {
     implicit val core: Core = new Core()
-    val empty1              = Node.New.Empty().wrapped
-    val empty2              = Node.New.Empty().wrapped
+
+    val empty1 = Node.New.Empty().wrapped
+    val empty2 = Node.New.Empty().wrapped
 
     val list1 = Utility.coreListFrom(NonEmptyList(empty1, List(empty2)))
     val list2 = Utility.coreListFrom(NonEmptyList(empty1, List(empty2)))

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
@@ -1,11 +1,13 @@
 package org.enso.compiler.test.core
 
+import cats.data.NonEmptyList
 import org.enso.core.CoreGraph.{DefinitionGen => CoreDef}
 import org.enso.graph.{Graph => PrimGraph}
 import org.enso.core.CoreGraph.DefinitionGen.Node.{Shape => NodeShape}
 import org.enso.compiler.core.Core
 import org.enso.compiler.test.CompilerTest
 import org.scalatest.BeforeAndAfterEach
+import org.enso.syntax.text.{Location => AstLocation}
 
 class SmartConstructorsTest extends CompilerTest with BeforeAndAfterEach {
 
@@ -40,6 +42,53 @@ class SmartConstructorsTest extends CompilerTest with BeforeAndAfterEach {
     Core.Node.Utility.isListNode(emptyNode) shouldEqual false
     Core.Node.Utility.isListNode(nilNode) shouldEqual true
     Core.Node.Utility.isListNode(consNode) shouldEqual true
+  }
+
+  "Core lists" should "be able to be constructed from arbitrary nodes" in {
+    val emptyNode1 = Node.New.empty().wrapped
+    val emptyNode2 = Node.New.empty().wrapped
+    val emptyNode3 = Node.New.empty().wrapped
+
+    val listOfOne = Core.Node.Utility.coreListFrom(emptyNode1)
+    val listOfMany = Core.Node.Utility
+      .coreListFrom(NonEmptyList(emptyNode1, List(emptyNode2, emptyNode3)))
+
+    listOfOne.head.target shouldEqual emptyNode1
+
+    listOfOne.tail.target match {
+      case NodeShape.MetaNil.any(_) =>
+      case _                        => fail
+    }
+
+    listOfMany.head.target shouldEqual emptyNode1
+
+    listOfMany.tail.target match {
+      case NodeShape.MetaList.any(e2) =>
+        e2.head.target shouldEqual emptyNode2
+
+        e2.tail.target match {
+          case NodeShape.MetaList.any(e3) =>
+            e3.head.target shouldEqual emptyNode3
+            e3.tail.target match {
+              case NodeShape.MetaNil.any(_) => succeed
+              case _                        => fail
+            }
+          case _ => fail
+        }
+      case _ => fail
+    }
+  }
+
+  // === Tests for Node Conversions ===========================================
+
+  "AST locations" should "be converted losslessly to core locations" in {
+    val startLoc = 1232
+    val endLoc = 1337
+
+    val astLoc = AstLocation(startLoc, endLoc)
+    val coreLoc = CoreDef.Node.LocationVal(startLoc, endLoc)
+
+    Node.Conversions.astLocationToNodeLocation(astLoc) shouldEqual coreLoc
   }
 
   // === Tests for Link Smart Constructors ====================================

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
@@ -1,119 +1,846 @@
 package org.enso.compiler.test.core
 
 import cats.data.NonEmptyList
+import org.enso.compiler.core.Core
+import org.enso.compiler.core.Core.Node.Utility
+import org.enso.core.CoreGraph.DefinitionGen.Node.{Shape => NodeShape}
 import org.enso.core.CoreGraph.{DefinitionGen => CoreDef}
 import org.enso.graph.{Graph => PrimGraph}
-import org.enso.core.CoreGraph.DefinitionGen.Node.{Shape => NodeShape}
-import org.enso.compiler.core.Core
-import org.enso.compiler.test.CompilerTest
-import org.scalatest.BeforeAndAfterEach
 import org.enso.syntax.text.{Location => AstLocation}
+import org.scalatest.{Assertion, BeforeAndAfterEach, Matchers, WordSpec}
 
-class SmartConstructorsTest extends CompilerTest with BeforeAndAfterEach {
+class SmartConstructorsTest
+    extends WordSpec
+    with Matchers
+    with BeforeAndAfterEach {
 
   // === Test Setup ===========================================================
 
+  import Core._
   import CoreDef.Link.Shape._
   import CoreDef.Node.Location._
   import CoreDef.Node.ParentLinks._
   import CoreDef.Node.Shape._
   import PrimGraph.Component.Refined._
-  import Core._
-
-  implicit var core: Core = _
-
-  override def beforeEach(): Unit = {
-    core = new Core()
-  }
 
   // === Useful Constants =====================================================
-  val blankLocation: CoreDef.Node.LocationVal[Graph] =
-    CoreDef.Node.LocationVal(0, 0)
+  val constantLocationStart = 201
+  val constantLocationEnd   = 1337
+  val dummyLocation: CoreDef.Node.LocationVal[Graph] =
+    CoreDef.Node.LocationVal(constantLocationStart, constantLocationEnd)
 
-  // === Tests for Node Smart Constructors ====================================
+  // === Utilities ============================================================
 
-  // === Tests for Node Utility Functions =====================================
-
-  "Nodes for meta lists" should "be correctly identified" in {
-    val emptyNode = Node.New.empty()
-    val nilNode   = Node.New.metaNil()
-    val consNode  = Node.New.metaList(emptyNode, nilNode).right.get
-
-    Core.Node.Utility.isListNode(emptyNode) shouldEqual false
-    Core.Node.Utility.isListNode(nilNode) shouldEqual true
-    Core.Node.Utility.isListNode(consNode) shouldEqual true
-  }
-
-  "Core lists" should "be able to be constructed from arbitrary nodes" in {
-    val emptyNode1 = Node.New.empty().wrapped
-    val emptyNode2 = Node.New.empty().wrapped
-    val emptyNode3 = Node.New.empty().wrapped
-
-    val listOfOne = Core.Node.Utility.coreListFrom(emptyNode1)
-    val listOfMany = Core.Node.Utility
-      .coreListFrom(NonEmptyList(emptyNode1, List(emptyNode2, emptyNode3)))
-
-    listOfOne.head.target shouldEqual emptyNode1
-
-    listOfOne.tail.target match {
-      case NodeShape.MetaNil.any(_) =>
-      case _                        => fail
-    }
-
-    listOfMany.head.target shouldEqual emptyNode1
-
-    listOfMany.tail.target match {
-      case NodeShape.MetaList.any(e2) =>
-        e2.head.target shouldEqual emptyNode2
-
-        e2.tail.target match {
-          case NodeShape.MetaList.any(e3) =>
-            e3.head.target shouldEqual emptyNode3
-            e3.tail.target match {
-              case NodeShape.MetaNil.any(_) => succeed
-              case _                        => fail
+  /** Expresses that a node should fail to construct, and provide the erroneous
+    * core structures in [[errList]].
+    *
+    * @param maybeErr the value coming out of the smart constructor being tested
+    * @param errList a meta list (on the core graph) containing the erroneous
+    *                core
+    * @param core an implicit core instance
+    * @tparam T the particular node shape being tested
+    * @return a success if [[maybeErr]] is a failure and the contained error
+    *         matches [[errList]], otherwise a failure
+    */
+  def shouldFailWith[T <: CoreDef.Node.Shape](
+    maybeErr: Core.ConsErrOr[T],
+    errList: RefinedNode[MetaList]
+  )(implicit core: Core): Assertion = {
+    maybeErr match {
+      case Left(err) =>
+        err.erroneousCore.target match {
+          case NodeShape.MetaList.any(xs) =>
+            if (Utility.listsAreEqual(xs, errList)) {
+              succeed
+            } else {
+              fail
             }
           case _ => fail
         }
-      case _ => fail
+      case Right(_) => fail
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Meta Shapes) ======================
+
+  "Empty nodes" should {
+    implicit val core: Core = new Core()
+    val emptyNode           = Node.New.Empty()
+
+    "have valid fields" in {
+      emptyNode.location shouldEqual Node.Constants.invalidLocation
+      emptyNode.parents shouldEqual Vector()
+    }
+  }
+
+  "Meta list nodes" should {
+    implicit val core: Core = new Core()
+    val emptyNode           = Node.New.Empty()
+    val nilNode             = Node.New.MetaNil()
+    val listNode            = Node.New.MetaList(emptyNode, nilNode).right.get
+
+    "have valid fields" in {
+      listNode.location shouldEqual Node.Constants.invalidLocation
+      listNode.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      listNode.head.source shouldEqual listNode
+      listNode.head.target shouldEqual emptyNode
+      listNode.tail.source shouldEqual listNode
+      listNode.tail.target shouldEqual nilNode
+    }
+
+    "have children parented to the node" in {
+      emptyNode.parents should contain(listNode.head.ix)
+      nilNode.parents should contain(listNode.tail.ix)
+    }
+
+    "fail to construct if tail isn't a valid meta list" in {
+      val failNode = Node.New.MetaList(emptyNode, emptyNode)
+
+      shouldFailWith(failNode, Utility.coreListFrom(emptyNode))
+    }
+  }
+
+  "Meta nil nodes" should {
+    implicit val core: Core = new Core()
+    val nilNode             = Node.New.MetaNil()
+
+    "have valid fields" in {
+      nilNode.location shouldEqual Node.Constants.invalidLocation
+      nilNode.parents shouldEqual Vector()
+    }
+  }
+
+  "Meta true nodes" should {
+    implicit val core: Core = new Core()
+    val trueNode            = Node.New.MetaTrue()
+
+    "have valid fields" in {
+      trueNode.location shouldEqual Node.Constants.invalidLocation
+      trueNode.parents shouldEqual Vector()
+    }
+  }
+
+  "Meta false nodes" should {
+    implicit val core: Core = new Core()
+    val falseNode           = Node.New.MetaFalse()
+
+    "have valid fields" in {
+      falseNode.location shouldEqual Node.Constants.invalidLocation
+      falseNode.parents shouldEqual Vector()
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Literals) =========================
+
+  "Numeric literal nodes" should {
+    implicit val core: Core = new Core()
+    val numLit              = "1e-262"
+    val number              = Node.New.NumericLiteral(numLit, dummyLocation)
+
+    "have valid fields" in {
+      number.number shouldEqual numLit
+      number.location shouldEqual dummyLocation
+      number.parents shouldEqual Vector()
+    }
+  }
+
+  "Text literal nodes" should {
+    implicit val core: Core = new Core()
+    val textLit             = "FooBarBaz"
+    val text                = Node.New.TextLiteral(textLit, dummyLocation)
+
+    "have valid fields" in {
+      text.text shouldEqual textLit
+      text.location shouldEqual dummyLocation
+      text.parents shouldEqual Vector()
+    }
+  }
+
+  "Foreign code literal nodes" should {
+    implicit val core: Core = new Core()
+    val codeLit             = "lambda x: x + 1"
+    val code                = Node.New.ForeignCodeLiteral(codeLit, dummyLocation)
+
+    "have valid fields" in {
+      code.code shouldEqual codeLit
+      code.location shouldEqual dummyLocation
+      code.parents shouldEqual Vector()
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Names) ============================
+
+  "Name nodes" should {
+    implicit val core: Core = new Core()
+    val nameLit             = "MyType"
+    val name                = Node.New.Name(nameLit, dummyLocation)
+
+    "have valid fields" in {
+      name.nameLiteral shouldEqual nameLit
+      name.location shouldEqual dummyLocation
+      name.parents shouldEqual Vector()
+    }
+  }
+
+  "This name nodes" should {
+    implicit val core: Core = new Core()
+    val thisName            = Node.New.ThisName(dummyLocation)
+
+    "have valid fields" in {
+      thisName.location shouldEqual dummyLocation
+      thisName.parents shouldEqual Vector()
+    }
+  }
+
+  "Here name nodes" should {
+    implicit val core: Core = new Core()
+    val hereName            = Node.New.HereName(dummyLocation)
+
+    "have valid fields" in {
+      hereName.location shouldEqual dummyLocation
+      hereName.parents shouldEqual Vector()
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Module) ===========================
+
+  "Module nodes" should {
+    implicit val core: Core = new Core()
+    val importNil           = Node.New.MetaNil()
+    val defNil              = Node.New.MetaNil()
+    val name                = Node.New.Name("MyModule", dummyLocation)
+
+    val module =
+      Node.New.ModuleDef(name, importNil, defNil, dummyLocation).right.get
+
+    "have valid fields" in {
+      module.location shouldEqual dummyLocation
+      module.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      module.name.source shouldEqual module
+      module.name.target shouldEqual name
+      module.imports.source shouldEqual module
+      module.imports.target shouldEqual importNil
+      module.definitions.source shouldEqual module
+      module.definitions.target shouldEqual defNil
+    }
+
+    "have children parented to the node" in {
+      name.parents should contain(module.name.ix)
+      importNil.parents should contain(module.imports.ix)
+      defNil.parents should contain(module.definitions.ix)
+    }
+
+    "fail to construct if imports isn't a meta list" in {
+      val failNode = Node.New.ModuleDef(name, name, defNil, dummyLocation)
+      shouldFailWith(failNode, Utility.coreListFrom(name))
+    }
+
+    "fail if construct definitions isn't a meta list" in {
+      val failNode = Node.New.ModuleDef(name, importNil, name, dummyLocation)
+      shouldFailWith(failNode, Utility.coreListFrom(name))
+    }
+  }
+
+  "Import nodes" should {
+    implicit val core: Core = new Core()
+    val segmentsNil         = Node.New.MetaNil()
+    val empty               = Node.New.Empty()
+    val imp =
+      Node.New.Import(segmentsNil, dummyLocation).right.get
+
+    "have valid fields" in {
+      imp.location shouldEqual dummyLocation
+      imp.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      imp.segments.source shouldEqual imp
+      imp.segments.target shouldEqual segmentsNil
+    }
+
+    "have children parented to the node" in {
+      segmentsNil.parents should contain(imp.segments.ix)
+    }
+
+    "fail to construct if segments isn't a valid meta list" in {
+      val errNode = Node.New.Import(empty, dummyLocation)
+
+      shouldFailWith(errNode, Utility.coreListFrom(empty))
+    }
+  }
+
+  "Top-level binding nodes" should {
+    implicit val core: Core = new Core()
+    val emptyModule         = Node.New.Empty()
+    val bindingSrc          = Node.New.Empty()
+    val bindingTgt          = Node.New.Empty()
+    val binding =
+      Node.New.Binding(bindingSrc, bindingTgt, dummyLocation)
+    val topLevelBinding =
+      Node.New.TopLevelBinding(emptyModule, binding, dummyLocation).right.get
+
+    "have valid fields" in {
+      topLevelBinding.location shouldEqual dummyLocation
+      topLevelBinding.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      topLevelBinding.module.source shouldEqual topLevelBinding
+      topLevelBinding.module.target shouldEqual emptyModule
+      topLevelBinding.binding.source shouldEqual topLevelBinding
+      topLevelBinding.binding.target shouldEqual binding
+    }
+
+    "have children parented to the node" in {
+      emptyModule.parents should contain(topLevelBinding.module.ix)
+      binding.parents should contain(topLevelBinding.binding.ix)
+    }
+
+    "fail to construct if binding isn't a valid binding" in {
+      val errNode =
+        Node.New.TopLevelBinding(emptyModule, bindingSrc, dummyLocation)
+
+      shouldFailWith(errNode, Utility.coreListFrom(bindingSrc))
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Type Definitions) =================
+
+  "Atom definition nodes" should {
+    implicit val core: Core = new Core()
+
+    val name    = Node.New.Empty()
+    val argName = Node.New.Empty()
+    val args    = Utility.coreListFrom(argName)
+
+    val atomDef = Node.New.AtomDef(name, args, dummyLocation).right.get
+
+    "have valid fields" in {
+      atomDef.location shouldEqual dummyLocation
+      atomDef.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      atomDef.name.source shouldEqual atomDef
+      atomDef.name.target shouldEqual name
+      atomDef.args.source shouldEqual atomDef
+      atomDef.args.target shouldEqual args
+    }
+
+    "have children parented to the node" in {
+      name.parents should contain(atomDef.name.ix)
+      args.parents should contain(atomDef.args.ix)
+    }
+
+    "fail to construct if args is not a valid meta list" in {
+      val errNode = Node.New.AtomDef(name, argName, dummyLocation)
+      shouldFailWith(errNode, Utility.coreListFrom(argName))
+    }
+  }
+
+  "Type definition nodes" should {
+    implicit val core: Core = new Core()
+
+    val name    = Node.New.Empty()
+    val tParam  = Node.New.Empty()
+    val tParams = Utility.coreListFrom(tParam)
+
+    val bodyExpr = Node.New.Empty()
+    val body     = Utility.coreListFrom(bodyExpr)
+
+    val typeDef = Node.New.TypeDef(name, tParams, body, dummyLocation).right.get
+
+    "have valid fields" in {
+      typeDef.location shouldEqual dummyLocation
+      typeDef.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      typeDef.name.source shouldEqual typeDef
+      typeDef.name.target shouldEqual name
+      typeDef.typeParams.source shouldEqual typeDef
+      typeDef.typeParams.target shouldEqual tParams
+      typeDef.body.source shouldEqual typeDef
+      typeDef.body.target shouldEqual body
+    }
+
+    "have children parented to the node" in {
+      name.parents should contain(typeDef.name.ix)
+      tParams.parents should contain(typeDef.typeParams.ix)
+      body.parents should contain(typeDef.body.ix)
+    }
+
+    "fail to construct of the type params are not a valid meta list" in {
+      val errNode = Node.New.TypeDef(name, name, body, dummyLocation)
+      shouldFailWith(errNode, Utility.coreListFrom(name))
+    }
+    "fail to construct if the body is not a valid meta list" in {
+      val errNode = Node.New.TypeDef(name, tParams, name, dummyLocation)
+      shouldFailWith(errNode, Utility.coreListFrom(name))
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Typing) ===========================
+
+  "Type ascription nodes" should {
+    implicit val core: Core = new Core()
+
+    val typed      = Node.New.Empty()
+    val sig        = Node.New.Empty()
+    val ascription = Node.New.TypeAscription(typed, sig, dummyLocation)
+
+    "have valid fields" in {
+      ascription.location shouldEqual dummyLocation
+      ascription.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      ascription.typed.source shouldEqual ascription
+      ascription.typed.target shouldEqual typed
+      ascription.sig.source shouldEqual ascription
+      ascription.sig.target shouldEqual sig
+    }
+
+    "have children parented to the node" in {
+      typed.parents should contain(ascription.typed.ix)
+      sig.parents should contain(ascription.sig.ix)
+    }
+  }
+
+  "Context ascription nodes" should {
+    implicit val core: Core = new Core()
+
+    val typed      = Node.New.Empty()
+    val context    = Node.New.Empty()
+    val ascription = Node.New.ContextAscription(typed, context, dummyLocation)
+
+    "have valid fields" in {
+      ascription.location shouldEqual dummyLocation
+      ascription.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      ascription.typed.source shouldEqual ascription
+      ascription.typed.target shouldEqual typed
+      ascription.context.source shouldEqual ascription
+      ascription.context.target shouldEqual context
+    }
+
+    "have children parented to the node" in {
+      typed.parents should contain(ascription.typed.ix)
+      context.parents should contain(ascription.context.ix)
+    }
+  }
+
+  "Typeset memeber nodes" should {
+    implicit val core: Core = new Core()
+
+    val label      = Node.New.Empty()
+    val memberType = Node.New.Empty()
+    val value      = Node.New.Empty()
+
+    val typesetMember =
+      Node.New.TypesetMember(label, memberType, value, dummyLocation)
+
+    "have valid fields" in {
+      typesetMember.location shouldEqual dummyLocation
+      typesetMember.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      typesetMember.label.source shouldEqual typesetMember
+      typesetMember.label.target shouldEqual label
+      typesetMember.memberType.source shouldEqual typesetMember
+      typesetMember.memberType.target shouldEqual memberType
+      typesetMember.value.source shouldEqual typesetMember
+      typesetMember.value.target shouldEqual value
+    }
+
+    "have children parented to the node" in {
+      label.parents should contain(typesetMember.label.ix)
+      memberType.parents should contain(typesetMember.memberType.ix)
+      value.parents should contain(typesetMember.value.ix)
+    }
+  }
+
+  "Typset subsumption nodes" should {
+    implicit val core: Core = new Core()
+
+    val left  = Node.New.Empty()
+    val right = Node.New.Empty()
+
+    val op = Node.New.TypesetSubsumption(left, right, dummyLocation)
+
+    "have valid fields" in {
+      op.location shouldEqual dummyLocation
+      op.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      op.left.source shouldEqual op
+      op.left.target shouldEqual left
+      op.right.source shouldEqual op
+      op.right.target shouldEqual right
+    }
+
+    "have children parented to the node" in {
+      left.parents should contain(op.left.ix)
+      right.parents should contain(op.right.ix)
+    }
+  }
+
+  "Typset equality nodes" should {
+    implicit val core: Core = new Core()
+
+    val left  = Node.New.Empty()
+    val right = Node.New.Empty()
+
+    val op = Node.New.TypesetEquality(left, right, dummyLocation)
+
+    "have valid fields" in {
+      op.location shouldEqual dummyLocation
+      op.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      op.left.source shouldEqual op
+      op.left.target shouldEqual left
+      op.right.source shouldEqual op
+      op.right.target shouldEqual right
+    }
+
+    "have children parented to the node" in {
+      left.parents should contain(op.left.ix)
+      right.parents should contain(op.right.ix)
+    }
+  }
+
+  "Typset concat nodes" should {
+    implicit val core: Core = new Core()
+
+    val left  = Node.New.Empty()
+    val right = Node.New.Empty()
+
+    val op = Node.New.TypesetConcat(left, right, dummyLocation)
+
+    "have valid fields" in {
+      op.location shouldEqual dummyLocation
+      op.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      op.left.source shouldEqual op
+      op.left.target shouldEqual left
+      op.right.source shouldEqual op
+      op.right.target shouldEqual right
+    }
+
+    "have children parented to the node" in {
+      left.parents should contain(op.left.ix)
+      right.parents should contain(op.right.ix)
+    }
+  }
+
+  "Typset union nodes" should {
+    implicit val core: Core = new Core()
+
+    val left  = Node.New.Empty()
+    val right = Node.New.Empty()
+
+    val op = Node.New.TypesetUnion(left, right, dummyLocation)
+
+    "have valid fields" in {
+      op.location shouldEqual dummyLocation
+      op.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      op.left.source shouldEqual op
+      op.left.target shouldEqual left
+      op.right.source shouldEqual op
+      op.right.target shouldEqual right
+    }
+
+    "have children parented to the node" in {
+      left.parents should contain(op.left.ix)
+      right.parents should contain(op.right.ix)
+    }
+  }
+
+  "Typset intersection nodes" should {
+    implicit val core: Core = new Core()
+
+    val left  = Node.New.Empty()
+    val right = Node.New.Empty()
+
+    val op = Node.New.TypesetIntersection(left, right, dummyLocation)
+
+    "have valid fields" in {
+      op.location shouldEqual dummyLocation
+      op.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      op.left.source shouldEqual op
+      op.left.target shouldEqual left
+      op.right.source shouldEqual op
+      op.right.target shouldEqual right
+    }
+
+    "have children parented to the node" in {
+      left.parents should contain(op.left.ix)
+      right.parents should contain(op.right.ix)
+    }
+  }
+
+  "Typset subtraction nodes" should {
+    implicit val core: Core = new Core()
+
+    val left  = Node.New.Empty()
+    val right = Node.New.Empty()
+
+    val op = Node.New.TypesetSubtraction(left, right, dummyLocation)
+
+    "have valid fields" in {
+      op.location shouldEqual dummyLocation
+      op.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      op.left.source shouldEqual op
+      op.left.target shouldEqual left
+      op.right.source shouldEqual op
+      op.right.target shouldEqual right
+    }
+
+    "have children parented to the node" in {
+      left.parents should contain(op.left.ix)
+      right.parents should contain(op.right.ix)
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Function) =========================
+
+  "Lambda nodes" should {
+    implicit val core: Core = new Core()
+
+    val arg  = Node.New.Empty()
+    val body = Node.New.Empty()
+
+    val lambda = Node.New.Lambda(arg, body, dummyLocation)
+
+    "have valid fields" in {
+      lambda.location shouldEqual dummyLocation
+      lambda.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      lambda.arg.source shouldEqual lambda
+      lambda.arg.target shouldEqual arg
+      lambda.body.source shouldEqual lambda
+      lambda.body.target shouldEqual body
+    }
+
+    "have children parented to the node" in {
+      arg.parents should contain(lambda.arg.ix)
+      body.parents should contain(lambda.body.ix)
+    }
+  }
+
+  "Function definition nodes" should {
+    implicit val core: Core = new Core()
+
+    val name = Node.New.Empty()
+    val arg  = Node.New.Empty()
+    val args = Utility.coreListFrom(arg)
+    val body = Node.New.Empty()
+
+    val functionDef =
+      Node.New.FunctionDef(name, args, body, dummyLocation).right.get
+
+    "have valid fields" in {
+      functionDef.location shouldEqual dummyLocation
+      functionDef.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      functionDef.name.source shouldEqual functionDef
+      functionDef.name.target shouldEqual name
+      functionDef.args.source shouldEqual functionDef
+      functionDef.args.target shouldEqual args
+      functionDef.body.source shouldEqual functionDef
+      functionDef.body.target shouldEqual body
+    }
+
+    "have children parented to the node" in {
+      name.parents should contain(functionDef.name.ix)
+      args.parents should contain(functionDef.args.ix)
+      body.parents should contain(functionDef.body.ix)
+    }
+
+    "fail to construct if args is not a meta list" in {
+      val errNode = Node.New.FunctionDef(name, name, body, dummyLocation)
+      shouldFailWith(errNode, Utility.coreListFrom(name))
+    }
+  }
+
+  "Method definition nodes" should {
+    implicit val core: Core = new Core()
+
+    val targetPath = Node.New.Empty()
+    val name       = Node.New.Empty()
+    val lamArg     = Node.New.Empty()
+    val lamBody    = Node.New.Empty()
+    val function   = Node.New.Lambda(lamArg, lamBody, dummyLocation)
+
+    val methodDef =
+      Node.New.MethodDef(targetPath, name, function, dummyLocation).right.get
+
+    "have valid fields" in {
+      methodDef.location shouldEqual dummyLocation
+      methodDef.parents shouldEqual Vector()
+    }
+
+    "have properly connected links" in {
+      methodDef.targetPath.source shouldEqual methodDef
+      methodDef.targetPath.target shouldEqual targetPath
+      methodDef.name.source shouldEqual methodDef
+      methodDef.name.target shouldEqual name
+      methodDef.function.source shouldEqual methodDef
+      methodDef.function.target shouldEqual function
+    }
+
+    "have children parented to the node" in {
+      targetPath.parents should contain(methodDef.targetPath.ix)
+      name.parents should contain(methodDef.name.ix)
+      function.parents should contain(methodDef.function.ix)
+    }
+
+    "fail to construct if function is not a valid function representation" in {
+      val errNode = Node.New.MethodDef(targetPath, name, name, dummyLocation)
+      shouldFailWith(errNode, Utility.coreListFrom(name))
+    }
+  }
+
+  // === Tests for Node Smart Constructors (Def-Site Args) ====================
+
+  // === Tests for Node Utility Functions =====================================
+
+  "Lists" should {
+    implicit val core: Core = new Core()
+    val empty1              = Node.New.Empty().wrapped
+    val empty2              = Node.New.Empty().wrapped
+
+    val list1 = Utility.coreListFrom(NonEmptyList(empty1, List(empty2)))
+    val list2 = Utility.coreListFrom(NonEmptyList(empty1, List(empty2)))
+    val list3 = Utility.coreListFrom(NonEmptyList(empty2, List(empty1)))
+
+    "be defined as equal when the child nodes are equal" in {
+      Utility.listsAreEqual(list1, list2) shouldEqual true
+    }
+
+    "be defined as not equal when the child nodes are not equal" in {
+      Utility.listsAreEqual(list1, list3) shouldEqual false
+    }
+  }
+
+  "Nodes for meta lists" should {
+    implicit val core: Core = new Core()
+    val emptyNode           = Node.New.Empty()
+    val nilNode             = Node.New.MetaNil()
+    val consNode            = Node.New.MetaList(emptyNode, nilNode).right.get
+
+    "be correctly identified" in {
+      Utility.isListNode(emptyNode) shouldEqual false
+      Utility.isListNode(nilNode) shouldEqual true
+      Utility.isListNode(consNode) shouldEqual true
+    }
+  }
+
+  "Core lists" should {
+    implicit val core: Core = new Core()
+    val emptyNode1          = Node.New.Empty().wrapped
+    val emptyNode2          = Node.New.Empty().wrapped
+    val emptyNode3          = Node.New.Empty().wrapped
+
+    val listOfOne = Utility.coreListFrom(emptyNode1)
+    val listOfMany = Utility
+      .coreListFrom(NonEmptyList(emptyNode1, List(emptyNode2, emptyNode3)))
+
+    "be able to be constructed from arbitrary nodes" in {
+      listOfOne.head.target shouldEqual emptyNode1
+
+      listOfOne.tail.target match {
+        case NodeShape.MetaNil.any(_) =>
+        case _                        => fail
+      }
+
+      listOfMany.head.target shouldEqual emptyNode1
+
+      listOfMany.tail.target match {
+        case NodeShape.MetaList.any(e2) =>
+          e2.head.target shouldEqual emptyNode2
+
+          e2.tail.target match {
+            case NodeShape.MetaList.any(e3) =>
+              e3.head.target shouldEqual emptyNode3
+              e3.tail.target match {
+                case NodeShape.MetaNil.any(_) => succeed
+                case _                        => fail
+              }
+            case _ => fail
+          }
+        case _ => fail
+      }
     }
   }
 
   // === Tests for Node Conversions ===========================================
 
-  "AST locations" should "be converted losslessly to core locations" in {
+  "AST locations" should {
     val startLoc = 1232
-    val endLoc = 1337
+    val endLoc   = 1337
 
-    val astLoc = AstLocation(startLoc, endLoc)
+    val astLoc  = AstLocation(startLoc, endLoc)
     val coreLoc = CoreDef.Node.LocationVal(startLoc, endLoc)
 
-    Node.Conversions.astLocationToNodeLocation(astLoc) shouldEqual coreLoc
+    "be converted losslessly to core locations" in {
+      Node.Conversions.astLocationToNodeLocation(astLoc) shouldEqual coreLoc
+    }
   }
 
   // === Tests for Link Smart Constructors ====================================
 
-  "Links" should "be able to be made with a source and target" in {
-    val n1 = Core.Node.New.empty()
-    val n2 = Core.Node.New.empty()
+  "Links" should {
+    implicit val core: Core = new Core()
 
-    val link = Core.Link.New.connected(n1, n2)
+    "be able to be made with a source and target" in {
+      val n1 = Node.New.Empty()
+      val n2 = Node.New.Empty()
 
-    link.source shouldEqual n1
-    link.target shouldEqual n2
-  }
+      val link = Link.New.Connected(n1, n2)
 
-  "Links" should "be able to be made with only a source" in {
-    val sourceNode = Core.Node.New.metaNil()
+      link.source shouldEqual n1
+      link.target shouldEqual n2
+    }
 
-    val link = Core.Link.New.disconnected(sourceNode)
+    "be able to be made with only a source" in {
+      val sourceNode = Node.New.MetaNil()
 
-    link.source shouldEqual sourceNode
+      val link = Link.New.Disconnected(sourceNode)
 
-    link.target match {
-      case NodeShape.Empty.any(_) => succeed
-      case _                      => fail
+      link.source shouldEqual sourceNode
+
+      link.target match {
+        case NodeShape.Empty.any(_) => succeed
+        case _                      => fail
+      }
     }
   }
-
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.test.core
 
 import org.enso.core.CoreGraph.{DefinitionGen => CoreDef}
 import org.enso.graph.{Graph => PrimGraph}
+import org.enso.core.CoreGraph.DefinitionGen.Node.{Shape => NodeShape}
 import org.enso.compiler.core.Core
 import org.enso.compiler.test.CompilerTest
 import org.scalatest.BeforeAndAfterEach
@@ -23,9 +24,23 @@ class SmartConstructorsTest extends CompilerTest with BeforeAndAfterEach {
     core = new Core()
   }
 
+  // === Useful Constants =====================================================
+  val blankLocation: CoreDef.Node.LocationVal[Graph] =
+    CoreDef.Node.LocationVal(0, 0)
+
   // === Tests for Node Smart Constructors ====================================
 
   // === Tests for Node Utility Functions =====================================
+
+  "Nodes for meta lists" should "be correctly identified" in {
+    val emptyNode = Node.New.empty()
+    val nilNode   = Node.New.metaNil()
+    val consNode  = Node.New.metaList(emptyNode, nilNode).right.get
+
+    Core.Node.Utility.isListNode(emptyNode) shouldEqual false
+    Core.Node.Utility.isListNode(nilNode) shouldEqual true
+    Core.Node.Utility.isListNode(consNode) shouldEqual true
+  }
 
   // === Tests for Link Smart Constructors ====================================
 
@@ -37,6 +52,19 @@ class SmartConstructorsTest extends CompilerTest with BeforeAndAfterEach {
 
     link.source shouldEqual n1
     link.target shouldEqual n2
+  }
+
+  "Links" should "be able to be made with only a source" in {
+    val sourceNode = Core.Node.New.metaNil()
+
+    val link = Core.Link.New.disconnected(sourceNode)
+
+    link.source shouldEqual sourceNode
+
+    link.target match {
+      case NodeShape.Empty.any(_) => succeed
+      case _                      => fail
+    }
   }
 
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
@@ -1,0 +1,42 @@
+package org.enso.compiler.test.core
+
+import org.enso.core.CoreGraph.{DefinitionGen => CoreDef}
+import org.enso.graph.{Graph => PrimGraph}
+import org.enso.compiler.core.Core
+import org.enso.compiler.test.CompilerTest
+import org.scalatest.BeforeAndAfterEach
+
+class SmartConstructorsTest extends CompilerTest with BeforeAndAfterEach {
+
+  // === Test Setup ===========================================================
+
+  import CoreDef.Link.Shape._
+  import CoreDef.Node.Location._
+  import CoreDef.Node.ParentLinks._
+  import CoreDef.Node.Shape._
+  import PrimGraph.Component.Refined._
+  import Core._
+
+  implicit var core: Core = _
+
+  override def beforeEach(): Unit = {
+    core = new Core()
+  }
+
+  // === Tests for Node Smart Constructors ====================================
+
+  // === Tests for Node Utility Functions =====================================
+
+  // === Tests for Link Smart Constructors ====================================
+
+  "Links" should "be able to be made with a source and target" in {
+    val n1 = core.Node.New.empty()
+    val n2 = core.Node.New.empty()
+
+    val link = core.Link.New.connected(n1, n2)
+
+    link.source shouldEqual n1
+    link.target shouldEqual n2
+  }
+
+}

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/SmartConstructorsTest.scala
@@ -22,11 +22,13 @@ class SmartConstructorsTest
   import CoreDef.Node.ParentLinks._
   import CoreDef.Node.Shape._
   import PrimGraph.Component.Refined._
+  import PrimGraph.VariantCast
 
   // === Useful Constants =====================================================
+
   val constantLocationStart = 201
   val constantLocationEnd   = 1337
-  val dummyLocation: CoreDef.Node.LocationVal[Graph] =
+  val dummyLocation: Core.Location =
     CoreDef.Node.LocationVal(constantLocationStart, constantLocationEnd)
 
   // === Utilities ============================================================
@@ -34,15 +36,16 @@ class SmartConstructorsTest
   /** Embodies the notion that a given node construction should fail with a
     * provided result.
     *
+    * It allows a literate style of assertion as is familiar from ScalaTest
+    * through use of an implicit class.
+    *
     * @param maybeErr the result of the possibly-erroring node construction
     * @param core an implicit instance of core
     * @tparam T the type of the node construction when it succeeds
     */
   implicit class ShouldFailWithResult[T <: CoreDef.Node.Shape](
     maybeErr: Core.ConsErrOr[T]
-  )(
-    implicit core: Core
-  ) {
+  )(implicit core: Core) {
 
     /** Expresses that a node should fail to construct, and provide the
       * erroneous core structures in [[errList]].
@@ -1307,7 +1310,6 @@ class SmartConstructorsTest
     }
 
     "contain a meta-list if passed a single node" in {
-      import PrimGraph.VariantCast
       val input = errNode
       val err   = Node.New.ConstructionError(input, dummyLocation)
 
@@ -1347,6 +1349,20 @@ class SmartConstructorsTest
     }
   }
 
+  "Nodes for meta booleans" should {
+    implicit val core: Core = new Core()
+
+    val emptyNode = Node.New.Empty()
+    val trueNode  = Node.New.MetaTrue()
+    val falseNode = Node.New.MetaFalse()
+
+    "be correctly identified" in {
+      Utility.isBoolNode(emptyNode) shouldEqual false
+      Utility.isBoolNode(trueNode) shouldEqual true
+      Utility.isBoolNode(falseNode) shouldEqual true
+    }
+  }
+
   "Nodes for meta lists" should {
     implicit val core: Core = new Core()
     val emptyNode           = Node.New.Empty()
@@ -1362,9 +1378,10 @@ class SmartConstructorsTest
 
   "Core lists" should {
     implicit val core: Core = new Core()
-    val emptyNode1          = Node.New.Empty().wrapped
-    val emptyNode2          = Node.New.Empty().wrapped
-    val emptyNode3          = Node.New.Empty().wrapped
+
+    val emptyNode1 = Node.New.Empty().wrapped
+    val emptyNode2 = Node.New.Empty().wrapped
+    val emptyNode3 = Node.New.Empty().wrapped
 
     val listOfOne = Utility.coreListFrom(emptyNode1)
     val listOfMany = Utility


### PR DESCRIPTION
### Pull Request Description
This PR adds smart constructors and other utilities that enable working fluently with the underlying core data structures. 

### Important Notes
- More complex test cases are coming in the next PR as work under #452. This will also include benchmarks.
- The smart constructor tests rigorously test all of the expected properties of the smart constructors.
- This PR also fixes debug printing in the parser test suite as it was annoying me.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
