### PR TITLE
String concat and string conversion functions

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/MethodResolverNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/MethodResolverNode.java
@@ -74,6 +74,15 @@ public abstract class MethodResolverNode extends Node {
   }
 
   @Specialization(guards = "cachedSymbol == symbol")
+  Function resolveStringCached(
+          UnresolvedSymbol symbol,
+          String self,
+          @Cached("symbol") UnresolvedSymbol cachedSymbol,
+          @Cached("resolveMethodOnString(cachedSymbol)") Function function) {
+    return function;
+  }
+
+  @Specialization(guards = "cachedSymbol == symbol")
   Function resolveFunctionCached(
       UnresolvedSymbol symbol,
       Function self,
@@ -105,6 +114,11 @@ public abstract class MethodResolverNode extends Node {
   Function resolveMethodOnNumber(UnresolvedSymbol symbol) {
     return ensureMethodExists(
         symbol.resolveFor(getBuiltins().number(), getBuiltins().any()), "Number", symbol);
+  }
+
+  Function resolveMethodOnString(UnresolvedSymbol symbol) {
+    return ensureMethodExists(
+            symbol.resolveFor(getBuiltins().text(), getBuiltins().any()), "Text", symbol);
   }
 
   Function resolveMethodOnFunction(UnresolvedSymbol symbol) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/NumberBinaryOpMethod.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/NumberBinaryOpMethod.java
@@ -12,7 +12,7 @@ import org.enso.interpreter.runtime.type.TypesGen;
 
 @NodeInfo(shortName = "Number.BinOp", description = "An abstract class for binary ops on numbers.")
 public abstract class NumberBinaryOpMethod extends BuiltinRootNode {
-  private BranchProfile thatOpBadTypeProfile = BranchProfile.create();
+  private final BranchProfile thatOpBadTypeProfile = BranchProfile.create();
 
   /**
    * Constructs an instance of this node.

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
@@ -13,7 +13,7 @@ import org.enso.interpreter.runtime.error.TypeError;
 import org.enso.interpreter.runtime.state.Stateful;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-/** An implementation of the operator + for numbers. */
+/** An implementation of generic string conversion. */
 @NodeInfo(shortName = "Any.to_text", description = "Generic text conversion.")
 public class AnyToTextNode extends BuiltinRootNode {
   private AnyToTextNode(Language language) {
@@ -21,7 +21,7 @@ public class AnyToTextNode extends BuiltinRootNode {
   }
 
   /**
-   * Creates a two-argument function wrapping this node.
+   * Creates a function wrapping this node.
    *
    * @param language the current language instance
    * @return a function wrapping this node
@@ -33,6 +33,12 @@ public class AnyToTextNode extends BuiltinRootNode {
         new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE));
   }
 
+  /**
+   * Executes the node.
+   *
+   * @param frame current execution frame.
+   * @return the result of converting input into a string.
+   */
   @Override
   public Stateful execute(VirtualFrame frame) {
     Object thisArg = Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[0];

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
@@ -1,0 +1,57 @@
+package org.enso.interpreter.node.expression.builtin.text;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.profiles.BranchProfile;
+import org.enso.interpreter.Language;
+import org.enso.interpreter.node.expression.builtin.BuiltinRootNode;
+import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.callable.function.FunctionSchema.CallStrategy;
+import org.enso.interpreter.runtime.error.TypeError;
+import org.enso.interpreter.runtime.state.Stateful;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+/** An implementation of the operator + for numbers. */
+@NodeInfo(shortName = "Any.to_text", description = "Generic text conversion.")
+public class AnyToTextNode extends BuiltinRootNode {
+  private AnyToTextNode(Language language) {
+    super(language);
+  }
+
+  /**
+   * Creates a two-argument function wrapping this node.
+   *
+   * @param language the current language instance
+   * @return a function wrapping this node
+   */
+  public static Function makeFunction(Language language) {
+    return Function.fromBuiltinRootNode(
+        new AnyToTextNode(language),
+        CallStrategy.ALWAYS_DIRECT,
+        new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE));
+  }
+
+  @Override
+  public Stateful execute(VirtualFrame frame) {
+    Object thisArg = Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[0];
+    Object state = Function.ArgumentsHelper.getState(frame.getArguments());
+    return new Stateful(state, toText(thisArg));
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private String toText(Object txt) {
+    return txt.toString();
+  }
+
+  /**
+   * Returns a language-specific name for this node.
+   *
+   * @return the name of this node
+   */
+  @Override
+  public String getName() {
+    return "Any.to_text";
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/ConcatNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/ConcatNode.java
@@ -1,0 +1,66 @@
+package org.enso.interpreter.node.expression.builtin.text;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.profiles.BranchProfile;
+import org.enso.interpreter.Language;
+import org.enso.interpreter.node.expression.builtin.BuiltinRootNode;
+import org.enso.interpreter.node.expression.builtin.number.NumberBinaryOpMethod;
+import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.callable.function.FunctionSchema.CallStrategy;
+import org.enso.interpreter.runtime.error.TypeError;
+import org.enso.interpreter.runtime.state.Stateful;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+/** An implementation of the operator + for numbers. */
+@NodeInfo(shortName = "Text.+", description = "Text concatenation.")
+public class ConcatNode extends BuiltinRootNode {
+  private final BranchProfile thatOpBadTypeProfile = BranchProfile.create();
+
+  private ConcatNode(Language language) {
+    super(language);
+  }
+
+  /**
+   * Creates a two-argument function wrapping this node.
+   *
+   * @param language the current language instance
+   * @return a function wrapping this node
+   */
+  public static Function makeFunction(Language language) {
+    return Function.fromBuiltinRootNode(
+        new ConcatNode(language),
+        CallStrategy.ALWAYS_DIRECT,
+        new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE),
+        new ArgumentDefinition(1, "that", ArgumentDefinition.ExecutionMode.EXECUTE));
+  }
+
+  @Override
+  public Stateful execute(VirtualFrame frame) {
+
+    String thisArg =
+        TypesGen.asString(Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[0]);
+
+    Object thatArg = Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[1];
+
+    if (TypesGen.isString(thatArg)) {
+      Object state = Function.ArgumentsHelper.getState(frame.getArguments());
+
+      return new Stateful(state, thisArg + TypesGen.asString(thatArg));
+    } else {
+      thatOpBadTypeProfile.enter();
+      throw new TypeError("Unexpected type for `that` operand in " + getName(), this);
+    }
+  }
+
+  /**
+   * Returns a language-specific name for this node.
+   *
+   * @return the name of this node
+   */
+  @Override
+  public String getName() {
+    return "Text.+";
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/ConcatNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/ConcatNode.java
@@ -13,7 +13,7 @@ import org.enso.interpreter.runtime.error.TypeError;
 import org.enso.interpreter.runtime.state.Stateful;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-/** An implementation of the operator + for numbers. */
+/** An implementation of the operator + for strings. */
 @NodeInfo(shortName = "Text.+", description = "Text concatenation.")
 public class ConcatNode extends BuiltinRootNode {
   private final BranchProfile thatOpBadTypeProfile = BranchProfile.create();
@@ -36,14 +36,17 @@ public class ConcatNode extends BuiltinRootNode {
         new ArgumentDefinition(1, "that", ArgumentDefinition.ExecutionMode.EXECUTE));
   }
 
+  /**
+   * Executes the node.
+   *
+   * @param frame current execution frame.
+   * @return the result of concatenating the input strings.
+   */
   @Override
   public Stateful execute(VirtualFrame frame) {
-
     String thisArg =
         TypesGen.asString(Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[0]);
-
     Object thatArg = Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[1];
-
     if (TypesGen.isString(thatArg)) {
       Object state = Function.ArgumentsHelper.getState(frame.getArguments());
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Builtins.java
@@ -18,6 +18,7 @@ import org.enso.interpreter.node.expression.builtin.number.SubtractNode;
 import org.enso.interpreter.node.expression.builtin.state.GetStateNode;
 import org.enso.interpreter.node.expression.builtin.state.PutStateNode;
 import org.enso.interpreter.node.expression.builtin.state.RunStateNode;
+import org.enso.interpreter.node.expression.builtin.text.AnyToTextNode;
 import org.enso.interpreter.node.expression.builtin.text.ConcatNode;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
@@ -28,6 +29,7 @@ import org.enso.pkg.QualifiedName;
 public class Builtins {
   public static final String MODULE_NAME = "Builtins";
   public static final String STRING_CONCAT_METHOD = "+";
+  public static final String TO_TEXT_METHOD = "to_text";
 
   /** Container for method names needed outside this class. */
   public static class MethodNames {
@@ -109,6 +111,7 @@ public class Builtins {
     scope.registerMethod(function, "call", ExplicitCallFunctionNode.makeFunction(language));
 
     scope.registerMethod(text, STRING_CONCAT_METHOD, ConcatNode.makeFunction(language));
+    scope.registerMethod(any, TO_TEXT_METHOD, AnyToTextNode.makeFunction(language));
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Builtins.java
@@ -18,6 +18,7 @@ import org.enso.interpreter.node.expression.builtin.number.SubtractNode;
 import org.enso.interpreter.node.expression.builtin.state.GetStateNode;
 import org.enso.interpreter.node.expression.builtin.state.PutStateNode;
 import org.enso.interpreter.node.expression.builtin.state.RunStateNode;
+import org.enso.interpreter.node.expression.builtin.text.ConcatNode;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.scope.ModuleScope;
@@ -26,6 +27,7 @@ import org.enso.pkg.QualifiedName;
 /** Container class for static predefined atoms, methods, and their containing scope. */
 public class Builtins {
   public static final String MODULE_NAME = "Builtins";
+  public static final String STRING_CONCAT_METHOD = "+";
 
   /** Container for method names needed outside this class. */
   public static class MethodNames {
@@ -105,6 +107,8 @@ public class Builtins {
     scope.registerMethod(debug, "breakpoint", DebugBreakpointNode.makeFunction(language));
 
     scope.registerMethod(function, "call", ExplicitCallFunctionNode.makeFunction(language));
+
+    scope.registerMethod(text, STRING_CONCAT_METHOD, ConcatNode.makeFunction(language));
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Builtins.java
@@ -28,8 +28,6 @@ import org.enso.pkg.QualifiedName;
 /** Container class for static predefined atoms, methods, and their containing scope. */
 public class Builtins {
   public static final String MODULE_NAME = "Builtins";
-  public static final String STRING_CONCAT_METHOD = "+";
-  public static final String TO_TEXT_METHOD = "to_text";
 
   /** Container for method names needed outside this class. */
   public static class MethodNames {
@@ -110,8 +108,8 @@ public class Builtins {
 
     scope.registerMethod(function, "call", ExplicitCallFunctionNode.makeFunction(language));
 
-    scope.registerMethod(text, STRING_CONCAT_METHOD, ConcatNode.makeFunction(language));
-    scope.registerMethod(any, TO_TEXT_METHOD, AnyToTextNode.makeFunction(language));
+    scope.registerMethod(text, "+", ConcatNode.makeFunction(language));
+    scope.registerMethod(any, "to_text", AnyToTextNode.makeFunction(language));
   }
 
   /**

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIR.scala
@@ -290,7 +290,12 @@ object AstToIR {
               }.mkString, None)
               exprs match {
                 case Right(expr) :: rest =>
-                  nonExprsString :: expr :: consolidate(rest)
+                  nonExprsString :: Application.Prefix(
+                    Name.Literal(Builtins.TO_TEXT_METHOD, None),
+                    List(CallArgument.Specified(None, expr, None)),
+                    false,
+                    None
+                  ) :: consolidate(rest)
                 case _ => List(nonExprsString)
               }
             }

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIR.scala
@@ -5,7 +5,6 @@ import cats.implicits._
 import org.enso.compiler.core.IR._
 import org.enso.compiler.exception.UnhandledEntity
 import org.enso.interpreter.Constants
-import org.enso.interpreter.runtime.Builtins
 import org.enso.syntax.text.AST
 
 // FIXME [AA] All places where we currently throw a `RuntimeException` should
@@ -274,47 +273,8 @@ object AstToIR {
             Literal.Text(fullString, getIdentifiedLocation(literal))
           case AST.Literal.Text.Block.Fmt(_, _, _) =>
             throw new RuntimeException("Format strings not yet supported")
-          case AST.Literal.Text.Line.Fmt(segments) =>
-            val litSegs = segments.collect {
-              case AST.Literal.Text.Segment.Plain(str) => Left(str)
-              case AST.Literal.Text.Segment.Esc(code)  => Left(code.repr)
-              case AST.Literal.Text.Segment.Expr(Some(expr)) =>
-                Right(translateExpression(expr))
-            }
-            def consolidate(
-              segments: List[Either[String, Expression]]
-            ): List[Expression] = {
-              val (nonExprs, exprs) = segments.span(_.isLeft)
-              val nonExprsString = Literal.Text(nonExprs.collect {
-                case Left(str) => str
-              }.mkString, None)
-              exprs match {
-                case Right(expr) :: rest =>
-                  nonExprsString :: Application.Prefix(
-                    Name.Literal(Builtins.TO_TEXT_METHOD, None),
-                    List(CallArgument.Specified(None, expr, None)),
-                    false,
-                    None
-                  ) :: consolidate(rest)
-                case _ => List(nonExprsString)
-              }
-            }
-            val exprs = consolidate(litSegs)
-            exprs match {
-              case Nil => Literal.Text("", getIdentifiedLocation(literal))
-              case first :: rest =>
-                rest.foldLeft(first)((str, expr) =>
-                  Application.Prefix(
-                    Name.Literal(Builtins.STRING_CONCAT_METHOD, None),
-                    List(
-                      CallArgument.Specified(None, str, None),
-                      CallArgument.Specified(None, expr, None)
-                    ),
-                    false,
-                    None
-                  )
-                )
-            }
+          case AST.Literal.Text.Line.Fmt(_) =>
+            throw new RuntimeException("Format strings not yet supported")
           case _ =>
             throw new UnhandledEntity(literal.shape, "translateLiteral")
         }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
@@ -24,6 +24,20 @@ class TextTest extends InterpreterTest {
     consumeOut shouldEqual List("Hello, World!")
   }
 
+  "Interpolated literals" should "delegate to the `to_text` method on the expression result" in {
+    val code =
+      """
+        |type My_Type a
+        |
+        |My_Type.to_text = case this of
+        |    My_Type a -> 'SurpriseString::`a`'
+        |
+        |main = IO.println 'Hello, `My_Type 10`'
+        |""".stripMargin
+    eval(code)
+    consumeOut shouldEqual List("Hello, SurpriseString::10")
+  }
+
   "Block raw text literals" should "exist in the language" in {
     val code =
       s"""

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
@@ -13,29 +13,30 @@ class TextTest extends InterpreterTest {
     consumeOut shouldEqual List("hello world!")
   }
 
-  "Single line interpolated literals" should "exist in the language" in {
+  "String concatenation" should "exist in the language" in {
     val code =
       """
         |main =
-        |    w = "World"
-        |    IO.println 'Hello, `w`!'
+        |    h = "Hello, "
+        |    w = "World!"
+        |    IO.println h+w
         |""".stripMargin
     eval(code)
     consumeOut shouldEqual List("Hello, World!")
   }
 
-  "Interpolated literals" should "delegate to the `to_text` method on the expression result" in {
+  "Arbitrary structures" should "be auto-convertible to strings with the to_text method" in {
     val code =
       """
         |type My_Type a
         |
-        |My_Type.to_text = case this of
-        |    My_Type a -> 'SurpriseString::`a`'
-        |
-        |main = IO.println 'Hello, `My_Type 10`'
+        |main =
+        |    IO.println 5.to_text
+        |    IO.println (My_Type (My_Type 10)).to_text
+        |    IO.println "123".to_text
         |""".stripMargin
     eval(code)
-    consumeOut shouldEqual List("Hello, SurpriseString::10")
+    consumeOut shouldEqual List("5", "My_Type (My_Type 10)", "123")
   }
 
   "Block raw text literals" should "exist in the language" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
@@ -13,6 +13,17 @@ class TextTest extends InterpreterTest {
     consumeOut shouldEqual List("hello world!")
   }
 
+  "Single line interpolated literals" should "exist in the language" in {
+    val code =
+      """
+        |main =
+        |    w = "World"
+        |    IO.println 'Hello, `w`!'
+        |""".stripMargin
+    eval(code)
+    consumeOut shouldEqual List("Hello, World!")
+  }
+
   "Block raw text literals" should "exist in the language" in {
     val code =
       s"""


### PR DESCRIPTION
### Pull Request Description
Introduces 2 simple methods to the enso standard library. The only feasible part of the failed interpolated strings effort.

### Important Notes
Allows to call methods on strings, which was previously impossible.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/style-guides/scala.md), [Java](https://github.com/luna/enso/blob/master/doc/style-guides/java.md), [Rust](https://github.com/luna/enso/blob/master/doc/style-guides/rust.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/style-guides/haskell.md) style guides as appropriate.
- [x] All code has been tested where possible.

