### PR TITLE
Language Execution Service

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeConnector.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeConnector.scala
@@ -42,8 +42,10 @@ class RuntimeConnector
       engine.sendBinary(Runtime.Api.serialize(msg))
       context.become(initialized(engine, senders + (msg.requestId -> sender())))
     case msg: Runtime.Api.Response =>
-      senders.get(msg.correlationId).foreach(_ ! msg)
-      context.become(initialized(engine, senders - msg.correlationId))
+      msg.correlationId.flatMap(senders.get).foreach(_ ! msg)
+      msg.correlationId.foreach { correlationId =>
+        context.become(initialized(engine, senders - correlationId))
+      }
   }
 }
 

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -40,17 +40,26 @@ object Runtime {
       new JsonSubTypes.Type(
         value = classOf[Api.ContextNotExistError],
         name  = "contextNotExistError"
+      ),
+      new JsonSubTypes.Type(value = classOf[Api.Execute], name = "execute"),
+      new JsonSubTypes.Type(
+        value = classOf[Api.InitializedNotification],
+        name  = "initializedNotification"
+      ),
+      new JsonSubTypes.Type(
+        value = classOf[Api.ExpressionValueUpdateNotification],
+        name  = "expressionValueUpdateNotification"
       )
     )
   )
   sealed trait Api
-  sealed trait ApiRequest extends Api
+  sealed trait ApiRequest  extends Api
   sealed trait ApiResponse extends Api
 
   object Api {
-
-    type ContextId = UUID
-    type RequestId = UUID
+    type ContextId    = UUID
+    type RequestId    = UUID
+    type ExpressionId = UUID
 
     /**
       * Indicates error response.
@@ -71,7 +80,29 @@ object Runtime {
       * @param correlationId request that initiated the response
       * @param payload response
       */
-    case class Response(correlationId: RequestId, payload: ApiResponse)
+    case class Response(correlationId: Option[RequestId], payload: ApiResponse)
+
+    object Response {
+
+      /**
+        * A smart constructor for [[Response]].
+        *
+        * @param correlationId the request id triggering this response.
+        * @param payload the response payload.
+        * @return a response object with specified correlation id and payload.
+        */
+      def apply(correlationId: RequestId, payload: ApiResponse): Response =
+        Response(Some(correlationId), payload)
+
+      /**
+        * A smart constructor for [[Response]] that was not triggered by
+        * any request (i.e. a notification).
+        *
+        * @param payload the data carried by the response.
+        * @return a response without a correlation id and specified payload.
+        */
+      def apply(payload: ApiResponse): Response = Response(None, payload)
+    }
 
     /**
       * A Request sent from the client to the runtime server, to create a new
@@ -101,7 +132,6 @@ object Runtime {
       * [[DestroyContextRequest]]
       *
       * @param contextId the destroyed context's id
-      * @param error optional error
       */
     case class DestroyContextResponse(contextId: ContextId) extends ApiResponse
 
@@ -110,9 +140,48 @@ object Runtime {
       */
     case class ContextNotExistError(contextId: ContextId) extends Error
 
+    /**
+      * Notification sent from the server to the client upon successful
+      * initialization. Any messages sent to the server before receiving this
+      * message will be dropped.
+      */
+    case class InitializedNotification() extends ApiResponse
+
+    /**
+      * An execution request for a given method.
+      * Note that this is a temporary message, only used to test functionality.
+      * To be replaced with actual execution stack API.
+      *
+      * @param modName the module to look for the method.
+      * @param consName the constructor the method is defined on.
+      * @param funName the method name.
+      * @param enterExprs the expressions that should be "entered" after
+      *                   executing the base method.
+      */
+    case class Execute(
+      modName: String,
+      consName: String,
+      funName: String,
+      enterExprs: List[ExpressionId]
+    ) extends ApiRequest
+
+    /**
+      * A notification sent from the server whenever an expression value
+      * becomes available.
+      * Note this is a temporary message, only used to test functionality.
+      * To be replaced with actual value computed notifications.
+      *
+      * @param expressionId the id of computed expression.
+      * @param shortValue the string representation of the expression's value.
+      */
+    case class ExpressionValueUpdateNotification(
+      expressionId: ExpressionId,
+      shortValue: String
+    ) extends ApiResponse
+
     private lazy val mapper = {
       val factory = new CBORFactory()
-      val mapper = new ObjectMapper(factory) with ScalaObjectMapper
+      val mapper  = new ObjectMapper(factory) with ScalaObjectMapper
       mapper.registerModule(DefaultScalaModule)
     }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
@@ -1,0 +1,207 @@
+package org.enso.interpreter.instrument;
+
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.frame.FrameInstance;
+import com.oracle.truffle.api.frame.FrameInstanceVisitor;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.*;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.node.ExpressionNode;
+import org.enso.interpreter.node.callable.FunctionCallInstrumentationNode;
+import org.enso.interpreter.runtime.tag.IdentifiedTag;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/** An instrument for getting values from AST-identified expressions. */
+@TruffleInstrument.Registration(
+    id = IdExecutionInstrument.INSTRUMENT_ID,
+    services = IdExecutionInstrument.class)
+public class IdExecutionInstrument extends TruffleInstrument {
+  public static final String INSTRUMENT_ID = "id-value-extractor";
+
+  private Env env;
+
+  /**
+   * Initializes the instrument. Substitute for a constructor, called by the Truffle framework.
+   *
+   * @param env the instrumentation environment
+   */
+  @Override
+  protected void onCreate(Env env) {
+    env.registerService(this);
+    this.env = env;
+  }
+
+  /** A value class for notifications about functions being called in the course of execution. */
+  public static class ExpressionCall {
+    private UUID expressionId;
+    private FunctionCallInstrumentationNode.FunctionCall call;
+
+    /**
+     * Creates an instance of this class.
+     *
+     * @param expressionId the expression id where function call was performed.
+     * @param call the actual function call data.
+     */
+    public ExpressionCall(UUID expressionId, FunctionCallInstrumentationNode.FunctionCall call) {
+      this.expressionId = expressionId;
+      this.call = call;
+    }
+
+    /** @return the id of the node performing the function call. */
+    public UUID getExpressionId() {
+      return expressionId;
+    }
+
+    /** @return the function call metadata. */
+    public FunctionCallInstrumentationNode.FunctionCall getCall() {
+      return call;
+    }
+  }
+
+  /** A value class for notifications about identified expressions' values being computed. */
+  public static class ExpressionValue {
+    private UUID expressionId;
+    private Object value;
+
+    /**
+     * Creates a new instance of this class.
+     *
+     * @param expressionId the id of the expression being computed.
+     * @param value the value returned by computing the expression.
+     */
+    public ExpressionValue(UUID expressionId, Object value) {
+      this.expressionId = expressionId;
+      this.value = value;
+    }
+
+    /** @return the id of the expression computed. */
+    public UUID getExpressionId() {
+      return expressionId;
+    }
+
+    /** @return the computed value of the expression. */
+    public Object getValue() {
+      return value;
+    }
+  }
+
+  /**
+   * Attach a new listener to observe identified nodes within given function.
+   *
+   * @param entryCallTarget the call target being observed.
+   * @param funSourceStart the source start of the observed range of ids.
+   * @param funSourceLength the length of the observed source range.
+   * @param valueCallback the consumer of the node value events.
+   * @param functionCallCallback the consumer of function call events.
+   * @return a reference to the attached event listener.
+   */
+  public EventBinding<ExecutionEventListener> bind(
+      CallTarget entryCallTarget,
+      int funSourceStart,
+      int funSourceLength,
+      Consumer<ExpressionValue> valueCallback,
+      Consumer<ExpressionCall> functionCallCallback) {
+    SourceSectionFilter filter =
+        SourceSectionFilter.newBuilder()
+            .tagIs(StandardTags.ExpressionTag.class, StandardTags.CallTag.class)
+            .tagIs(IdentifiedTag.class)
+            .indexIn(funSourceStart, funSourceLength)
+            .build();
+
+    EventBinding<ExecutionEventListener> binding =
+        env.getInstrumenter()
+            .attachExecutionEventListener(
+                filter,
+                new IdExecutionEventListener(entryCallTarget, functionCallCallback, valueCallback));
+    return binding;
+  }
+
+  /** The listener class used by this instrument. */
+  private static class IdExecutionEventListener implements ExecutionEventListener {
+    private final CallTarget entryCallTarget;
+    private final Consumer<ExpressionCall> functionCallCallback;
+    private final Consumer<ExpressionValue> valueCallback;
+
+    /**
+     * Creates a new listener.
+     *
+     * @param entryCallTarget the call target being observed.
+     * @param functionCallCallback the consumer of function call events.
+     * @param valueCallback the consumer of the node value events.
+     */
+    public IdExecutionEventListener(
+        CallTarget entryCallTarget,
+        Consumer<ExpressionCall> functionCallCallback,
+        Consumer<ExpressionValue> valueCallback) {
+      this.entryCallTarget = entryCallTarget;
+      this.functionCallCallback = functionCallCallback;
+      this.valueCallback = valueCallback;
+    }
+
+    @Override
+    public void onEnter(EventContext context, VirtualFrame frame) {}
+
+    /**
+     * Triggered when a node (either a function call sentry or an identified expression) finishes
+     * execution.
+     *
+     * @param context the event context.
+     * @param frame the current execution frame.
+     * @param result the result of executing the node this method was triggered for.
+     */
+    @Override
+    public void onReturnValue(EventContext context, VirtualFrame frame, Object result) {
+      if (!isTopFrame(entryCallTarget)) {
+        return;
+      }
+      Node node = context.getInstrumentedNode();
+      if (node instanceof FunctionCallInstrumentationNode
+          && result instanceof FunctionCallInstrumentationNode.FunctionCall) {
+        functionCallCallback.accept(
+            new ExpressionCall(
+                ((FunctionCallInstrumentationNode) node).getId(),
+                (FunctionCallInstrumentationNode.FunctionCall) result));
+      } else if (node instanceof ExpressionNode) {
+        valueCallback.accept(
+            new ExpressionValue(((ExpressionNode) context.getInstrumentedNode()).getId(), result));
+      }
+    }
+
+    @Override
+    public void onReturnExceptional(
+        EventContext context, VirtualFrame frame, Throwable exception) {}
+
+    /**
+     * Checks if we're not inside a recursive call, i.e. the {@link #entryCallTarget} only appears
+     * in the stack trace once.
+     *
+     * @return {@code true} if it's not a recursive call, {@code false} otherwise.
+     */
+    private boolean isTopFrame(CallTarget entryCallTarget) {
+      Object result =
+          Truffle.getRuntime()
+              .iterateFrames(
+                  new FrameInstanceVisitor<Object>() {
+                    boolean seenFirst = false;
+
+                    @Override
+                    public Object visitFrame(FrameInstance frameInstance) {
+                      CallTarget ct = frameInstance.getCallTarget();
+                      if (ct != entryCallTarget) {
+                        return null;
+                      }
+                      if (seenFirst) {
+                        return new Object();
+                      } else {
+                        seenFirst = true;
+                        return null;
+                      }
+                    }
+                  });
+      return result == null;
+    }
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/ApplicationNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/ApplicationNode.java
@@ -5,6 +5,8 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import java.util.Arrays;
+import java.util.UUID;
+
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.callable.argument.CallArgument;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
@@ -99,5 +101,16 @@ public class ApplicationNode extends ExpressionNode {
             this.callable.executeGeneric(frame), frame, state, evaluateArguments(frame));
     frame.setObject(getStateFrameSlot(), result.getState());
     return result.getValue();
+  }
+
+  /**
+   * Sets the expression ID for this node.
+   *
+   * @param id the ID for this node.
+   */
+  @Override
+  public void setId(UUID id) {
+    super.setId(id);
+    invokeCallableNode.setId(id);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/FunctionCallInstrumentationNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/FunctionCallInstrumentationNode.java
@@ -17,6 +17,9 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.source.SourceSection;
 import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.tag.IdentifiedTag;
+
+import java.util.UUID;
 
 /**
  * A node used for instrumenting function calls. It does nothing useful from the language
@@ -25,6 +28,7 @@ import org.enso.interpreter.runtime.callable.function.Function;
 @GenerateWrapper
 @NodeInfo(description = "A node used for instrumenting function calls.")
 public class FunctionCallInstrumentationNode extends Node implements InstrumentableNode {
+  private UUID id;
 
   FunctionCallInstrumentationNode() {}
 
@@ -54,7 +58,14 @@ public class FunctionCallInstrumentationNode extends Node implements Instrumenta
     private final Object state;
     private final @CompilerDirectives.CompilationFinal(dimensions = 1) Object[] arguments;
 
-    private FunctionCall(Function function, Object state, Object[] arguments) {
+    /**
+     * Creates an instance of this class.
+     *
+     * @param function the function being called.
+     * @param state the monadic state to pass to the function.
+     * @param arguments the arguments passed to the function.
+     */
+    public FunctionCall(Function function, Object state, Object[] arguments) {
       this.function = function;
       this.state = state;
       this.arguments = arguments;
@@ -127,14 +138,14 @@ public class FunctionCallInstrumentationNode extends Node implements Instrumenta
   }
 
   /**
-   * Makrs this node as carrying the {@link StandardTags.CallTag} tag.
+   * Makrs this node with relevant runtime tags.
    *
    * @param tag the tag to check agains.
-   * @return true if the tag is {@link StandardTags.CallTag}, false otherwise.
+   * @return true if the node carries the {@code tag}, false otherwise.
    */
   @Override
   public boolean hasTag(Class<? extends Tag> tag) {
-    return tag == StandardTags.CallTag.class;
+    return tag == StandardTags.CallTag.class || (tag == IdentifiedTag.class && id != null);
   }
 
   /** @return the source section of this node. */
@@ -142,5 +153,19 @@ public class FunctionCallInstrumentationNode extends Node implements Instrumenta
   public SourceSection getSourceSection() {
     Node parent = getParent();
     return parent == null ? null : parent.getSourceSection();
+  }
+
+  /** @return the expression ID of this node. */
+  public UUID getId() {
+    return id;
+  }
+
+  /**
+   * Sets the expression ID of this node.
+   *
+   * @param expressionId the ID to assign this node.
+   */
+  public void setId(UUID expressionId) {
+    this.id = expressionId;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
@@ -18,6 +18,8 @@ import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.error.NotInvokableException;
 import org.enso.interpreter.runtime.state.Stateful;
 
+import java.util.UUID;
+
 /**
  * This class is responsible for performing the actual invocation of a given callable with its
  * arguments.
@@ -219,5 +221,14 @@ public abstract class InvokeCallableNode extends BaseNode {
   public SourceSection getSourceSection() {
     Node parent = getParent();
     return parent == null ? null : parent.getSourceSection();
+  }
+
+  /**
+   * Sets the expression ID of this node.
+   *
+   * @param id the ID to assign this node.
+   */
+  public void setId(UUID id) {
+    invokeFunctionNode.setId(id);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/InvokeFunctionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/InvokeFunctionNode.java
@@ -20,6 +20,8 @@ import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.callable.function.FunctionSchema;
 import org.enso.interpreter.runtime.state.Stateful;
 
+import java.util.UUID;
+
 /**
  * This class represents the protocol for remapping the arguments provided at a call site into the
  * positional order expected by the definition of the {@link Function}.
@@ -157,5 +159,14 @@ public abstract class InvokeFunctionNode extends BaseNode {
   public SourceSection getSourceSection() {
     Node parent = getParent();
     return parent == null ? null : parent.getSourceSection();
+  }
+
+  /**
+   * Sets the expression ID of this node.
+   *
+   * @param id the expression ID to assign this node.
+   */
+  public void setId(UUID id) {
+    functionCallInstrumentationNode.setId(id);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
@@ -16,6 +16,7 @@ import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.RootNode;
+import com.oracle.truffle.api.source.SourceSection;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.node.callable.InteropApplicationNode;
 import org.enso.interpreter.node.callable.dispatch.InvokeFunctionNode;
@@ -115,6 +116,16 @@ public final class Function implements TruffleObject {
    */
   public RootCallTarget getCallTarget() {
     return callTarget;
+  }
+
+  /** @return the name of this function. */
+  public String getName() {
+    return getCallTarget().getRootNode().getName();
+  }
+
+  /** @return the source section this function was defined in. */
+  public SourceSection getSourceSection() {
+    return getCallTarget().getRootNode().getSourceSection();
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -1,0 +1,116 @@
+package org.enso.interpreter.service;
+
+import com.oracle.truffle.api.instrumentation.EventBinding;
+import com.oracle.truffle.api.instrumentation.ExecutionEventListener;
+import com.oracle.truffle.api.interop.ArityException;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.interop.UnsupportedTypeException;
+import com.oracle.truffle.api.source.SourceSection;
+import org.enso.interpreter.instrument.IdExecutionInstrument;
+import org.enso.interpreter.node.callable.FunctionCallInstrumentationNode;
+import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.Module;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.scope.ModuleScope;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * A service allowing externally-triggered code execution, registered by an instance of the
+ * language.
+ */
+public class ExecutionService {
+  private final Context context;
+  private final IdExecutionInstrument idExecutionInstrument;
+  private InteropLibrary interopLibrary = InteropLibrary.getFactory().getUncached();
+
+  /**
+   * Creates a new instance of this service.
+   *
+   * @param context the language context to use.
+   * @param idExecutionInstrument an instance of the {@link IdExecutionInstrument} to use in the
+   *     course of executions.
+   */
+  public ExecutionService(Context context, IdExecutionInstrument idExecutionInstrument) {
+    this.idExecutionInstrument = idExecutionInstrument;
+    this.context = context;
+  }
+
+  private Optional<FunctionCallInstrumentationNode.FunctionCall> prepareFunctionCall(
+      String moduleName, String consName, String methodName) {
+    Optional<Module> moduleMay = context.compiler().topScope().getModule(moduleName);
+    if (!moduleMay.isPresent()) {
+      return Optional.empty();
+    }
+    ModuleScope scope = moduleMay.get().getScope(context);
+    Optional<AtomConstructor> atomConstructorMay = scope.getConstructor(consName);
+    if (!atomConstructorMay.isPresent()) {
+      return Optional.empty();
+    }
+    AtomConstructor atomConstructor = atomConstructorMay.get();
+    Function function = scope.lookupMethodDefinition(atomConstructor, methodName);
+    if (function == null) {
+      return Optional.empty();
+    }
+    FunctionCallInstrumentationNode.FunctionCall call =
+        new FunctionCallInstrumentationNode.FunctionCall(
+            function, context.getBuiltins().unit(), new Object[] {atomConstructor.newInstance()});
+    return Optional.of(call);
+  }
+
+  /**
+   * Executes a function with given arguments, represented as runtime language-level objects.
+   *
+   * @param call the call metadata.
+   * @param valueCallback the consumer for expression value events.
+   * @param funCallCallback the consumer for function call events.
+   */
+  public void execute(
+      FunctionCallInstrumentationNode.FunctionCall call,
+      Consumer<IdExecutionInstrument.ExpressionValue> valueCallback,
+      Consumer<IdExecutionInstrument.ExpressionCall> funCallCallback)
+      throws UnsupportedMessageException, ArityException, UnsupportedTypeException {
+
+    SourceSection src = call.getFunction().getSourceSection();
+    if (src == null) {
+      return;
+    }
+    EventBinding<ExecutionEventListener> listener =
+        idExecutionInstrument.bind(
+            call.getFunction().getCallTarget(),
+            src.getCharIndex(),
+            src.getCharLength(),
+            valueCallback,
+            funCallCallback);
+    interopLibrary.execute(call);
+    listener.dispose();
+  }
+
+  /**
+   * Executes a method described by its name, constructor it's defined on and the module it's
+   * defined in.
+   *
+   * @param moduleName the qualified name of the module the method is defined in.
+   * @param consName the name of the constructor the method is defined on.
+   * @param methodName the method name.
+   * @param valueCallback the consumer for expression value events.
+   * @param funCallCallback the consumer for function call events.
+   */
+  public void execute(
+      String moduleName,
+      String consName,
+      String methodName,
+      Consumer<IdExecutionInstrument.ExpressionValue> valueCallback,
+      Consumer<IdExecutionInstrument.ExpressionCall> funCallCallback)
+      throws UnsupportedMessageException, ArityException, UnsupportedTypeException {
+    Optional<FunctionCallInstrumentationNode.FunctionCall> callMay =
+        prepareFunctionCall(moduleName, consName, methodName);
+    if (!callMay.isPresent()) {
+      return;
+    }
+    execute(callMay.get(), valueCallback, funCallCallback);
+  }
+}

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -212,7 +212,7 @@ class Compiler(
     source: Source,
     scope: ModuleScope
   ): Unit = {
-    new IRToTruffle(language, source, scope).run(ir)
+    new IRToTruffle(context, source, scope).run(ir)
   }
 
   /** Generates code for the truffle interpreter in an inline context.
@@ -229,7 +229,7 @@ class Compiler(
     inlineContext: InlineContext
   ): RuntimeExpression = {
     new IRToTruffle(
-      this.language,
+      context,
       source,
       inlineContext.moduleScope.getOrElse(
         throw new CompilerError(

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IRToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IRToTruffle.scala
@@ -63,16 +63,18 @@ import scala.jdk.OptionConverters._
   * It should be noted that, as is, there is no support for cross-module links,
   * with each lowering pass operating solely on a single module.
   *
-  * @param language the language instance for which this is executing
+  * @param context the language context instance for which this is executing
   * @param source the source code that corresponds to the text for which code
   *               is being generated
   * @param moduleScope the scope of the module for which code is being generated
   */
 class IRToTruffle(
-  val language: Language,
+  val context: Context,
   val source: Source,
   val moduleScope: ModuleScope
 ) {
+
+  val language: Language = context.getLanguage
 
   // ==========================================================================
   // === Top-Level Runners ====================================================
@@ -120,8 +122,6 @@ class IRToTruffle(
     * @param module the module for which code should be generated
     */
   private def processModule(module: IR.Module): Unit = {
-    val context: Context = language.getCurrentContext
-
     val imports = module.imports
     val atomDefs = module.bindings.collect {
       case atom: IR.Module.Scope.Definition.Atom => atom

--- a/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
@@ -1,7 +1,17 @@
 package org.enso.interpeter.instrument
 
 import java.nio.ByteBuffer
+import java.util.UUID
+import java.util.function.Consumer
 
+import com.oracle.truffle.api.TruffleContext
+import com.oracle.truffle.api.instrumentation.TruffleInstrument
+import org.enso.interpreter.instrument.IdExecutionInstrument.{
+  ExpressionCall,
+  ExpressionValue
+}
+import org.enso.interpreter.node.callable.FunctionCallInstrumentationNode.FunctionCall
+import org.enso.interpreter.service.ExecutionService
 import org.enso.polyglot.runtime.Runtime.Api
 import org.graalvm.polyglot.io.MessageEndpoint
 
@@ -21,7 +31,7 @@ class Endpoint(handler: Handler) extends MessageEndpoint {
   def setClient(ep: MessageEndpoint): Unit = client = ep
 
   /**
-    * Sends a message to the connected client.
+    * Sends a response to the connected client.
     *
     * @param msg the message to send.
     */
@@ -48,6 +58,87 @@ class Handler {
   val endpoint       = new Endpoint(this)
   val contextManager = new ExecutionContextManager
 
+  var executionService: ExecutionService = _
+  var truffleContext: TruffleContext     = _
+
+  /**
+    * Initializes the handler with relevant Truffle objects, allowing it to
+    * perform code execution.
+    *
+    * @param service the language execution service instance.
+    * @param context the current Truffle context.
+    */
+  def initializeExecutionService(
+    service: ExecutionService,
+    context: TruffleContext
+  ): Unit = {
+    executionService = service
+    truffleContext   = context
+    endpoint.sendToClient(Api.Response(Api.InitializedNotification()))
+  }
+
+  sealed private trait ExecutionItem
+
+  private case class MethodExecution(
+    module: String,
+    constructor: String,
+    function: String
+  ) extends ExecutionItem
+
+  private case class CallDataExecution(callData: FunctionCall)
+      extends ExecutionItem
+
+  private def sendVal(res: ExpressionValue): Unit = {
+    endpoint.sendToClient(
+      Api.Response(
+        Api.ExpressionValueUpdateNotification(
+          res.getExpressionId,
+          res.getValue.toString
+        )
+      )
+    )
+  }
+
+  private def execute(
+    executionItem: ExecutionItem,
+    furtherStack: List[UUID]
+  ): Unit = {
+    var enterables: Map[UUID, FunctionCall] = Map()
+    val valsCallback: Consumer[ExpressionValue] =
+      if (furtherStack.isEmpty) sendVal else _ => ()
+    val callablesCallback: Consumer[ExpressionCall] = fun =>
+      enterables += fun.getExpressionId -> fun.getCall
+    executionItem match {
+      case MethodExecution(module, cons, function) =>
+        executionService.execute(
+          module,
+          cons,
+          function,
+          valsCallback,
+          callablesCallback
+        )
+      case CallDataExecution(callData) =>
+        executionService.execute(callData, valsCallback, callablesCallback)
+    }
+
+    furtherStack match {
+      case Nil => ()
+      case item :: tail =>
+        enterables
+          .get(item)
+          .foreach(call => execute(CallDataExecution(call), tail))
+    }
+  }
+
+  private def withContext(action: => Unit): Unit = {
+    val token = truffleContext.enter()
+    try {
+      action
+    } finally {
+      truffleContext.leave(token)
+    }
+  }
+
   /**
     * Handles a message received from the client.
     *
@@ -71,6 +162,9 @@ class Handler {
           Api.Response(requestId, Api.ContextNotExistError(contextId))
         )
       }
+
+    case Api.Request(_, Api.Execute(mod, cons, fun, furtherStack)) =>
+      withContext(execute(MethodExecution(mod, cons, fun), furtherStack))
 
   }
 }

--- a/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
@@ -79,15 +79,15 @@ class Handler {
 
   sealed private trait ExecutionItem
 
-  private case class MethodExecution(
-    module: String,
-    constructor: String,
-    function: String
-  ) extends ExecutionItem
+  private object ExecutionItem {
+    case class Method(
+      module: String,
+      constructor: String,
+      function: String
+    ) extends ExecutionItem
 
-  private case class CallDataExecution(callData: FunctionCall)
-      extends ExecutionItem
-
+    case class CallData(callData: FunctionCall) extends ExecutionItem
+  }
   private def sendVal(res: ExpressionValue): Unit = {
     endpoint.sendToClient(
       Api.Response(
@@ -109,7 +109,7 @@ class Handler {
     val callablesCallback: Consumer[ExpressionCall] = fun =>
       enterables += fun.getExpressionId -> fun.getCall
     executionItem match {
-      case MethodExecution(module, cons, function) =>
+      case ExecutionItem.Method(module, cons, function) =>
         executionService.execute(
           module,
           cons,
@@ -117,7 +117,7 @@ class Handler {
           valsCallback,
           callablesCallback
         )
-      case CallDataExecution(callData) =>
+      case ExecutionItem.CallData(callData) =>
         executionService.execute(callData, valsCallback, callablesCallback)
     }
 
@@ -126,7 +126,7 @@ class Handler {
       case item :: tail =>
         enterables
           .get(item)
-          .foreach(call => execute(CallDataExecution(call), tail))
+          .foreach(call => execute(ExecutionItem.CallData(call), tail))
     }
   }
 
@@ -164,7 +164,7 @@ class Handler {
       }
 
     case Api.Request(_, Api.Execute(mod, cons, fun, furtherStack)) =>
-      withContext(execute(MethodExecution(mod, cons, fun), furtherStack))
+      withContext(execute(ExecutionItem.Method(mod, cons, fun), furtherStack))
 
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/Metadata.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/Metadata.scala
@@ -1,0 +1,41 @@
+package org.enso.interpreter.test
+
+import java.util.UUID
+
+private case class Item(start: Int, len: Int, id: UUID) {
+  def toJsonString: String =
+    s"""[{"index": {"value": $start}, "size": {"value": $len}}, "$id"]"""
+}
+
+/**
+  * A helper class for decorating source code with expression IDs.
+  */
+class Metadata {
+
+  private var items: List[Item] = List()
+
+  /**
+    * Adds another entry to this metadata container.
+    *
+    * @param start the start position of the entry.
+    * @param len the length of the entry.
+    * @return the new entry's id.
+    */
+  def addItem(start: Int, len: Int): UUID = {
+    val id = UUID.randomUUID();
+    items ::= Item(start, len, id)
+    id
+  }
+
+  private def toJsonString: String =
+    "[" + items.map(_.toJsonString).mkString(",") + "]"
+
+  /**
+    * Appends a serialized version of this at the end of a source code string.
+    *
+    * @param code the code to append metadata to.
+    * @return the code decorated with this metadata.
+    */
+  def appendToCode(code: String): String =
+    s"$code\n\n\n#### METADATA ####\n$toJsonString\n[]"
+}

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -1,0 +1,127 @@
+package org.enso.interpreter.test.instrument
+
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.file.Files
+import java.util.UUID
+
+import org.enso.interpreter.test.Metadata
+import org.enso.pkg.Package
+import org.enso.polyglot.runtime.Runtime.Api
+import org.enso.polyglot.{
+  LanguageInfo,
+  PolyglotContext,
+  RuntimeOptions,
+  RuntimeServerInfo
+}
+import org.graalvm.polyglot.Context
+import org.graalvm.polyglot.io.MessageEndpoint
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RuntimeServerTest
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterEach {
+
+  var context: TestContext = _
+
+  class TestContext(packageName: String) {
+    var endPoint: MessageEndpoint        = _
+    var messageQueue: List[Api.Response] = List()
+    val tmpDir: File                     = Files.createTempDirectory("enso-test-packages").toFile
+    val pkg: Package                     = Package.create(tmpDir, packageName)
+    val executionContext = new PolyglotContext(
+      Context
+        .newBuilder(LanguageInfo.ID)
+        .allowExperimentalOptions(true)
+        .allowAllAccess(true)
+        .option(RuntimeOptions.getPackagesPathOption, pkg.root.getAbsolutePath)
+        .option(RuntimeServerInfo.ENABLE_OPTION, "true")
+        .serverTransport { (uri, peer) =>
+          if (uri.toString == RuntimeServerInfo.URI) {
+            endPoint = peer
+            new MessageEndpoint {
+              override def sendText(text: String): Unit = {}
+
+              override def sendBinary(data: ByteBuffer): Unit =
+                messageQueue ++= Api.deserializeResponse(data)
+
+              override def sendPing(data: ByteBuffer): Unit = {}
+
+              override def sendPong(data: ByteBuffer): Unit = {}
+
+              override def sendClose(): Unit = {}
+            }
+          } else null
+        }
+        .build()
+    )
+    executionContext.context.initialize(LanguageInfo.ID)
+
+    def mkFile(name: String): File = new File(tmpDir, name)
+
+    def writeFile(name: String, contents: String): Unit = {
+      Files.write(mkFile(name).toPath, contents.getBytes): Unit
+    }
+
+    def writeMain(contents: String): Unit = {
+      Files.write(pkg.mainFile.toPath, contents.getBytes): Unit
+    }
+
+    def send(msg: Api.Request): Unit = endPoint.sendBinary(Api.serialize(msg))
+
+    def receive: Option[Api.Response] = {
+      val msg = messageQueue.headOption
+      messageQueue = messageQueue.drop(1)
+      msg
+    }
+  }
+
+  override protected def beforeEach(): Unit = {
+    context = new TestContext("Test")
+    val Some(Api.Response(_, Api.InitializedNotification())) = context.receive
+  }
+
+  "Runtime server" should "allow executing a stack of functions by entering them through call-sites" in {
+    val metadata = new Metadata
+    val idMainX  = metadata.addItem(14, 7)
+    val idMainY  = metadata.addItem(30, 7)
+    val idFooY   = metadata.addItem(85, 8)
+    val idFooZ   = metadata.addItem(102, 5)
+
+    context.writeMain(
+      metadata.appendToCode(
+        """
+          |main =
+          |    x = 1 + 5
+          |    y = x.foo 5
+          |    z = y + 5
+          |    z
+          |
+          |Number.foo = x ->
+          |    y = this + 3
+          |    z = y * x
+          |    z
+          |""".stripMargin
+      )
+    )
+    context.send(
+      Api.Request(
+        UUID.randomUUID(),
+        Api.Execute(
+          "Test.Main",
+          "Main",
+          "main",
+          List(idMainY)
+        )
+      )
+    )
+    val updates = Set(context.receive, context.receive)
+    updates shouldEqual Set(
+      Some(Api.Response(Api.ExpressionValueUpdateNotification(idFooY, "9"))),
+      Some(Api.Response(Api.ExpressionValueUpdateNotification(idFooZ, "45")))
+    )
+  }
+}

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ExpressionIdTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ExpressionIdTest.scala
@@ -1,34 +1,8 @@
 package org.enso.interpreter.test.semantic
 
-import java.util.UUID
-
-import org.enso.interpreter.node.callable.ApplicationNode
-import org.enso.interpreter.node.callable.function.CreateFunctionNode
-import org.enso.interpreter.node.callable.thunk.ForceNode
-import org.enso.interpreter.node.controlflow.MatchNode
-import org.enso.interpreter.node.expression.literal.IntegerLiteralNode
-import org.enso.interpreter.node.scope.{AssignmentNode, ReadLocalTargetNode}
-import org.enso.interpreter.test.InterpreterTest
+import org.enso.interpreter.test.{InterpreterTest, Metadata}
 
 class ExpressionIdTest extends InterpreterTest {
-  case class Item(start: Int, len: Int, id: UUID) {
-    def toJsonString: String =
-      s"""[{"index": {"value": $start}, "size": {"value": $len}}, "$id"]"""
-  }
-
-  class Metadata {
-    var items: List[Item] = List()
-    def addItem(start: Int, len: Int): UUID = {
-      val id = UUID.randomUUID();
-      items ::= Item(start, len, id)
-      id
-    }
-    def toJsonString: String =
-      "[" + items.map(_.toJsonString).mkString(",") + "]"
-    def appendToCode(code: String): String =
-      s"$code\n\n\n#### METADATA ####\n$toJsonString\n[]"
-  }
-
   "Ids" should "be correct in simple arithmetic expressions" in
   withIdsInstrumenter { instrumenter =>
     val code = "main = 2 + 45 * 20"


### PR DESCRIPTION
### Pull Request Description
Introduces a truffle-side language service capable of performing on-demand code execution.
Couples the service with watcher instruments, enabling entering functions through call sites.

### Important Notes
There's a bunch of test-only API messages, to be superseded by @4e6 's work on context stacks.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md), [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
