### PR TITLE
Fixed Nested Serialization on the Parser Service Request Format

### DIFF
--- a/common/parser-service/src/main/scala/org/enso/ParserService.scala
+++ b/common/parser-service/src/main/scala/org/enso/ParserService.scala
@@ -1,6 +1,5 @@
 package org.enso
 
-import io.circe.parser.decode
 import org.enso.flexer.Reader
 import org.enso.parserservice.Protocol
 import org.enso.parserservice.Server
@@ -41,10 +40,7 @@ case class ParserService() extends Server with Protocol {
 
   def handleRequest(request: Request): Response = {
     request match {
-      case ParseRequest(program, idsJson) =>
-        val ids = Parser.idMapFromJson(idsJson).getOrElse {
-          throw new Exception("Could not decode IDMap from json.")
-        }
+      case ParseRequest(program, ids) =>
         val ast  = runParser(program, ids)
         val json = serializeAst(ast)
         Protocol.Success(json)

--- a/common/parser-service/src/main/scala/org/enso/parserservice/Protocol.scala
+++ b/common/parser-service/src/main/scala/org/enso/parserservice/Protocol.scala
@@ -3,6 +3,7 @@ package org.enso.parserservice
 import io.circe.parser._
 import io.circe.generic.auto._
 import io.circe.syntax._
+import org.enso.syntax.text.Parser
 
 /** Types implementing parser server protocol.
   *
@@ -10,7 +11,8 @@ import io.circe.syntax._
   */
 object Protocol {
   sealed trait Request
-  final case class ParseRequest(program: String, ids: String) extends Request
+  final case class ParseRequest(program: String, ids: Parser.IDMap)
+      extends Request
 
   sealed trait Response
   final case class Success(ast_json: String) extends Response


### PR DESCRIPTION
### Pull Request Description
Fix following the change from #556 — we accidently ended up having a JSON with a string with another serialized JSON.
Parser service takes request serialized as JSON. Request fields can be thusly fully typed, and don't need to consist `String` with another JSON. 

### Important Notes
Tested against IDE's `wip/jv/idmap` branch.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
