### PR TITLE
Add a `--version` Flag for the CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -47,7 +47,7 @@ Please list the reproduction steps for your bug. For example:
 - Please include any error output if relevant.
 -->
 
-### Luna Version
+### Enso Version
 <!--
 - Please include the output of `enso --version`.
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -53,6 +53,12 @@ Please list the reproduction steps for your bug. For example:
 
 For example:
 ```
-
+Enso Compiler and Runtime
+Version:    0.0.1
+Built with: scala-2.13.1 for GraalVM 20.0.0
+Built from: wip/ara/better-version @ 1030864652f8f1e316ab3438f933f62f2806ebe4
+            Uncommitted changes, 1 commit on branch
+Running on: Java HotSpot(TM) 64-Bit Server VM GraalVM EE 20.0.0, JDK 1.8.0_241-b07
+            Mac OS X 10.15.3 (x86_64)
 ```
 -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -50,4 +50,9 @@ Please list the reproduction steps for your bug. For example:
 ### Luna Version
 <!--
 - Please include the output of `enso --version`.
+
+For example:
+```
+
+```
 -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,15 +41,15 @@ jobs:
           tar -x -z -C ~ -f sbt.tgz
           echo "##vso[task.setvariable variable=PATH]~/sbt/bin/:$PATH"
         displayName: Install SBT
-#      - script: |
-#          sbt -no-colors syntaxJS/fullOptJS
-#        displayName: Generate target/scala-parser.js
-#        continueOnError: true
-#      - task: PublishPipelineArtifact@1
-#        inputs:
-#          targetPath: '$(Pipeline.Workspace)/s/target/scala-parser.js'
-#          artifact: 'parser-js'
-#          publishLocation: 'pipeline'
+      - script: |
+          sbt -no-colors syntaxJS/fullOptJS
+        displayName: Generate target/scala-parser.js
+        continueOnError: true
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: '$(Pipeline.Workspace)/s/target/scala-parser.js'
+          artifact: 'parser-js'
+          publishLocation: 'pipeline'
       - script: |
           sbt -no-colors test
         displayName: Test SBT
@@ -85,89 +85,89 @@ jobs:
           echo "##vso[task.complete result=Failed;]DONE"
         condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
         displayName: Fail on Issues
-#  - job: macOS
-#    timeoutInMinutes: 90
-#    pool:
-#      vmImage: macOS-10.15
-#    steps:
-#      - script: |
-#          curl -fSL -o graal.tar.gz $(graalReleasesUrl)/vm-$(graalVersion)/$(graalDistributionName)-darwin-amd64-$(graalVersion).tar.gz
-#          tar -x -z -C ~ -f graal.tar.gz
-#          ls ~/$(graalDistributionName)-$(graalVersion)
-#          sudo mv ~/$(graalDistributionName)-$(graalVersion) /Library/Java/JavaVirtualMachines
-#          echo "##vso[task.setvariable variable=JAVA_HOME]/Library/Java/JavaVirtualMachines/$(graalDistributionName)-$(graalVersion)/Contents/Home"
-#          echo "##vso[task.setvariable variable=PATH]/Library/Java/JavaVirtualMachines/$(graalDistributionName)-$(graalVersion)/Contents/Home/bin:$PATH"
-#        displayName: Install GraalVM
-#      - script: |
-#          curl -fSL -o sbt.tgz https://piccolo.link/sbt-$(sbtVersion).tgz
-#          tar -x -z -C ~ -f sbt.tgz
-#          echo "##vso[task.setvariable variable=PATH]~/sbt/bin/:$PATH"
-#        displayName: Install SBT
-#      - script: |
-#          sbt -no-colors syntaxJS/fullOptJS
-#        displayName: Generate target/scala-parser.js
-#        continueOnError: true
-#      - script: |
-#          sbt -no-colors test
-#        displayName: Test SBT
-#        continueOnError: true
-#      - script: |
-#          sbt -no-colors syntax/bench
-#        displayName: Benchmark the Parser
-#        continueOnError: true
-#      - script: |
-#          sbt -no-colors runtime/Benchmark/compile
-#        displayName: Check Runtime Benchmarks Compile
-#        continueOnError: true
-#      - task: PublishTestResults@2
-#        inputs:
-#          testResultsFormat: 'JUnit'
-#          testResultsFiles: '**/TEST-*.xml'
-#      - script: |
-#          echo "##vso[task.complete result=Failed;]DONE"
-#        condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
-#        displayName: Fail on Issues
-#  - job: Windows
-#    timeoutInMinutes: 90
-#    pool:
-#      vmImage: windows-2019
-#    steps:
-#      - script: |
-#          curl -fSL -o graal.zip $(graalReleasesUrl)/vm-$(graalVersion)/$(graalDistributionName)-windows-amd64-$(graalVersion).zip
-#          7z x -y -oC:\ graal.zip
-#        displayName: Install GraalVM
-#      - script: |
-#          curl -fSL -o sbt.tgz https://piccolo.link/sbt-$(sbtVersion).tgz
-#          tar -x -z -C %USERPROFILE% -f sbt.tgz
-#        displayName: Install SBT
-#      - script: |
-#          call refreshenv
-#          echo ##vso[task.setvariable variable=JAVA_HOME]C:\$(graalDistributionName)-$(graalVersion)
-#          echo ##vso[task.setvariable variable=PATH]C:\$(graalDistributionName)-$(graalVersion)\bin;%PATH%
-#          echo ##vso[task.setvariable variable=PATH]%USERPROFILE%\sbt\bin\;%PATH%
-#          echo ##vso[task.setvariable variable=TRUFFLE_STRICT_OPTION_DEPRECATION]true
-#        displayName: Adjust Environment Variables
-#      - script: |
-#          sbt -no-colors syntaxJS/fullOptJS
-#        displayName: Generate target/scala-parser.js
-#        continueOnError: true
-#      - script: |
-#          sbt test
-#        displayName: Test SBT
-#        continueOnError: true
-#      - script: |
-#          sbt syntax/bench
-#        displayName: Benchmark the Parser
-#        continueOnError: true
-#      - script: |
-#          sbt runtime/Benchmark/compile
-#        displayName: Check Runtime Benchmarks Compile
-#        continueOnError: true
-#      - task: PublishTestResults@2
-#        inputs:
-#          testResultsFormat: 'JUnit'
-#          testResultsFiles: '**/TEST-*.xml'
-#      - script: |
-#          echo "##vso[task.complete result=Failed;]DONE"
-#        condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
-#        displayName: Fail on Issues
+  - job: macOS
+    timeoutInMinutes: 90
+    pool:
+      vmImage: macOS-10.15
+    steps:
+      - script: |
+          curl -fSL -o graal.tar.gz $(graalReleasesUrl)/vm-$(graalVersion)/$(graalDistributionName)-darwin-amd64-$(graalVersion).tar.gz
+          tar -x -z -C ~ -f graal.tar.gz
+          ls ~/$(graalDistributionName)-$(graalVersion)
+          sudo mv ~/$(graalDistributionName)-$(graalVersion) /Library/Java/JavaVirtualMachines
+          echo "##vso[task.setvariable variable=JAVA_HOME]/Library/Java/JavaVirtualMachines/$(graalDistributionName)-$(graalVersion)/Contents/Home"
+          echo "##vso[task.setvariable variable=PATH]/Library/Java/JavaVirtualMachines/$(graalDistributionName)-$(graalVersion)/Contents/Home/bin:$PATH"
+        displayName: Install GraalVM
+      - script: |
+          curl -fSL -o sbt.tgz https://piccolo.link/sbt-$(sbtVersion).tgz
+          tar -x -z -C ~ -f sbt.tgz
+          echo "##vso[task.setvariable variable=PATH]~/sbt/bin/:$PATH"
+        displayName: Install SBT
+      - script: |
+          sbt -no-colors syntaxJS/fullOptJS
+        displayName: Generate target/scala-parser.js
+        continueOnError: true
+      - script: |
+          sbt -no-colors test
+        displayName: Test SBT
+        continueOnError: true
+      - script: |
+          sbt -no-colors syntax/bench
+        displayName: Benchmark the Parser
+        continueOnError: true
+      - script: |
+          sbt -no-colors runtime/Benchmark/compile
+        displayName: Check Runtime Benchmarks Compile
+        continueOnError: true
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/TEST-*.xml'
+      - script: |
+          echo "##vso[task.complete result=Failed;]DONE"
+        condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
+        displayName: Fail on Issues
+  - job: Windows
+    timeoutInMinutes: 90
+    pool:
+      vmImage: windows-2019
+    steps:
+      - script: |
+          curl -fSL -o graal.zip $(graalReleasesUrl)/vm-$(graalVersion)/$(graalDistributionName)-windows-amd64-$(graalVersion).zip
+          7z x -y -oC:\ graal.zip
+        displayName: Install GraalVM
+      - script: |
+          curl -fSL -o sbt.tgz https://piccolo.link/sbt-$(sbtVersion).tgz
+          tar -x -z -C %USERPROFILE% -f sbt.tgz
+        displayName: Install SBT
+      - script: |
+          call refreshenv
+          echo ##vso[task.setvariable variable=JAVA_HOME]C:\$(graalDistributionName)-$(graalVersion)
+          echo ##vso[task.setvariable variable=PATH]C:\$(graalDistributionName)-$(graalVersion)\bin;%PATH%
+          echo ##vso[task.setvariable variable=PATH]%USERPROFILE%\sbt\bin\;%PATH%
+          echo ##vso[task.setvariable variable=TRUFFLE_STRICT_OPTION_DEPRECATION]true
+        displayName: Adjust Environment Variables
+      - script: |
+          sbt -no-colors syntaxJS/fullOptJS
+        displayName: Generate target/scala-parser.js
+        continueOnError: true
+      - script: |
+          sbt test
+        displayName: Test SBT
+        continueOnError: true
+      - script: |
+          sbt syntax/bench
+        displayName: Benchmark the Parser
+        continueOnError: true
+      - script: |
+          sbt runtime/Benchmark/compile
+        displayName: Check Runtime Benchmarks Compile
+        continueOnError: true
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/TEST-*.xml'
+      - script: |
+          echo "##vso[task.complete result=Failed;]DONE"
+        condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
+        displayName: Fail on Issues

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
       options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
     steps:
       - script: |
-          /tmp/docker exec -t -u 0 ci-container sh -c "yum install -y sudo"
+          /tmp/docker exec -t -u 0 ci-container sh -c "yum install -y sudo git"
         displayName: Setup Sudo
       - script: |
           curl -fSL -o sbt.tgz https://piccolo.link/sbt-$(sbtVersion).tgz
@@ -85,89 +85,89 @@ jobs:
           echo "##vso[task.complete result=Failed;]DONE"
         condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
         displayName: Fail on Issues
-  - job: macOS
-    timeoutInMinutes: 90
-    pool:
-      vmImage: macOS-10.15
-    steps:
-      - script: |
-          curl -fSL -o graal.tar.gz $(graalReleasesUrl)/vm-$(graalVersion)/$(graalDistributionName)-darwin-amd64-$(graalVersion).tar.gz
-          tar -x -z -C ~ -f graal.tar.gz
-          ls ~/$(graalDistributionName)-$(graalVersion)
-          sudo mv ~/$(graalDistributionName)-$(graalVersion) /Library/Java/JavaVirtualMachines
-          echo "##vso[task.setvariable variable=JAVA_HOME]/Library/Java/JavaVirtualMachines/$(graalDistributionName)-$(graalVersion)/Contents/Home"
-          echo "##vso[task.setvariable variable=PATH]/Library/Java/JavaVirtualMachines/$(graalDistributionName)-$(graalVersion)/Contents/Home/bin:$PATH"
-        displayName: Install GraalVM
-      - script: |
-          curl -fSL -o sbt.tgz https://piccolo.link/sbt-$(sbtVersion).tgz
-          tar -x -z -C ~ -f sbt.tgz
-          echo "##vso[task.setvariable variable=PATH]~/sbt/bin/:$PATH"
-        displayName: Install SBT
-      - script: |
-          sbt -no-colors syntaxJS/fullOptJS
-        displayName: Generate target/scala-parser.js
-        continueOnError: true
-      - script: |
-          sbt -no-colors test
-        displayName: Test SBT
-        continueOnError: true
-      - script: |
-          sbt -no-colors syntax/bench
-        displayName: Benchmark the Parser
-        continueOnError: true
-      - script: |
-          sbt -no-colors runtime/Benchmark/compile
-        displayName: Check Runtime Benchmarks Compile
-        continueOnError: true
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '**/TEST-*.xml'
-      - script: |
-          echo "##vso[task.complete result=Failed;]DONE"
-        condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
-        displayName: Fail on Issues
-  - job: Windows
-    timeoutInMinutes: 90
-    pool:
-      vmImage: windows-2019
-    steps:
-      - script: |
-          curl -fSL -o graal.zip $(graalReleasesUrl)/vm-$(graalVersion)/$(graalDistributionName)-windows-amd64-$(graalVersion).zip
-          7z x -y -oC:\ graal.zip
-        displayName: Install GraalVM
-      - script: |
-          curl -fSL -o sbt.tgz https://piccolo.link/sbt-$(sbtVersion).tgz
-          tar -x -z -C %USERPROFILE% -f sbt.tgz
-        displayName: Install SBT
-      - script: |
-          call refreshenv
-          echo ##vso[task.setvariable variable=JAVA_HOME]C:\$(graalDistributionName)-$(graalVersion)
-          echo ##vso[task.setvariable variable=PATH]C:\$(graalDistributionName)-$(graalVersion)\bin;%PATH%
-          echo ##vso[task.setvariable variable=PATH]%USERPROFILE%\sbt\bin\;%PATH%
-          echo ##vso[task.setvariable variable=TRUFFLE_STRICT_OPTION_DEPRECATION]true
-        displayName: Adjust Environment Variables
-      - script: |
-          sbt -no-colors syntaxJS/fullOptJS
-        displayName: Generate target/scala-parser.js
-        continueOnError: true
-      - script: |
-          sbt test
-        displayName: Test SBT
-        continueOnError: true
-      - script: |
-          sbt syntax/bench
-        displayName: Benchmark the Parser
-        continueOnError: true
-      - script: |
-          sbt runtime/Benchmark/compile
-        displayName: Check Runtime Benchmarks Compile
-        continueOnError: true
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '**/TEST-*.xml'
-      - script: |
-          echo "##vso[task.complete result=Failed;]DONE"
-        condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
-        displayName: Fail on Issues
+#  - job: macOS
+#    timeoutInMinutes: 90
+#    pool:
+#      vmImage: macOS-10.15
+#    steps:
+#      - script: |
+#          curl -fSL -o graal.tar.gz $(graalReleasesUrl)/vm-$(graalVersion)/$(graalDistributionName)-darwin-amd64-$(graalVersion).tar.gz
+#          tar -x -z -C ~ -f graal.tar.gz
+#          ls ~/$(graalDistributionName)-$(graalVersion)
+#          sudo mv ~/$(graalDistributionName)-$(graalVersion) /Library/Java/JavaVirtualMachines
+#          echo "##vso[task.setvariable variable=JAVA_HOME]/Library/Java/JavaVirtualMachines/$(graalDistributionName)-$(graalVersion)/Contents/Home"
+#          echo "##vso[task.setvariable variable=PATH]/Library/Java/JavaVirtualMachines/$(graalDistributionName)-$(graalVersion)/Contents/Home/bin:$PATH"
+#        displayName: Install GraalVM
+#      - script: |
+#          curl -fSL -o sbt.tgz https://piccolo.link/sbt-$(sbtVersion).tgz
+#          tar -x -z -C ~ -f sbt.tgz
+#          echo "##vso[task.setvariable variable=PATH]~/sbt/bin/:$PATH"
+#        displayName: Install SBT
+#      - script: |
+#          sbt -no-colors syntaxJS/fullOptJS
+#        displayName: Generate target/scala-parser.js
+#        continueOnError: true
+#      - script: |
+#          sbt -no-colors test
+#        displayName: Test SBT
+#        continueOnError: true
+#      - script: |
+#          sbt -no-colors syntax/bench
+#        displayName: Benchmark the Parser
+#        continueOnError: true
+#      - script: |
+#          sbt -no-colors runtime/Benchmark/compile
+#        displayName: Check Runtime Benchmarks Compile
+#        continueOnError: true
+#      - task: PublishTestResults@2
+#        inputs:
+#          testResultsFormat: 'JUnit'
+#          testResultsFiles: '**/TEST-*.xml'
+#      - script: |
+#          echo "##vso[task.complete result=Failed;]DONE"
+#        condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
+#        displayName: Fail on Issues
+#  - job: Windows
+#    timeoutInMinutes: 90
+#    pool:
+#      vmImage: windows-2019
+#    steps:
+#      - script: |
+#          curl -fSL -o graal.zip $(graalReleasesUrl)/vm-$(graalVersion)/$(graalDistributionName)-windows-amd64-$(graalVersion).zip
+#          7z x -y -oC:\ graal.zip
+#        displayName: Install GraalVM
+#      - script: |
+#          curl -fSL -o sbt.tgz https://piccolo.link/sbt-$(sbtVersion).tgz
+#          tar -x -z -C %USERPROFILE% -f sbt.tgz
+#        displayName: Install SBT
+#      - script: |
+#          call refreshenv
+#          echo ##vso[task.setvariable variable=JAVA_HOME]C:\$(graalDistributionName)-$(graalVersion)
+#          echo ##vso[task.setvariable variable=PATH]C:\$(graalDistributionName)-$(graalVersion)\bin;%PATH%
+#          echo ##vso[task.setvariable variable=PATH]%USERPROFILE%\sbt\bin\;%PATH%
+#          echo ##vso[task.setvariable variable=TRUFFLE_STRICT_OPTION_DEPRECATION]true
+#        displayName: Adjust Environment Variables
+#      - script: |
+#          sbt -no-colors syntaxJS/fullOptJS
+#        displayName: Generate target/scala-parser.js
+#        continueOnError: true
+#      - script: |
+#          sbt test
+#        displayName: Test SBT
+#        continueOnError: true
+#      - script: |
+#          sbt syntax/bench
+#        displayName: Benchmark the Parser
+#        continueOnError: true
+#      - script: |
+#          sbt runtime/Benchmark/compile
+#        displayName: Check Runtime Benchmarks Compile
+#        continueOnError: true
+#      - task: PublishTestResults@2
+#        inputs:
+#          testResultsFormat: 'JUnit'
+#          testResultsFiles: '**/TEST-*.xml'
+#      - script: |
+#          echo "##vso[task.complete result=Failed;]DONE"
+#        condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
+#        displayName: Fail on Issues

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,9 @@ jobs:
 #          artifact: 'parser-js'
 #          publishLocation: 'pipeline'
       - script: |
+          cd s/
+        displayName: Change to Checkout Directory
+      - script: |
           sbt -no-colors test
         displayName: Test SBT
         continueOnError: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,15 +41,17 @@ jobs:
           tar -x -z -C ~ -f sbt.tgz
           echo "##vso[task.setvariable variable=PATH]~/sbt/bin/:$PATH"
         displayName: Install SBT
-      - script: |
-          sbt -no-colors syntaxJS/fullOptJS
-        displayName: Generate target/scala-parser.js
-        continueOnError: true
-      - task: PublishPipelineArtifact@1
-        inputs:
-          targetPath: '$(Pipeline.Workspace)/s/target/scala-parser.js'
-          artifact: 'parser-js'
-          publishLocation: 'pipeline'
+      - checkout: self
+        persistCredentials: true
+#      - script: |
+#          sbt -no-colors syntaxJS/fullOptJS
+#        displayName: Generate target/scala-parser.js
+#        continueOnError: true
+#      - task: PublishPipelineArtifact@1
+#        inputs:
+#          targetPath: '$(Pipeline.Workspace)/s/target/scala-parser.js'
+#          artifact: 'parser-js'
+#          publishLocation: 'pipeline'
       - script: |
           sbt -no-colors test
         displayName: Test SBT

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,7 @@ jobs:
         displayName: Install SBT
       - checkout: self
         persistCredentials: true
+        path: repo
 #      - script: |
 #          sbt -no-colors syntaxJS/fullOptJS
 #        displayName: Generate target/scala-parser.js
@@ -53,7 +54,7 @@ jobs:
 #          artifact: 'parser-js'
 #          publishLocation: 'pipeline'
       - script: |
-          cd s/
+          cd repo
         displayName: Change to Checkout Directory
       - script: |
           sbt -no-colors test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,9 +41,6 @@ jobs:
           tar -x -z -C ~ -f sbt.tgz
           echo "##vso[task.setvariable variable=PATH]~/sbt/bin/:$PATH"
         displayName: Install SBT
-      - checkout: self
-        persistCredentials: true
-        path: repo
 #      - script: |
 #          sbt -no-colors syntaxJS/fullOptJS
 #        displayName: Generate target/scala-parser.js
@@ -53,9 +50,6 @@ jobs:
 #          targetPath: '$(Pipeline.Workspace)/s/target/scala-parser.js'
 #          artifact: 'parser-js'
 #          publishLocation: 'pipeline'
-      - script: |
-          cd repo
-        displayName: Change to Checkout Directory
       - script: |
           sbt -no-colors test
         displayName: Test SBT

--- a/build.sbt
+++ b/build.sbt
@@ -597,32 +597,32 @@ lazy val runner = project
   )
   .settings(
     Compile / sourceGenerators += Def.task {
-      val file = (Compile / sourceManaged).value / "buildinfo" / "Info.scala"
-      val gitHash = ("git rev-parse HEAD" !!).trim
-      val gitBranch = ("git rev-parse --abbrev-ref HEAD" !!).trim
-      val isDirty = !("git status --porcelain" !!).trim.isEmpty
+      val file             = (Compile / sourceManaged).value / "buildinfo" / "Info.scala"
+      val gitHash          = ("git rev-parse HEAD" !!).trim
+      val gitBranch        = ("git rev-parse --abbrev-ref HEAD" !!).trim
+      val isDirty          = !("git status --porcelain" !!).trim.isEmpty
       val dirtyCommitCount = ("git rev-list --count master.." !!).trim
       val latestCommitDate = ("git log HEAD -1 --format=%cd" !!).trim
 
       val fileContents =
         s"""
-          |package buildinfo
-          |
-          |object Info {
-          |
-          |  // Versions
-          |  val ensoVersion   = "$ensoVersion"
-          |  val scalacVersion = "$scalacVersion"
-          |  val graalVersion  = "$graalVersion"
-          |
-          |  // Git Info
-          |  val commit            = "$gitHash"
-          |  val branch            = "$gitBranch"
-          |  val isDirty           = $isDirty
-          |  val branchCommitCount = "$dirtyCommitCount"
-          |  val latestCommitDate  = "$latestCommitDate"
-          |}
-          |""".stripMargin
+           |package buildinfo
+           |
+           |object Info {
+           |
+           |  // Versions
+           |  val ensoVersion   = "$ensoVersion"
+           |  val scalacVersion = "$scalacVersion"
+           |  val graalVersion  = "$graalVersion"
+           |
+           |  // Git Info
+           |  val commit            = "$gitHash"
+           |  val branch            = "$gitBranch"
+           |  val isDirty           = $isDirty
+           |  val branchCommitCount = "$dirtyCommitCount"
+           |  val latestCommitDate  = "$latestCommitDate"
+           |}
+           |""".stripMargin
       IO.write(file, fileContents)
       Seq(file)
     }.taskValue

--- a/build.sbt
+++ b/build.sbt
@@ -602,6 +602,7 @@ lazy val runner = project
       val gitBranch = ("git rev-parse --abbrev-ref HEAD" !!).trim
       val isDirty = !("git status --porcelain" !!).trim.isEmpty
       val dirtyCommitCount = ("git rev-list --count master.." !!).trim
+      val latestCommitDate = ("git log HEAD -1 --format=%cd" !!).trim
 
       val fileContents =
         s"""
@@ -615,10 +616,11 @@ lazy val runner = project
           |  val graalVersion  = "$graalVersion"
           |
           |  // Git Info
-          |  val commit  = "$gitHash"
-          |  val branch  = "$gitBranch"
-          |  val isDirty = $isDirty
-          |  val dirtyCommitCount = "$dirtyCommitCount"
+          |  val commit            = "$gitHash"
+          |  val branch            = "$gitBranch"
+          |  val isDirty           = $isDirty
+          |  val branchCommitCount = "$dirtyCommitCount"
+          |  val latestCommitDate  = "$latestCommitDate"
           |}
           |""".stripMargin
       IO.write(file, fileContents)

--- a/build.sbt
+++ b/build.sbt
@@ -597,34 +597,9 @@ lazy val runner = project
   )
   .settings(
     Compile / sourceGenerators += Def.task {
-      val file             = (Compile / sourceManaged).value / "buildinfo" / "Info.scala"
-      val gitHash          = ("git rev-parse HEAD" !!).trim
-      val gitBranch        = ("git rev-parse --abbrev-ref HEAD" !!).trim
-      val isDirty          = !("git status --porcelain" !!).trim.isEmpty
-      val dirtyCommitCount = ("git rev-list --count master.." !!).trim
-      val latestCommitDate = ("git log HEAD -1 --format=%cd" !!).trim
-
-      val fileContents =
-        s"""
-           |package buildinfo
-           |
-           |object Info {
-           |
-           |  // Versions
-           |  val ensoVersion   = "$ensoVersion"
-           |  val scalacVersion = "$scalacVersion"
-           |  val graalVersion  = "$graalVersion"
-           |
-           |  // Git Info
-           |  val commit            = "$gitHash"
-           |  val branch            = "$gitBranch"
-           |  val isDirty           = $isDirty
-           |  val branchCommitCount = "$dirtyCommitCount"
-           |  val latestCommitDate  = "$latestCommitDate"
-           |}
-           |""".stripMargin
-      IO.write(file, fileContents)
-      Seq(file)
+      val file = (Compile / sourceManaged).value / "buildinfo" / "Info.scala"
+      BuildInfo
+        .writeBuildInfoFile(file, ensoVersion, scalacVersion, graalVersion)
     }.taskValue
   )
   .dependsOn(runtime)

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -270,7 +270,7 @@ object Main {
     val osVersion = System.getProperty("os.version")
 
     val dirtyStr = if (Info.isDirty) {
-      "Uncommitted changes, "
+      "Uncommitted changes,"
     } else {
       ""
     }

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -262,20 +262,34 @@ object Main {
     * @param options A description of the CLI options syntax
     */
   def displayVersion(@unused options: Options): Unit = {
+    // Running platform information
+    val vmName = System.getProperty("java.vm.name")
+    val jreVersion = System.getProperty("java.runtime.version")
+    val osArch = System.getProperty("os.arch")
+    val osName = System.getProperty("os.name")
+    val osVersion = System.getProperty("os.version")
+
     val dirtyStr = if (Info.isDirty) {
-      "Dirty"
+      "Uncommitted changes, "
     } else {
-      "Clean"
+      ""
+    }
+    val commitStr = if (Info.branchCommitCount == "1") {
+      "commit"
+    } else {
+      "commits"
     }
 
     val versionOutput =
       s"""
-        |Enso Compiler and Runtime
-        |Version: ${Info.ensoVersion}
-        |Built from: ${Info.branch}@${Info.commit}${dirtyStr}
-        |Built with: scala-${Info.scalacVersion} for GraalVM ${Info.graalVersion}
-        |Running on:
-        |""".stripMargin
+         |Enso Compiler and Runtime
+         |Version:    ${Info.ensoVersion}
+         |Built with: scala-${Info.scalacVersion} for GraalVM ${Info.graalVersion}
+         |Built from: ${Info.branch} @ ${Info.commit}
+         |            ${dirtyStr} ${Info.branchCommitCount} $commitStr on branch
+         |Running on: $vmName, JDK $jreVersion
+         |            $osName $osVersion ($osArch)
+         |""".stripMargin
 
     println(versionOutput)
   }

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -3,6 +3,7 @@ package org.enso.runner
 import java.io.File
 import java.util.UUID
 
+import buildinfo.Info
 import cats.implicits._
 import org.apache.commons.cli.{Option => CliOption, _}
 import org.enso.languageserver
@@ -11,6 +12,7 @@ import org.enso.pkg.Package
 import org.enso.polyglot.{ExecutionContext, LanguageInfo, Module}
 import org.graalvm.polyglot.Value
 
+import scala.annotation.unused
 import scala.util.Try
 
 /** The main CLI entry point class. */
@@ -26,6 +28,7 @@ object Main {
   private val PORT_OPTION            = "port"
   private val ROOT_ID_OPTION         = "root-id"
   private val ROOT_PATH_OPTION       = "path"
+  private val VERSION_OPTION         = "version"
 
   /**
     * Builds the [[Options]] object representing the CLI syntax.
@@ -95,6 +98,10 @@ object Main {
       .longOpt(ROOT_PATH_OPTION)
       .desc("Path to the content root.")
       .build()
+    val version = CliOption.builder
+      .longOpt(VERSION_OPTION)
+      .desc("Checks the version of the Enso executable.")
+      .build
 
     val options = new Options
     options
@@ -108,6 +115,7 @@ object Main {
       .addOption(portOption)
       .addOption(uuidOption)
       .addOption(pathOption)
+      .addOption(version)
 
     options
   }
@@ -249,6 +257,29 @@ object Main {
     } yield languageserver.LanguageServerConfig(interface, port, rootId, rootPath)
     // format: on
 
+  /** Prints the version of the enso executable.
+    *
+    * @param options A description of the CLI options syntax
+    */
+  def displayVersion(@unused options: Options): Unit = {
+    val dirtyStr = if (Info.isDirty) {
+      "Dirty"
+    } else {
+      "Clean"
+    }
+
+    val versionOutput =
+      s"""
+        |Enso Compiler and Runtime
+        |Version: ${Info.ensoVersion}
+        |Built from: ${Info.branch}@${Info.commit}${dirtyStr}
+        |Built with: scala-${Info.scalacVersion} for GraalVM ${Info.graalVersion}
+        |Running on:
+        |""".stripMargin
+
+    println(versionOutput)
+  }
+
   /**
     * Main entry point for the CLI program.
     *
@@ -264,6 +295,10 @@ object Main {
     }
     if (line.hasOption(HELP_OPTION)) {
       printHelp(options)
+      exitSuccess()
+    }
+    if (line.hasOption(VERSION_OPTION)) {
+      displayVersion(options)
       exitSuccess()
     }
     if (line.hasOption(NEW_OPTION)) {

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -270,14 +270,9 @@ object Main {
     val osVersion = System.getProperty("os.version")
 
     val dirtyStr = if (Info.isDirty) {
-      "Uncommitted changes,"
+      "*"
     } else {
       ""
-    }
-    val commitStr = if (Info.branchCommitCount == "1") {
-      "commit"
-    } else {
-      "commits"
     }
 
     val versionOutput =
@@ -285,8 +280,7 @@ object Main {
          |Enso Compiler and Runtime
          |Version:    ${Info.ensoVersion}
          |Built with: scala-${Info.scalacVersion} for GraalVM ${Info.graalVersion}
-         |Built from: ${Info.branch} @ ${Info.commit}
-         |            ${dirtyStr} ${Info.branchCommitCount} $commitStr on branch
+         |Built from: ${Info.branch}$dirtyStr @ ${Info.commit}
          |Running on: $vmName, JDK $jreVersion
          |            $osName $osVersion ($osArch)
          |""".stripMargin

--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -12,7 +12,6 @@ object BuildInfo {
     val gitHash          = ("git rev-parse HEAD" !!).trim
     val gitBranch        = ("git rev-parse --abbrev-ref HEAD" !!).trim
     val isDirty          = !("git status --porcelain" !!).trim.isEmpty
-    val dirtyCommitCount = ("git rev-list --count master..HEAD" !!).trim
     val latestCommitDate = ("git log HEAD -1 --format=%cd" !!).trim
 
     val fileContents =
@@ -30,7 +29,6 @@ object BuildInfo {
          |  val commit            = "$gitHash"
          |  val branch            = "$gitBranch"
          |  val isDirty           = $isDirty
-         |  val branchCommitCount = "$dirtyCommitCount"
          |  val latestCommitDate  = "$latestCommitDate"
          |}
          |""".stripMargin

--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -12,7 +12,7 @@ object BuildInfo {
     val gitHash          = ("git rev-parse HEAD" !!).trim
     val gitBranch        = ("git rev-parse --abbrev-ref HEAD" !!).trim
     val isDirty          = !("git status --porcelain" !!).trim.isEmpty
-    val dirtyCommitCount = "0" // ("git rev-list --count master.." !!).trim
+    val dirtyCommitCount = ("git rev-list --count master..HEAD" !!).trim
     val latestCommitDate = ("git log HEAD -1 --format=%cd" !!).trim
 
     val fileContents =

--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -12,7 +12,7 @@ object BuildInfo {
     val gitHash          = ("git rev-parse HEAD" !!).trim
     val gitBranch        = ("git rev-parse --abbrev-ref HEAD" !!).trim
     val isDirty          = !("git status --porcelain" !!).trim.isEmpty
-    val dirtyCommitCount = ("git rev-list --count master.." !!).trim
+    val dirtyCommitCount = "0" // ("git rev-list --count master.." !!).trim
     val latestCommitDate = ("git log HEAD -1 --format=%cd" !!).trim
 
     val fileContents =

--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -1,0 +1,40 @@
+import sbt._
+
+import scala.sys.process._
+
+object BuildInfo {
+  def writeBuildInfoFile(
+    file: File,
+    ensoVersion: String,
+    scalacVersion: String,
+    graalVersion: String
+  ): Seq[File] = {
+    val gitHash          = ("git rev-parse HEAD" !!).trim
+    val gitBranch        = ("git rev-parse --abbrev-ref HEAD" !!).trim
+    val isDirty          = !("git status --porcelain" !!).trim.isEmpty
+    val dirtyCommitCount = ("git rev-list --count master.." !!).trim
+    val latestCommitDate = ("git log HEAD -1 --format=%cd" !!).trim
+
+    val fileContents =
+      s"""
+         |package buildinfo
+         |
+         |object Info {
+         |
+         |  // Versions
+         |  val ensoVersion   = "$ensoVersion"
+         |  val scalacVersion = "$scalacVersion"
+         |  val graalVersion  = "$graalVersion"
+         |
+         |  // Git Info
+         |  val commit            = "$gitHash"
+         |  val branch            = "$gitBranch"
+         |  val isDirty           = $isDirty
+         |  val branchCommitCount = "$dirtyCommitCount"
+         |  val latestCommitDate  = "$latestCommitDate"
+         |}
+         |""".stripMargin
+    IO.write(file, fileContents)
+    Seq(file)
+  }
+}


### PR DESCRIPTION
### Pull Request Description
This PR adds a `--version` CLI option to the runner project, which prints detailed information about the build and execution context of the enso binary. 

### Important Notes
An example.

```
Enso Compiler and Runtime
Version:    0.0.1
Built with: scala-2.13.1 for GraalVM 20.0.0
Built from: wip/ara/better-version @ 1030864652f8f1e316ab3438f933f62f2806ebe4
            Uncommitted changes, 1 commit on branch
Running on: Java HotSpot(TM) 64-Bit Server VM GraalVM EE 20.0.0, JDK 1.8.0_241-b07
            Mac OS X 10.15.3 (x86_64)
```

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
