### PR TITLE
Add executionContext push & pop commands

### DIFF
--- a/doc/design/engine/engine-services.md
+++ b/doc/design/engine/engine-services.md
@@ -716,7 +716,7 @@ interface ProjectListRecentResponse {
 ```
 
 ##### Errors
-- [`ProjectDataStoreError`](#projectdatastoreerror) to signal problems with 
+- [`ProjectDataStoreError`](#projectdatastoreerror) to signal problems with
 underlying data store.
 
 #### `project/create`
@@ -2069,6 +2069,8 @@ null
 ##### Errors
 - [`AccessDeniedError`](#accessdeniederror) when the user does not hold the
   `executionContext/canModify` capability for this context.
+- [`EmptyStackError`](#emptystackerror) when the user tries to pop an empty
+  stack.
 
 #### `executionContext/recompute`
 Sent from the client to the server to force recomputation of current position.
@@ -2195,6 +2197,16 @@ It signals that provided context was not found.
 "error" : {
   "code" : 2002,
   "message" : "Context not found"
+}
+```
+
+##### `EmptyStackError`
+It signals that stack is empty.
+
+```typescript
+"error" : {
+  "code" : 2003,
+  "message" : "Stack is empty"
 }
 ```
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -94,8 +94,7 @@ class MainModule(serverConfig: LanguageServerConfig) {
 
   lazy val contextRegistry =
     system.actorOf(
-      ContextRegistry
-        .props(languageServerConfig.executionContext, runtimeConnector),
+      ContextRegistry.props(languageServerConfig, runtimeConnector),
       "context-registry"
     )
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/ClientController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/ClientController.scala
@@ -78,6 +78,8 @@ class ClientController(
       ExecutionContextCreate -> executioncontext.CreateHandler
         .props(requestTimeout, contextRegistry),
       ExecutionContextDestroy -> executioncontext.DestroyHandler
+        .props(requestTimeout, contextRegistry),
+      ExecutionContextPush -> executioncontext.PushHandler
         .props(requestTimeout, contextRegistry)
     )
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/ClientController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/ClientController.scala
@@ -80,6 +80,8 @@ class ClientController(
       ExecutionContextDestroy -> executioncontext.DestroyHandler
         .props(requestTimeout, contextRegistry),
       ExecutionContextPush -> executioncontext.PushHandler
+        .props(requestTimeout, contextRegistry),
+      ExecutionContextPop -> executioncontext.PopHandler
         .props(requestTimeout, contextRegistry)
     )
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/JsonRpc.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/JsonRpc.scala
@@ -36,6 +36,7 @@ object JsonRpc {
     .registerRequest(InfoFile)
     .registerRequest(ExecutionContextCreate)
     .registerRequest(ExecutionContextDestroy)
+    .registerRequest(ExecutionContextPush)
     .registerNotification(ForceReleaseCapability)
     .registerNotification(GrantCapability)
     .registerNotification(TextDidChange)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/JsonRpc.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/JsonRpc.scala
@@ -37,6 +37,7 @@ object JsonRpc {
     .registerRequest(ExecutionContextCreate)
     .registerRequest(ExecutionContextDestroy)
     .registerRequest(ExecutionContextPush)
+    .registerRequest(ExecutionContextPop)
     .registerNotification(ForceReleaseCapability)
     .registerNotification(GrantCapability)
     .registerNotification(TextDidChange)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PopHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PopHandler.scala
@@ -3,10 +3,12 @@ package org.enso.languageserver.requesthandler.executioncontext
 import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
 import org.enso.jsonrpc.Errors.ServiceError
 import org.enso.jsonrpc._
-import org.enso.languageserver.filemanager.FileManagerApi
 import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.ExecutionApi._
-import org.enso.languageserver.runtime.ContextRegistryProtocol
+import org.enso.languageserver.runtime.{
+  ContextRegistryProtocol,
+  RuntimeFailureMapper
+}
 import org.enso.languageserver.util.UnhandledLogging
 
 import scala.concurrent.duration.FiniteDuration
@@ -51,8 +53,8 @@ class PopHandler(
       cancellable.cancel()
       context.stop(self)
 
-    case AccessDeniedError =>
-      replyTo ! ResponseError(Some(id), FileManagerApi.AccessDeniedError)
+    case error: ContextRegistryProtocol.Failure =>
+      replyTo ! ResponseError(Some(id), RuntimeFailureMapper.mapFailure(error))
       cancellable.cancel()
       context.stop(self)
   }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PopHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PopHandler.scala
@@ -1,0 +1,72 @@
+package org.enso.languageserver.requesthandler.executioncontext
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
+import org.enso.jsonrpc.Errors.ServiceError
+import org.enso.jsonrpc._
+import org.enso.languageserver.filemanager.FileManagerApi
+import org.enso.languageserver.requesthandler.RequestTimeout
+import org.enso.languageserver.runtime.ExecutionApi._
+import org.enso.languageserver.runtime.ContextRegistryProtocol
+import org.enso.languageserver.util.UnhandledLogging
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * A request handler for `executionContext/push` commands.
+  *
+  * @param timeout request timeout
+  * @param contextRegistry a reference to the context registry.
+  */
+class PopHandler(
+  timeout: FiniteDuration,
+  contextRegistry: ActorRef
+) extends Actor
+    with ActorLogging
+    with UnhandledLogging {
+
+  import context.dispatcher, ContextRegistryProtocol._
+
+  override def receive: Receive = requestStage
+
+  private def requestStage: Receive = {
+    case Request(ExecutionContextPop, id, params: ExecutionContextPop.Params) =>
+      contextRegistry ! PopContextRequest(sender(), params.contextId)
+      val cancellable =
+        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+      context.become(responseStage(id, sender(), cancellable))
+  }
+
+  private def responseStage(
+    id: Id,
+    replyTo: ActorRef,
+    cancellable: Cancellable
+  ): Receive = {
+    case RequestTimeout =>
+      log.error(s"Request $id timed out")
+      replyTo ! ResponseError(Some(id), ServiceError)
+      context.stop(self)
+
+    case PopContextResponse(_) =>
+      replyTo ! ResponseResult(ExecutionContextPop, id, Unused)
+      cancellable.cancel()
+      context.stop(self)
+
+    case AccessDeniedError =>
+      replyTo ! ResponseError(Some(id), FileManagerApi.AccessDeniedError)
+      cancellable.cancel()
+      context.stop(self)
+  }
+}
+
+object PopHandler {
+
+  /**
+    * Creates configuration object used to create a [[PopHandler]].
+    *
+    * @param timeout request timeout
+    * @param contextRegistry a reference to the context registry.
+    */
+  def props(timeout: FiniteDuration, contextRegistry: ActorRef): Props =
+    Props(new PopHandler(timeout, contextRegistry))
+
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PushHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PushHandler.scala
@@ -1,0 +1,89 @@
+package org.enso.languageserver.requesthandler.executioncontext
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
+import org.enso.jsonrpc.Errors.ServiceError
+import org.enso.jsonrpc._
+import org.enso.languageserver.filemanager.FileManagerApi
+import org.enso.languageserver.filemanager.FileSystemFailureMapper
+import org.enso.languageserver.requesthandler.RequestTimeout
+import org.enso.languageserver.runtime.ExecutionApi._
+import org.enso.languageserver.runtime.ContextRegistryProtocol
+import org.enso.languageserver.util.UnhandledLogging
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * A request handler for `executionContext/push` commands.
+  *
+  * @param timeout request timeout
+  * @param contextRegistry a reference to the context registry.
+  */
+class PushHandler(
+  timeout: FiniteDuration,
+  contextRegistry: ActorRef
+) extends Actor
+    with ActorLogging
+    with UnhandledLogging {
+
+  import context.dispatcher, ContextRegistryProtocol._
+
+  override def receive: Receive = requestStage
+
+  private def requestStage: Receive = {
+    case Request(
+        ExecutionContextPush,
+        id,
+        params: ExecutionContextPush.Params
+        ) =>
+      contextRegistry ! PushContextRequest(
+        sender(),
+        params.contextId,
+        params.stackItem
+      )
+      val cancellable =
+        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+      context.become(responseStage(id, sender(), cancellable))
+  }
+
+  private def responseStage(
+    id: Id,
+    replyTo: ActorRef,
+    cancellable: Cancellable
+  ): Receive = {
+    case RequestTimeout =>
+      log.error(s"Request $id timed out")
+      replyTo ! ResponseError(Some(id), ServiceError)
+      context.stop(self)
+
+    case PushContextResponse(_) =>
+      replyTo ! ResponseResult(ExecutionContextPush, id, Unused)
+      cancellable.cancel()
+      context.stop(self)
+
+    case AccessDeniedError =>
+      replyTo ! ResponseError(Some(id), FileManagerApi.AccessDeniedError)
+      cancellable.cancel()
+      context.stop(self)
+
+    case FileSystemError(error) =>
+      replyTo ! ResponseError(
+        Some(id),
+        FileSystemFailureMapper.mapFailure(error)
+      )
+      cancellable.cancel()
+      context.stop(self)
+  }
+}
+
+object PushHandler {
+
+  /**
+    * Creates configuration object used to create a [[PushHandler]].
+    *
+    * @param timeout request timeout
+    * @param contextRegistry a reference to the context registry.
+    */
+  def props(timeout: FiniteDuration, contextRegistry: ActorRef): Props =
+    Props(new PushHandler(timeout, contextRegistry))
+
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
@@ -85,8 +85,7 @@ final class ContextRegistry(config: Config, runtime: ActorRef)
       }
 
     case PopContextRequest(client, contextId) =>
-      val contexts = store.getContexts(client)
-      if (contexts.contains(contextId)) {
+      if (store.hasContext(client, contextId)) {
         val handler = context.actorOf(PopContextHandler.props(timeout, runtime))
         handler.forward(Api.PopContextRequest(contextId))
       } else {
@@ -142,7 +141,7 @@ object ContextRegistry {
   /**
     * Creates a configuration object used to create a [[ContextRegistry]].
     *
-    * @param config configuration
+    * @param config language server configuration
     * @param runtime reference to the [[RuntimeConnector]]
     */
   def props(config: Config, runtime: ActorRef): Props =

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
@@ -81,7 +81,7 @@ final class ContextRegistry(config: Config, runtime: ActorRef)
             sender() ! FileSystemError(error)
         }
       } else {
-        sender() ! AccessDeniedError
+        sender() ! AccessDenied
       }
 
     case PopContextRequest(client, contextId) =>
@@ -90,7 +90,7 @@ final class ContextRegistry(config: Config, runtime: ActorRef)
         val handler = context.actorOf(PopContextHandler.props(timeout, runtime))
         handler.forward(Api.PopContextRequest(contextId))
       } else {
-        sender() ! AccessDeniedError
+        sender() ! AccessDenied
       }
   }
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
@@ -83,6 +83,15 @@ final class ContextRegistry(config: Config, runtime: ActorRef)
       } else {
         sender() ! AccessDeniedError
       }
+
+    case PopContextRequest(client, contextId) =>
+      val contexts = store.getContexts(client)
+      if (contexts.contains(contextId)) {
+        val handler = context.actorOf(PopContextHandler.props(timeout, runtime))
+        handler.forward(Api.PopContextRequest(contextId))
+      } else {
+        sender() ! AccessDeniedError
+      }
   }
 
   private def getRuntimeStackItem(

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
@@ -3,7 +3,8 @@ package org.enso.languageserver.runtime
 import java.util.UUID
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
-import org.enso.languageserver.data.ExecutionContextConfig
+import org.enso.languageserver.data.Config
+import org.enso.languageserver.filemanager.FileSystemFailure
 import org.enso.languageserver.runtime.ExecutionApi.ContextId
 import org.enso.languageserver.runtime.handler._
 import org.enso.languageserver.util.UnhandledLogging
@@ -35,24 +36,25 @@ import org.enso.polyglot.runtime.Runtime.Api
   *
   * }}}
   *
-  * @param config execution context configuration
+  * @param config configuration
   * @param runtime reference to the [[RuntimeConnector]]
   */
-final class ContextRegistry(config: ExecutionContextConfig, runtime: ActorRef)
+final class ContextRegistry(config: Config, runtime: ActorRef)
     extends Actor
     with ActorLogging
     with UnhandledLogging {
 
-  import ContextRegistry._, ContextRegistryProtocol._
+  import ContextRegistryProtocol._
+
+  private val timeout = config.executionContext.requestTimeout
 
   override def receive: Receive =
-    withStore(Store(Map()))
+    withStore(ContextRegistry.Store(Map()))
 
-  private def withStore(store: Store): Receive = {
+  private def withStore(store: ContextRegistry.Store): Receive = {
     case CreateContextRequest(client) =>
-      val handler = context.actorOf(
-        CreateContextHandler.props(config.requestTimeout, runtime)
-      )
+      val handler =
+        context.actorOf(CreateContextHandler.props(timeout, runtime))
       val contextId = UUID.randomUUID()
       handler.forward(Api.CreateContextRequest(contextId))
       context.become(withStore(store.addContext(client, contextId)))
@@ -60,15 +62,53 @@ final class ContextRegistry(config: ExecutionContextConfig, runtime: ActorRef)
     case DestroyContextRequest(client, contextId) =>
       val contexts = store.getContexts(client)
       if (contexts.contains(contextId)) {
-        val handler = context.actorOf(
-          DestroyContextHandler.props(config.requestTimeout, runtime)
-        )
+        val handler =
+          context.actorOf(DestroyContextHandler.props(timeout, runtime))
         handler.forward(Api.DestroyContextRequest(contextId))
         context.become(withStore(store.updated(client, contexts - contextId)))
       } else {
         sender() ! AccessDenied
       }
+
+    case PushContextRequest(client, contextId, stackItem) =>
+      if (store.hasContext(client, contextId)) {
+        getRuntimeStackItem(stackItem) match {
+          case Right(stackItem) =>
+            val handler =
+              context.actorOf(PushContextHandler.props(timeout, runtime))
+            handler.forward(Api.PushContextRequest(contextId, stackItem))
+          case Left(error) =>
+            sender() ! FileSystemError(error)
+        }
+      } else {
+        sender() ! AccessDeniedError
+      }
   }
+
+  private def getRuntimeStackItem(
+    stackItem: StackItem
+  ): Either[FileSystemFailure, Api.StackItem] =
+    stackItem match {
+      case StackItem.ExplicitCall(pointer, argument, arguments) =>
+        getRuntimeMethodPointer(pointer).map { methodPointer =>
+          Api.StackItem.ExplicitCall(methodPointer, argument, arguments)
+        }
+
+      case StackItem.LocalCall(expressionId) =>
+        Right(Api.StackItem.LocalCall(expressionId))
+    }
+
+  private def getRuntimeMethodPointer(
+    pointer: MethodPointer
+  ): Either[FileSystemFailure, Api.MethodPointer] =
+    config.findContentRoot(pointer.file.rootId).map { rootPath =>
+      Api.MethodPointer(
+        file          = pointer.file.toFile(rootPath).toPath,
+        definedOnType = pointer.definedOnType,
+        name          = pointer.name
+      )
+    }
+
 }
 
 object ContextRegistry {
@@ -85,14 +125,17 @@ object ContextRegistry {
 
     def getContexts(client: ClientRef): Set[ContextId] =
       store.getOrElse(client, Set())
+
+    def hasContext(client: ClientRef, contextId: ContextId): Boolean =
+      getContexts(client).contains(contextId)
   }
 
   /**
     * Creates a configuration object used to create a [[ContextRegistry]].
     *
-    * @param config execution context configuration
+    * @param config configuration
     * @param runtime reference to the [[RuntimeConnector]]
     */
-  def props(config: ExecutionContextConfig, runtime: ActorRef): Props =
+  def props(config: Config, runtime: ActorRef): Props =
     Props(new ContextRegistry(config, runtime))
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
@@ -1,6 +1,7 @@
 package org.enso.languageserver.runtime
 
 import akka.actor.ActorRef
+import org.enso.languageserver.filemanager.FileSystemFailure
 import org.enso.languageserver.runtime.ExecutionApi.ContextId
 
 object ContextRegistryProtocol {
@@ -39,6 +40,27 @@ object ContextRegistryProtocol {
   case class DestroyContextResponse(contextId: ContextId)
 
   /**
+    * A request to the context registry to push an execution context
+    * down the stack.
+    *
+    * @param client reference to the client
+    * @param contextId execution context identifier
+    * @param stackItem an object representing an item on the stack
+    */
+  case class PushContextRequest(
+    client: ActorRef,
+    contextId: ContextId,
+    stackItem: StackItem
+  )
+
+  /**
+    * A response about pushing the new item to the stack.
+    *
+    * @param contextId execution context identifier
+    */
+  case class PushContextResponse(contextId: ContextId)
+
+  /**
     * Signals that user doesn't have access to the requested context.
     */
   case object AccessDenied extends Failure
@@ -47,4 +69,11 @@ object ContextRegistryProtocol {
     * Signals that context was not found.
     */
   case class ContextNotFound(contextId: ContextId) extends Failure
+
+  /**
+    * Signals about file system error.
+    *
+    * @param error file system failure
+    */
+  case class FileSystemError(error: FileSystemFailure) extends Failure
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
@@ -61,6 +61,22 @@ object ContextRegistryProtocol {
   case class PushContextResponse(contextId: ContextId)
 
   /**
+    * A request to the context registry to move an execution context
+    * up the stack.
+    *
+    * @param client reference to the client
+    * @param contextId execution context identifier
+    */
+  case class PopContextRequest(client: ActorRef, contextId: ContextId)
+
+  /**
+    * A response about popping the stack.
+    *
+    * @param contextId execution context identifier
+    */
+  case class PopContextResponse(contextId: ContextId)
+
+  /**
     * Signals that user doesn't have access to the requested context.
     */
   case object AccessDenied extends Failure

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
@@ -83,6 +83,8 @@ object ContextRegistryProtocol {
 
   /**
     * Signals that context was not found.
+    *
+    * @param contextId execution context identifier
     */
   case class ContextNotFound(contextId: ContextId) extends Failure
 
@@ -92,4 +94,11 @@ object ContextRegistryProtocol {
     * @param error file system failure
     */
   case class FileSystemError(error: FileSystemFailure) extends Failure
+
+  /**
+    * Signals that stack is empty.
+    *
+    * @param contextId execution context identifier
+    */
+  case class EmptyStackError(contextId: ContextId) extends Failure
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExecutionApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExecutionApi.scala
@@ -54,6 +54,18 @@ object ExecutionApi {
     }
   }
 
+  case object ExecutionContextPop extends Method("executionContext/pop") {
+
+    case class Params(contextId: ContextId)
+
+    implicit val hasParams = new HasParams[this.type] {
+      type Params = ExecutionContextPop.Params
+    }
+    implicit val hasResult = new HasResult[this.type] {
+      type Result = Unused.type
+    }
+  }
+
   case object StackItemNotFoundError extends Error(2001, "Stack item not found")
 
   case object ContextNotFoundError extends Error(2002, "Context not found")

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExecutionApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExecutionApi.scala
@@ -42,6 +42,18 @@ object ExecutionApi {
     }
   }
 
+  case object ExecutionContextPush extends Method("executionContext/push") {
+
+    case class Params(contextId: ContextId, stackItem: StackItem)
+
+    implicit val hasParams = new HasParams[this.type] {
+      type Params = ExecutionContextPush.Params
+    }
+    implicit val hasResult = new HasResult[this.type] {
+      type Result = Unused.type
+    }
+  }
+
   case object StackItemNotFoundError extends Error(2001, "Stack item not found")
 
   case object ContextNotFoundError extends Error(2002, "Context not found")

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExecutionApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExecutionApi.scala
@@ -70,4 +70,6 @@ object ExecutionApi {
 
   case object ContextNotFoundError extends Error(2002, "Context not found")
 
+  case object EmptyStackError extends Error(2003, "Stack is empty")
+
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/MethodPointer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/MethodPointer.scala
@@ -4,5 +4,9 @@ import org.enso.languageserver.filemanager.Path
 
 /**
   * An object pointing to a method definition.
+  *
+  * @param file path to the method file
+  * @param definedOnType method type
+  * @param name method name
   */
 case class MethodPointer(file: Path, definedOnType: String, name: String)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/MethodPointer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/MethodPointer.scala
@@ -1,0 +1,8 @@
+package org.enso.languageserver.runtime
+
+import org.enso.languageserver.filemanager.Path
+
+/**
+  * An object pointing to a method definition.
+  */
+case class MethodPointer(file: Path, definedOnType: String, name: String)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeFailureMapper.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeFailureMapper.scala
@@ -1,6 +1,7 @@
 package org.enso.languageserver.runtime
 
 import org.enso.jsonrpc._
+import org.enso.languageserver.filemanager.FileSystemFailureMapper
 import org.enso.languageserver.protocol.ErrorApi._
 import org.enso.languageserver.runtime.ExecutionApi._
 import org.enso.polyglot.runtime.Runtime.Api
@@ -19,6 +20,8 @@ object RuntimeFailureMapper {
         AccessDeniedError
       case ContextRegistryProtocol.ContextNotFound(_) =>
         ContextNotFoundError
+      case ContextRegistryProtocol.FileSystemError(error) =>
+        FileSystemFailureMapper.mapFailure(error)
     }
 
   /**

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeFailureMapper.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeFailureMapper.scala
@@ -22,6 +22,8 @@ object RuntimeFailureMapper {
         ContextNotFoundError
       case ContextRegistryProtocol.FileSystemError(error) =>
         FileSystemFailureMapper.mapFailure(error)
+      case ContextRegistryProtocol.EmptyStackError(_) =>
+        EmptyStackError
     }
 
   /**
@@ -34,6 +36,8 @@ object RuntimeFailureMapper {
     error match {
       case Api.ContextNotExistError(contextId) =>
         ContextRegistryProtocol.ContextNotFound(contextId)
+      case Api.EmptyStackError(contextId) =>
+        ContextRegistryProtocol.EmptyStackError(contextId)
     }
 
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/StackItem.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/StackItem.scala
@@ -27,7 +27,7 @@ object StackItem {
   ) extends StackItem
 
   /**
-    * A cal corresponding to "entering a function call".
+    * A call corresponding to "entering a function call".
     *
     * @param expressionId an expression identifier
     */

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/StackItem.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/StackItem.scala
@@ -1,0 +1,97 @@
+package org.enso.languageserver.runtime
+
+import java.util.UUID
+
+import io.circe.generic.auto._
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder, Json}
+
+/**
+  * A representation of an executable position in code.
+  */
+sealed trait StackItem
+
+object StackItem {
+
+  /**
+    * A call performed at the top of the stack, to initialize the context.
+    */
+  case class ExplicitCall(
+    methodPointer: MethodPointer,
+    thisArgumentExpression: Option[String],
+    positionalArgumentsExpressions: Vector[String]
+  ) extends StackItem
+
+  /**
+    * A cal corresponding to "entering a function call".
+    */
+  case class LocalCall(expressionId: UUID) extends StackItem
+
+  private object CodecField {
+
+    val Type = "type"
+
+    val MethodPointer = "methodPointer"
+
+    val ThisArgumentExpression = "thisArgumentExpression"
+
+    val PositionalArgumentsExpressions = "positionalArgumentsExpressions"
+
+    val ExpressionId = "expressionId"
+  }
+
+  private object CodecType {
+
+    val ExplicitCall = "ExplicitCall"
+
+    val LocalCall = "LocalCall"
+  }
+
+  implicit val encoder: Encoder[StackItem] =
+    Encoder.instance[StackItem] {
+      case ExplicitCall(
+          methodPointer,
+          thisArgumentExpression,
+          positionalArgumentsExpressions
+          ) =>
+        Json.obj(
+          CodecField.Type                           -> CodecType.ExplicitCall.asJson,
+          CodecField.MethodPointer                  -> methodPointer.asJson,
+          CodecField.ThisArgumentExpression         -> thisArgumentExpression.asJson,
+          CodecField.PositionalArgumentsExpressions -> positionalArgumentsExpressions.asJson
+        )
+
+      case LocalCall(expressionId) =>
+        Json.obj(
+          CodecField.Type         -> CodecType.LocalCall.asJson,
+          CodecField.ExpressionId -> expressionId.asJson
+        )
+    }
+
+  implicit val decoder: Decoder[StackItem] =
+    Decoder.instance { cursor =>
+      cursor.downField(CodecField.Type).as[String].flatMap {
+        case CodecType.ExplicitCall =>
+          for {
+            methodPointer <- cursor
+              .downField(CodecField.MethodPointer)
+              .as[MethodPointer]
+            thisArgumentExpression <- cursor
+              .downField(CodecField.ThisArgumentExpression)
+              .as[Option[String]]
+            positionalArgumentsExpressions <- cursor
+              .downField(CodecField.PositionalArgumentsExpressions)
+              .as[Vector[String]]
+          } yield ExplicitCall(
+            methodPointer,
+            thisArgumentExpression,
+            positionalArgumentsExpressions
+          )
+
+        case CodecType.LocalCall =>
+          for {
+            expressionId <- cursor.downField(CodecField.ExpressionId).as[UUID]
+          } yield LocalCall(expressionId)
+      }
+    }
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/StackItem.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/StackItem.scala
@@ -15,6 +15,10 @@ object StackItem {
 
   /**
     * A call performed at the top of the stack, to initialize the context.
+    *
+    * @param methodPointer points to a method definition
+    * @param thisArgumentExpression optional argument
+    * @param positionalArgumentsExpressions positional arguments
     */
   case class ExplicitCall(
     methodPointer: MethodPointer,
@@ -24,6 +28,8 @@ object StackItem {
 
   /**
     * A cal corresponding to "entering a function call".
+    *
+    * @param expressionId an expression identifier
     */
   case class LocalCall(expressionId: UUID) extends StackItem
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PopContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PopContextHandler.scala
@@ -1,0 +1,63 @@
+package org.enso.languageserver.runtime.handler
+
+import java.util.UUID
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
+import org.enso.languageserver.requesthandler.RequestTimeout
+import org.enso.languageserver.runtime.ContextRegistryProtocol
+import org.enso.languageserver.util.UnhandledLogging
+import org.enso.polyglot.runtime.Runtime.Api
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * A request handler for push commands.
+  *
+  * @param timeout request timeout
+  * @param runtime reference to the runtime conector
+  */
+final class PopContextHandler(
+  timeout: FiniteDuration,
+  runtime: ActorRef
+) extends Actor
+    with ActorLogging
+    with UnhandledLogging {
+
+  import context.dispatcher
+
+  override def receive: Receive = requestStage
+
+  private def requestStage: Receive = {
+    case msg: Api.PopContextRequest =>
+      runtime ! Api.Request(UUID.randomUUID(), msg)
+      val cancellable =
+        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+      context.become(responseStage(sender(), cancellable))
+  }
+
+  private def responseStage(
+    replyTo: ActorRef,
+    cancellable: Cancellable
+  ): Receive = {
+    case RequestTimeout =>
+      replyTo ! RequestTimeout
+      context.stop(self)
+
+    case Api.Response(_, Api.PopContextResponse(contextId)) =>
+      replyTo ! ContextRegistryProtocol.PopContextResponse(contextId)
+      cancellable.cancel()
+      context.stop(self)
+  }
+}
+
+object PopContextHandler {
+
+  /**
+    * Creates a configuration object used to create [[PopContextHandler]].
+    *
+    * @param timeout request timeout
+    * @param runtime reference to the runtime conector
+    */
+  def props(timeout: FiniteDuration, runtime: ActorRef): Props =
+    Props(new PopContextHandler(timeout, runtime))
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PopContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PopContextHandler.scala
@@ -4,7 +4,10 @@ import java.util.UUID
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
 import org.enso.languageserver.requesthandler.RequestTimeout
-import org.enso.languageserver.runtime.ContextRegistryProtocol
+import org.enso.languageserver.runtime.{
+  ContextRegistryProtocol,
+  RuntimeFailureMapper
+}
 import org.enso.languageserver.util.UnhandledLogging
 import org.enso.polyglot.runtime.Runtime.Api
 
@@ -45,6 +48,11 @@ final class PopContextHandler(
 
     case Api.Response(_, Api.PopContextResponse(contextId)) =>
       replyTo ! ContextRegistryProtocol.PopContextResponse(contextId)
+      cancellable.cancel()
+      context.stop(self)
+
+    case Api.Response(_, error: Api.Error) =>
+      replyTo ! RuntimeFailureMapper.mapApiError(error)
       cancellable.cancel()
       context.stop(self)
   }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PushContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PushContextHandler.scala
@@ -4,7 +4,10 @@ import java.util.UUID
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
 import org.enso.languageserver.requesthandler.RequestTimeout
-import org.enso.languageserver.runtime.ContextRegistryProtocol
+import org.enso.languageserver.runtime.{
+  ContextRegistryProtocol,
+  RuntimeFailureMapper
+}
 import org.enso.languageserver.util.UnhandledLogging
 import org.enso.polyglot.runtime.Runtime.Api
 
@@ -45,6 +48,11 @@ final class PushContextHandler(
 
     case Api.Response(_, Api.PushContextResponse(contextId)) =>
       replyTo ! ContextRegistryProtocol.PushContextResponse(contextId)
+      cancellable.cancel()
+      context.stop(self)
+
+    case Api.Response(_, error: Api.Error) =>
+      replyTo ! RuntimeFailureMapper.mapApiError(error)
       cancellable.cancel()
       context.stop(self)
   }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PushContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PushContextHandler.scala
@@ -1,0 +1,63 @@
+package org.enso.languageserver.runtime.handler
+
+import java.util.UUID
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
+import org.enso.languageserver.requesthandler.RequestTimeout
+import org.enso.languageserver.runtime.ContextRegistryProtocol
+import org.enso.languageserver.util.UnhandledLogging
+import org.enso.polyglot.runtime.Runtime.Api
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * A request handler for push commands.
+  *
+  * @param timeout request timeout
+  * @param runtime reference to the runtime conector
+  */
+final class PushContextHandler(
+  timeout: FiniteDuration,
+  runtime: ActorRef
+) extends Actor
+    with ActorLogging
+    with UnhandledLogging {
+
+  import context.dispatcher
+
+  override def receive: Receive = requestStage
+
+  private def requestStage: Receive = {
+    case msg: Api.PushContextRequest =>
+      runtime ! Api.Request(UUID.randomUUID(), msg)
+      val cancellable =
+        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+      context.become(responseStage(sender(), cancellable))
+  }
+
+  private def responseStage(
+    replyTo: ActorRef,
+    cancellable: Cancellable
+  ): Receive = {
+    case RequestTimeout =>
+      replyTo ! RequestTimeout
+      context.stop(self)
+
+    case Api.Response(_, Api.PushContextResponse(contextId)) =>
+      replyTo ! ContextRegistryProtocol.PushContextResponse(contextId)
+      cancellable.cancel()
+      context.stop(self)
+  }
+}
+
+object PushContextHandler {
+
+  /**
+    * Creates a configuration object used to create [[PushContextHandler]].
+    *
+    * @param timeout request timeout
+    * @param runtime reference to the runtime conector
+    */
+  def props(timeout: FiniteDuration, runtime: ActorRef): Props =
+    Props(new PushContextHandler(timeout, runtime))
+}

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/BaseServerTest.scala
@@ -59,10 +59,7 @@ class BaseServerTest extends JsonRpcServerTestKit {
         ReceivesTreeUpdatesHandler.props(config, new FileSystem, zioExec)
       )
     val contextRegistry =
-      system.actorOf(
-        ContextRegistry
-          .props(config.executionContext, runtimeConnectorProbe.ref)
-      )
+      system.actorOf(ContextRegistry.props(config, runtimeConnectorProbe.ref))
     lazy val capabilityRouter =
       system.actorOf(CapabilityRouter.props(bufferRegistry, fileEventRegistry))
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/ContextRegistryTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/ContextRegistryTest.scala
@@ -216,7 +216,7 @@ class ContextRegistryTest extends BaseServerTest {
       client.expectJson(json.ok(3))
     }
 
-    "pop empty stack" in {
+    "return EmptyStackError when popping empty stack" in {
       val client = new WsTestClient(address)
 
       // create context
@@ -245,9 +245,17 @@ class ContextRegistryTest extends BaseServerTest {
         }
       runtimeConnectorProbe.lastSender ! Api.Response(
         requestId2,
-        Api.PopContextResponse(contextId)
+        Api.EmptyStackError(contextId)
       )
-      client.expectJson(json.ok(2))
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id" : 2,
+            "error" : {
+              "code" : 2003,
+              "message" : "Stack is empty"
+            }
+          }
+          """)
     }
   }
 

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -39,6 +39,22 @@ object Runtime {
         name  = "destroyContextResponse"
       ),
       new JsonSubTypes.Type(
+        value = classOf[Api.PushContextRequest],
+        name  = "pushContextRequest"
+      ),
+      new JsonSubTypes.Type(
+        value = classOf[Api.PushContextResponse],
+        name  = "pushContextResponse"
+      ),
+      new JsonSubTypes.Type(
+        value = classOf[Api.PopContextRequest],
+        name  = "popContextRequest"
+      ),
+      new JsonSubTypes.Type(
+        value = classOf[Api.PopContextResponse],
+        name  = "popContextResponse"
+      ),
+      new JsonSubTypes.Type(
         value = classOf[Api.ContextNotExistError],
         name  = "contextNotExistError"
       )
@@ -67,6 +83,19 @@ object Runtime {
     /**
       * A representation of an executable position in code.
       */
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes(
+      Array(
+        new JsonSubTypes.Type(
+          value = classOf[StackItem.ExplicitCall],
+          name  = "explicitCall"
+        ),
+        new JsonSubTypes.Type(
+          value = classOf[StackItem.LocalCall],
+          name  = "localCall"
+        )
+      )
+    )
     sealed trait StackItem
 
     object StackItem {
@@ -130,7 +159,6 @@ object Runtime {
       * [[DestroyContextRequest]]
       *
       * @param contextId the destroyed context's id
-      * @param error optional error
       */
     case class DestroyContextResponse(contextId: ContextId) extends ApiResponse
 

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -57,6 +57,10 @@ object Runtime {
       new JsonSubTypes.Type(
         value = classOf[Api.ContextNotExistError],
         name  = "contextNotExistError"
+      ),
+      new JsonSubTypes.Type(
+        value = classOf[Api.EmptyStackError],
+        name  = "emptyStackError"
       )
     )
   )
@@ -195,9 +199,18 @@ object Runtime {
     case class PopContextResponse(contextId: ContextId) extends ApiResponse
 
     /**
-      * An error payload signifying a non-existent context.
+      * An error response signifying a non-existent context.
+      *
+      * @param contextId the context's id
       */
     case class ContextNotExistError(contextId: ContextId) extends Error
+
+    /**
+      * An error response signifying that stack is empty.
+      *
+      * @param contextId the context's id
+      */
+    case class EmptyStackError(contextId: ContextId) extends Error
 
     private lazy val mapper = {
       val factory = new CBORFactory()

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -152,6 +152,21 @@ object Runtime {
     case class PushContextResponse(contextId: ContextId) extends ApiResponse
 
     /**
+      * A Request sent from the client to the runtime server, to move
+      * the execution context up the stack.
+      *
+      * @param contextId the context's id.
+      */
+    case class PopContextRequest(contextId: ContextId) extends ApiRequest
+
+    /**
+      * A response sent from the server upon handling the [[PopContextRequest]]
+      *
+      * @param contextId the context's id.
+      */
+    case class PopContextResponse(contextId: ContextId) extends ApiResponse
+
+    /**
       * An error payload signifying a non-existent context.
       */
     case class ContextNotExistError(contextId: ContextId) extends Error

--- a/engine/runtime/src/main/scala/org/enso/interpeter/instrument/ExecutionContext.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpeter/instrument/ExecutionContext.scala
@@ -48,20 +48,22 @@ class ExecutionContextManager {
     *
     * @param id the context id.
     * @param item stack item.
+    * @return Unit representing success or None if the context does not exist.
     */
-  def push(id: ContextId, item: StackItem): Unit =
+  def push(id: ContextId, item: StackItem): Option[Unit] =
     for {
       stack <- contexts.get(ExecutionContext(id))
-    } stack.push(item)
+    } yield stack.push(item)
 
   /**
     * If the context exists and stack not empty, pop the item from the stack.
     *
     * @param id the context id.
+    * @return stack item or None if the stack is empty or not exists.
     */
-  def pop(id: ContextId): Unit =
+  def pop(id: ContextId): Option[StackItem] =
     for {
       stack <- contexts.get(ExecutionContext(id))
       if stack.nonEmpty
-    } stack.pop()
+    } yield stack.pop()
 }

--- a/engine/runtime/src/main/scala/org/enso/interpeter/instrument/ExecutionContext.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpeter/instrument/ExecutionContext.scala
@@ -1,6 +1,8 @@
 package org.enso.interpeter.instrument
 
-import org.enso.polyglot.runtime.Runtime.Api.ContextId
+import org.enso.polyglot.runtime.Runtime.Api.{ContextId, StackItem}
+
+import scala.collection.mutable.Stack
 
 /**
   * Represents an execution context.
@@ -13,20 +15,22 @@ case class ExecutionContext(id: ContextId)
   * Storage for active execution contexts.
   */
 class ExecutionContextManager {
-  private var contexts: List[ExecutionContext] = List()
+  private var contexts: Map[ExecutionContext, Stack[StackItem]] = Map()
 
   /**
     * Creates a new context with a given id.
     *
     * @param id the context id.
     */
-  def create(id: ContextId): Unit = contexts ::= ExecutionContext(id)
+  def create(id: ContextId): Unit =
+    contexts += ExecutionContext(id) -> Stack.empty
 
   /**
     * Destroys a context with a given id.
     * @param id the context id.
     */
-  def destroy(id: ContextId): Unit = contexts = contexts.filter(_.id != id)
+  def destroy(id: ContextId): Unit =
+    contexts -= ExecutionContext(id)
 
   /**
     * Gets a context with a given id.
@@ -34,5 +38,30 @@ class ExecutionContextManager {
     * @param id the context id.
     * @return the context with the given id, if exists.
     */
-  def get(id: ContextId): Option[ExecutionContext] = contexts.find(_.id == id)
+  def get(id: ContextId): Option[ExecutionContext] =
+    for {
+      _ <- contexts.get(ExecutionContext(id))
+    } yield ExecutionContext(id)
+
+  /**
+    * If the context exists, push the item on the stack.
+    *
+    * @param id the context id.
+    * @param item stack item.
+    */
+  def push(id: ContextId, item: StackItem): Unit =
+    for {
+      stack <- contexts.get(ExecutionContext(id))
+    } stack.push(item)
+
+  /**
+    * If the context exists, and stack not empty, pop the item from the stack.
+    *
+    * @param id the context id.
+    */
+  def pop(id: ContextId): Unit =
+    for {
+      stack <- contexts.get(ExecutionContext(id))
+      if stack.nonEmpty
+    } stack.pop()
 }

--- a/engine/runtime/src/main/scala/org/enso/interpeter/instrument/ExecutionContext.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpeter/instrument/ExecutionContext.scala
@@ -55,7 +55,7 @@ class ExecutionContextManager {
     } stack.push(item)
 
   /**
-    * If the context exists, and stack not empty, pop the item from the stack.
+    * If the context exists and stack not empty, pop the item from the stack.
     *
     * @param id the context id.
     */

--- a/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
@@ -72,5 +72,29 @@ class Handler {
         )
       }
 
+    case Api.Request(requestId, Api.PushContextRequest(contextId, item)) =>
+      if (contextManager.get(contextId).isDefined) {
+        contextManager.push(contextId, item)
+        endpoint.sendToClient(
+          Api.Response(requestId, Api.PushContextResponse(contextId))
+        )
+      } else {
+        endpoint.sendToClient(
+          Api.Response(requestId, Api.ContextNotExistError(contextId))
+        )
+      }
+
+    case Api.Request(requestId, Api.PopContextRequest(contextId)) =>
+      if (contextManager.get(contextId).isDefined) {
+        contextManager.pop(contextId)
+        endpoint.sendToClient(
+          Api.Response(requestId, Api.PopContextResponse(contextId))
+        )
+      } else {
+        endpoint.sendToClient(
+          Api.Response(requestId, Api.ContextNotExistError(contextId))
+        )
+      }
+
   }
 }

--- a/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
@@ -72,24 +72,21 @@ class Handler {
         )
       }
 
-    case Api.Request(requestId, Api.PushContextRequest(contextId, item)) =>
-      if (contextManager.get(contextId).isDefined) {
-        contextManager.push(contextId, item)
-        endpoint.sendToClient(
-          Api.Response(requestId, Api.PushContextResponse(contextId))
-        )
-      } else {
-        endpoint.sendToClient(
-          Api.Response(requestId, Api.ContextNotExistError(contextId))
-        )
+    case Api.Request(requestId, Api.PushContextRequest(contextId, item)) => {
+      val payload = contextManager.push(contextId, item) match {
+        case Some(()) => Api.PushContextResponse(contextId)
+        case None     => Api.ContextNotExistError(contextId)
       }
+      endpoint.sendToClient(Api.Response(requestId, payload))
+    }
 
     case Api.Request(requestId, Api.PopContextRequest(contextId)) =>
       if (contextManager.get(contextId).isDefined) {
-        contextManager.pop(contextId)
-        endpoint.sendToClient(
-          Api.Response(requestId, Api.PopContextResponse(contextId))
-        )
+        val payload = contextManager.pop(contextId) match {
+          case Some(_) => Api.PopContextResponse(contextId)
+          case None    => Api.EmptyStackError(contextId)
+        }
+        endpoint.sendToClient(Api.Response(requestId, payload))
       } else {
         endpoint.sendToClient(
           Api.Response(requestId, Api.ContextNotExistError(contextId))

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ContextManagementTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ContextManagementTest.scala
@@ -81,4 +81,44 @@ class ContextManagementTest
       Api.Response(requestId2, Api.ContextNotExistError(contextId2))
     )
   }
+
+  "Runtime server" should "push and pop the context stack" in {
+    val contextId    = UUID.randomUUID()
+    val expressionId = UUID.randomUUID()
+    val requestId1   = UUID.randomUUID()
+    val requestId2   = UUID.randomUUID()
+    val requestId3   = UUID.randomUUID()
+    send(Api.Request(requestId1, Api.CreateContextRequest(contextId)))
+    receive shouldEqual Some(
+      Api.Response(requestId1, Api.CreateContextResponse(contextId))
+    )
+    send(
+      Api.Request(
+        requestId2,
+        Api.PushContextRequest(contextId, Api.StackItem.LocalCall(expressionId))
+      )
+    )
+    receive shouldEqual Some(
+      Api.Response(requestId2, Api.PushContextResponse(contextId))
+    )
+    send(Api.Request(requestId3, Api.PopContextRequest(contextId)))
+    receive shouldEqual Some(
+      Api.Response(requestId3, Api.PopContextResponse(contextId))
+    )
+  }
+
+  "Runtime server" should "fail pushing context stack if it doesn't exist" in {
+    val contextId    = UUID.randomUUID()
+    val expressionId = UUID.randomUUID()
+    val requestId    = UUID.randomUUID()
+    send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(contextId, Api.StackItem.LocalCall(expressionId))
+      )
+    )
+    receive shouldEqual Some(
+      Api.Response(requestId, Api.ContextNotExistError(contextId))
+    )
+  }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ContextManagementTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ContextManagementTest.scala
@@ -121,4 +121,18 @@ class ContextManagementTest
       Api.Response(requestId, Api.ContextNotExistError(contextId))
     )
   }
+
+  "Runtime server" should "fail popping empty stack" in {
+    val contextId  = UUID.randomUUID()
+    val requestId1 = UUID.randomUUID()
+    val requestId2 = UUID.randomUUID()
+    send(Api.Request(requestId1, Api.CreateContextRequest(contextId)))
+    receive shouldEqual Some(
+      Api.Response(requestId1, Api.CreateContextResponse(contextId))
+    )
+    send(Api.Request(requestId2, Api.PopContextRequest(contextId)))
+    receive shouldEqual Some(
+      Api.Response(requestId2, Api.EmptyStackError(contextId))
+    )
+  }
 }


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

closes: #588 
closes: #592

Changelog:

- add: executionContext/push
- add: executionContext/pop
- add: corresponding Push&Pop messages to runtime API
- add: support of the stack operations to the runtime `ExecutionContextManager`

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

Protocol extended with `EmptyStackError`, returned when popping an empty stack.

``` typescript
"error" : {
  "code" : 2003,
  "message" : "Stack is empty"
}
```

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
