### PR TITLE
Remove file manager warmup in tests

### DIFF
--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/BaseServerTest.scala
@@ -40,7 +40,9 @@ class BaseServerTest extends JsonRpcServerTestKit {
   override def clientControllerFactory: ClientControllerFactory = {
     val languageServer = system.actorOf(Props(new LanguageServer(config)))
     languageServer ! LanguageProtocol.Initialize
-    val fileManager = getFileManager()
+    val zioExec = ZioExec(zio.Runtime.default)
+    val fileManager =
+      system.actorOf(FileManager.props(config, new FileSystem, zioExec))
     val bufferRegistry =
       system.actorOf(
         BufferRegistry.props(fileManager)(Sha3_224VersionCalculator)
@@ -54,21 +56,5 @@ class BaseServerTest extends JsonRpcServerTestKit {
       capabilityRouter,
       fileManager
     )
-  }
-
-  private def getFileManager(): ActorRef = {
-    implicit val timeout = Timeout(10.seconds)
-    val zioExec = ZioExec(zio.Runtime.default)
-    val fileManager =
-      system.actorOf(FileManager.props(config, new FileSystem, zioExec))
-    // Tests requiring FileManager can randomly fail with timeout on
-    // Windows. And it's always the first one that fails. I assume it happens
-    // due to a cold Zio executor. Here we send a few messages to warm up the
-    // FileManager.
-    val result = fileManager ? FileManagerProtocol.ExistsFile(
-      Path(testContentRootId, Vector())
-    )
-    Await.ready(result, Duration.Inf)
-    fileManager
   }
 }


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Run GitHub Actions without the warmup hack.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
