### PR TITLE
Update GraalVM to 20.0.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,6 +142,7 @@ jobs:
           echo ##vso[task.setvariable variable=JAVA_HOME]C:\$(graalDistributionName)-$(graalVersion)
           echo ##vso[task.setvariable variable=PATH]C:\$(graalDistributionName)-$(graalVersion)\bin;%PATH%
           echo ##vso[task.setvariable variable=PATH]%USERPROFILE%\sbt\bin\;%PATH%
+          echo ##vso[task.setvariable variable=TRUFFLE_STRICT_OPTION_DEPRECATION]true
         displayName: Adjust Environment Variables
       - script: |
           sbt -no-colors syntaxJS/fullOptJS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ trigger:
 pr: none
 
 variables:
-  graalVersion: 19.3.1 # Please ensure this is in sync with the graalAPIVersion in build.sbt
+  graalVersion: 20.0.0 # Please ensure this is in sync with the graalAPIVersion in build.sbt
   graalReleasesUrl: https://github.com/graalvm/graalvm-ce-builds/releases/download
   graalDistributionName: graalvm-ce-java8
   sbtVersion: 1.3.3    # Please ensure this is in sync with project/build.properties

--- a/build.sbt
+++ b/build.sbt
@@ -355,9 +355,9 @@ lazy val project_manager = (project in file("common/project-manager"))
 //////////////////////
 
 val truffleRunOptions = Seq(
-  "-Dgraal.TruffleIterativePartialEscape=true",
+  "-Dpolyglot.engine.IterativePartialEscape=true",
   "-XX:-UseJVMCIClassLoader",
-  "-Dgraal.TruffleBackgroundCompilation=false",
+  "-Dpolyglot.engine.BackgroundCompilation=false",
   "-Dgraalvm.locatorDisabled=true"
 )
 
@@ -553,6 +553,7 @@ lazy val runner = project
           )
         )
       ),
+    commands += WithDebugCommand.withDebug,
     inConfig(Compile)(truffleRunOptionsSettings),
     libraryDependencies ++= Seq(
       "org.graalvm.sdk"       % "polyglot-tck"           % graalVersion % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 //////////////////////////////
 
 val scalacVersion = "2.13.1"
-val graalVersion  = "19.3.1"
+val graalVersion  = "20.0.0"
 val circeVersion  = "0.13.0"
 organization in ThisBuild := "org.enso"
 scalaVersion in ThisBuild := scalacVersion

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
@@ -47,7 +47,7 @@ trait InterpreterRunner {
       )
   }
   val output           = new ByteArrayOutputStream()
-  val ctx              = Context.newBuilder(LanguageInfo.ID).out(output).build()
+  val ctx              = Context.newBuilder(LanguageInfo.ID).allowExperimentalOptions(true).out(output).build()
   val executionContext = new ExecutionContext(ctx)
 
   def withLocationsInstrumenter(test: LocationsInstrumenter => Unit): Unit = {

--- a/project/WithDebugCommand.scala
+++ b/project/WithDebugCommand.scala
@@ -17,7 +17,7 @@ import sbt._
 object WithDebugCommand {
 
   val truffleNoBackgroundCompilationOptions = Seq(
-    "-Dgraal.TruffleBackgroundCompilation=false"
+    "-Dpolyglot.engine.BackgroundCompilation=false"
   )
 
   val truffleDumpGraphsOptions = Seq(
@@ -26,10 +26,10 @@ object WithDebugCommand {
   )
 
   val truffleShowCompilationsOptions = Seq(
-    "-Dgraal.TraceTruffleCompilation=true",
-    "-Dgraal.TraceTruffleCompilationCallTree=true",
-    "-Dgraal.TraceTruffleInlining=true",
-    "-Dgraal.TraceTrufflePerformanceWarnings=true"
+    "-Dpolyglot.engine.TraceCompilation=true",
+    "-Dpolyglot.engine.TraceCompilationCallTree=true",
+    "-Dpolyglot.engine.TraceInlining=true",
+    "-Dpolyglot.engine.TracePerformanceWarnings=true"
   )
 
   val trufflePrintAssemblyOptions = Seq(


### PR DESCRIPTION
### Pull Request Description
Closes #520.

### Important Notes

The benchmark results for both v19 and v20 are very similar on my machine, besides a few highlighted exceptions. See the original (and very verbose) output logs [here.](https://gist.github.com/rzats/a40dd575ded344928f96eb5ad5d57526)

| Benchmark  | GraalVM 19.3.1 | GraalVM 20.0.0 |
| ------------- | ------------- | ------------- |
| AtomBenchmarks.benchGenerateList | 15.458242904915702  | 16.413785484116907 | 
| AtomBenchmarks.benchMapReverseCurryList | 22.969261846144597  | 21.243586123728388 |
| AtomBenchmarks.benchMapReverseList | 20.57017271427409  | 21.989881841025646  |
| ***AtomBenchmarks.benchReverseList*** | ***35.51495561110558***  | ***19.47601254844943***  |
| AtomBenchmarks.benchReverseListMethods | 20.97737287136907  | 19.92246298164083  |
| ***AtomBenchmarks.benchSumList*** | ***17.263403325563722***  | ***6.457845852615831***  |
| AtomBenchmarks.benchSumListFallback | 7.236245815898873  | 6.131506735199339  |
| AtomBenchmarks.benchSumListMethods | 8.454580947887866  | 8.151325625560538 |
| AtomBenchmarks.sumListLeftFold | 6.523510021335296  | 6.670444832771824  |
| NamedDefaultedArgumentBenchmarks.benchSumTCOWithDefaultArgs | 51.03333002135889  | 50.87828658811418  |
| ***NamedDefaultedArgumentBenchmarks.benchSumTCOWithNamedArgs*** | ***24.357791573350955***  | ***50.55821447211682***  |
| RecursionBenchmarks.benchNestedThunkSum | 36.38848489720949  | 41.17952319258729  |
| RecursionBenchmarks.benchOversaturatedRecursiveCall | 48.4766120820271  | 49.71516899021767  |
| RecursionBenchmarks.benchSumRecursive | 7.174044739876558E-4  | 7.320496063816858E-4  |
| RecursionBenchmarks.benchSumStateTCO | 48.536994919666064  | 48.57687544242765  |
| RecursionBenchmarks.benchSumTCO | 48.63046886711716  | 48.68137251673151  |
| RecursionBenchmarks.benchSumTCOFoldLike | 48.66120624001649  | 48.590116440556265  |
| RecursionBenchmarks.benchSumTCOWithEval | 50.039484320893564  | 48.70605361556713  |

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
