### PR TITLE
Execution Context Integration with Text Change Events

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -62,6 +62,9 @@ class MainModule(serverConfig: LanguageServerConfig) {
 
   implicit val materializer = SystemMaterializer.get(system)
 
+  lazy val runtimeConnector =
+    system.actorOf(RuntimeConnector.props, "runtime-connector")
+
   lazy val languageServer =
     system.actorOf(
       Props(new LanguageServer(languageServerConfig)),
@@ -74,7 +77,10 @@ class MainModule(serverConfig: LanguageServerConfig) {
   )
 
   lazy val bufferRegistry =
-    system.actorOf(BufferRegistry.props(fileManager), "buffer-registry")
+    system.actorOf(
+      BufferRegistry.props(fileManager, runtimeConnector),
+      "buffer-registry"
+    )
 
   lazy val receivesTreeUpdatesHandler =
     system.actorOf(
@@ -88,9 +94,6 @@ class MainModule(serverConfig: LanguageServerConfig) {
       CapabilityRouter.props(bufferRegistry, receivesTreeUpdatesHandler),
       "capability-router"
     )
-
-  lazy val runtimeConnector =
-    system.actorOf(RuntimeConnector.props, "runtime-connector")
 
   lazy val contextRegistry =
     system.actorOf(

--- a/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManager.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManager.scala
@@ -52,8 +52,9 @@ class FileManager(
       val result =
         for {
           rootPath <- IO.fromEither(config.findContentRoot(path.rootId))
-          content  <- fs.read(path.toFile(rootPath))
-        } yield content
+          file = path.toFile(rootPath)
+          content <- fs.read(file)
+        } yield FileManagerProtocol.FileContent(file, content)
       exec
         .execTimed(config.fileManager.timeout, result)
         .map(FileManagerProtocol.ReadFileResult)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerProtocol.scala
@@ -1,8 +1,11 @@
 package org.enso.languageserver.filemanager
 
+import java.io.File
 import java.util.UUID
 
 object FileManagerProtocol {
+
+  case class FileContent(path: File, content: String)
 
   /**
     * Gets all content roots.
@@ -43,7 +46,7 @@ object FileManagerProtocol {
     *
     * @param result either file system failure or content of a file
     */
-  case class ReadFileResult(result: Either[FileSystemFailure, String])
+  case class ReadFileResult(result: Either[FileSystemFailure, FileContent])
 
   /**
     * Requests the Language Server create a file system object.

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/file/ReadFileHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/file/ReadFileHandler.scala
@@ -54,8 +54,8 @@ class ReadFileHandler(requestTimeout: FiniteDuration, fileManager: ActorRef)
       cancellable.cancel()
       context.stop(self)
 
-    case FileManagerProtocol.ReadFileResult(Right(content)) =>
-      replyTo ! ResponseResult(ReadFile, id, ReadFile.Result(content))
+    case FileManagerProtocol.ReadFileResult(Right(file)) =>
+      replyTo ! ResponseResult(ReadFile, id, ReadFile.Result(file.content))
       cancellable.cancel()
       context.stop(self)
   }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
@@ -43,8 +43,8 @@ final class ContextEventsListener(
           contextId,
           updates
         )
+    // ignore updates from other contexts
     case _: Api.ExpressionValuesComputed =>
-      // ignore updates from other contexts
   }
 
   private def toRuntimeUpdate(

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
@@ -1,4 +1,4 @@
-package org.enso.languageserver.runtime
+package org.enso.languageserver.runtim
 
 import akka.actor.{Actor, ActorLogging, Props}
 import org.enso.languageserver.data.{Client, Config}
@@ -7,8 +7,9 @@ import org.enso.languageserver.util.UnhandledLogging
 import org.enso.polyglot.runtime.Runtime.Api
 
 /**
-  * Event listener is created for the given context. It handles notifications
-  * from the runtime and send updates to the client.
+  * EventListener listens event stream for the notifications from the runtime
+  * and send updates to the client. The listener is created per context, and
+  * only handles the notifications with the given `contextId`.
   *
   * @param config configuration
   * @param client reference to the client
@@ -43,7 +44,7 @@ final class ContextEventsListener(
           contextId,
           updates
         )
-    // ignore updates from other contexts
+
     case _: Api.ExpressionValuesComputed =>
   }
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
@@ -1,4 +1,4 @@
-package org.enso.languageserver.runtim
+package org.enso.languageserver.runtime
 
 import akka.actor.{Actor, ActorLogging, Props}
 import org.enso.languageserver.data.{Client, Config}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeConnector.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeConnector.scala
@@ -42,7 +42,9 @@ class RuntimeConnector
       context.system.eventStream.publish(msg)
     case msg: Runtime.Api.Request =>
       engine.sendBinary(Runtime.Api.serialize(msg))
-      context.become(initialized(engine, senders + (msg.requestId -> sender())))
+      msg.requestId.foreach { id =>
+        context.become(initialized(engine, senders + (id -> sender())))
+      }
     case msg: Runtime.Api.Response =>
       msg.correlationId.flatMap(senders.get).foreach(_ ! msg)
       msg.correlationId.foreach { correlationId =>

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/Buffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/Buffer.scala
@@ -1,15 +1,18 @@
 package org.enso.languageserver.text
 
+import java.io.File
+
 import org.enso.languageserver.data.ContentBasedVersioning
 import org.enso.text.buffer.Rope
 
 /**
   * A buffer state representation.
   *
+  * @param file the file linked to the buffer.
   * @param contents the contents of the buffer.
   * @param version the current version of the buffer contents.
   */
-case class Buffer(contents: Rope, version: Buffer.Version)
+case class Buffer(file: File, contents: Rope, version: Buffer.Version)
 
 object Buffer {
   type Version = String
@@ -17,24 +20,28 @@ object Buffer {
   /**
     * Creates a new buffer with a freshly generated version.
     *
+    * @param file the file linked to the buffer.
     * @param contents the contents of this buffer.
     * @param versionCalculator a digest calculator for content based versioning.
     * @return a new buffer instance.
     */
   def apply(
+    file: File,
     contents: Rope
   )(implicit versionCalculator: ContentBasedVersioning): Buffer =
-    Buffer(contents, versionCalculator.evalVersion(contents.toString))
+    Buffer(file, contents, versionCalculator.evalVersion(contents.toString))
 
   /**
     * Creates a new buffer with a freshly generated version.
     *
+    * @param file the file linked to the buffer.
     * @param contents the contents of this buffer.
     * @param versionCalculator a digest calculator for content based versioning.
     * @return a new buffer instance.
     */
   def apply(
+    file: File,
     contents: String
   )(implicit versionCalculator: ContentBasedVersioning): Buffer =
-    Buffer(Rope(contents))
+    Buffer(file, Rope(contents))
 }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/BaseServerTest.scala
@@ -47,7 +47,9 @@ class BaseServerTest extends JsonRpcServerTestKit {
       system.actorOf(FileManager.props(config, new FileSystem, zioExec))
     val bufferRegistry =
       system.actorOf(
-        BufferRegistry.props(fileManager, runtimeConnectorProbe.ref)(Sha3_224VersionCalculator)
+        BufferRegistry.props(fileManager, runtimeConnectorProbe.ref)(
+          Sha3_224VersionCalculator
+        )
       )
     val fileEventRegistry =
       system.actorOf(

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/BaseServerTest.scala
@@ -47,7 +47,7 @@ class BaseServerTest extends JsonRpcServerTestKit {
       system.actorOf(FileManager.props(config, new FileSystem, zioExec))
     val bufferRegistry =
       system.actorOf(
-        BufferRegistry.props(fileManager)(Sha3_224VersionCalculator)
+        BufferRegistry.props(fileManager, runtimeConnectorProbe.ref)(Sha3_224VersionCalculator)
       )
     val fileEventRegistry =
       system.actorOf(

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/FileNotificationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/FileNotificationsTest.scala
@@ -1,0 +1,262 @@
+package org.enso.languageserver.websocket
+
+import java.io.File
+
+import io.circe.literal._
+import org.enso.polyglot.runtime.Runtime.Api
+import org.enso.text.editing.model.{Position, Range, TextEdit}
+
+class FileNotificationsTest extends BaseServerTest {
+
+  def file(name: String): File = new File(testContentRoot.toFile, name)
+
+  "text operations" should {
+
+    "notify runtime about operations with files" in {
+      // Interaction:
+      // 1.  Client 1 creates a file.
+      // 2.  Client 1 opens the file.
+      // 3.  Client 1 receives confirmation.
+      // 4.  Runtime receives open notification.
+      // 5.  Client 2 opens the same file.
+      // 6.  Client 2 receives confirmation
+      // 7.  Runtime receives no notifications.
+      // 8.  Client 1 edits the file.
+      // 9.  Client 2 receives a notification.
+      // 10. Runtime receives edit notification.
+      // 11. Client 1 saves the file.
+      // 12. Runtime receives no notifications.
+      // 13. Client 1 closes the file.
+      // 14. Runtime receives no notifications.
+      // 15. Client 2 closes the file.
+      // 16. Runtime receives close notification.
+      val client1 = getInitialisedWsClient()
+      val client2 = getInitialisedWsClient()
+
+      // 1
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "file/write",
+            "id": 0,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              },
+              "contents": "123456789"
+            }
+          }
+          """)
+      client1.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 0,
+            "result": null
+          }
+          """)
+
+      // 2
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/openFile",
+            "id": 1,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
+      // 3
+      client1.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+              "writeCapability": {
+                "method": "canEdit",
+                "registerOptions": { "path": {
+                  "rootId": $testContentRootId,
+                  "segments": ["foo.txt"]
+                } }
+              },
+              "content": "123456789",
+              "currentVersion": "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522"
+            }
+          }
+          """)
+      // 4
+      runtimeConnectorProbe.expectMsg(
+        Api.Request(Api.OpenFileNotification(file("foo.txt"), "123456789"))
+      )
+
+      // 5
+      client2.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/openFile",
+            "id": 2,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
+      // 6
+      client2.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+              "writeCapability": null,
+              "content": "123456789",
+              "currentVersion": "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522"
+            }
+          }
+          """)
+      // 7
+      runtimeConnectorProbe.expectNoMessage()
+
+      // 8
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/applyEdit",
+            "id": 3,
+            "params": {
+              "edit": {
+                "path": {
+                  "rootId": $testContentRootId,
+                  "segments": [ "foo.txt" ]
+                },
+                "oldVersion": "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522",
+                "newVersion": "7602967cab172183d1a67ea40cb8e92e23218764bc9934c3795fcea5",
+                "edits": [
+                  {
+                    "range": {
+                      "start": { "line": 0, "character": 0 },
+                      "end": { "line": 0, "character": 0 }
+                    },
+                    "text": "bar"
+                  }
+                ]
+              }
+            }
+          }
+          """)
+      client1.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 3,
+            "result": null
+          }
+          """)
+      // 9
+      client2.expectJson(json"""
+          {
+            "jsonrpc" : "2.0",
+            "method" : "text/didChange",
+            "params" : {
+              "edits" : [
+                {
+                  "path" : {
+                    "rootId" : $testContentRootId,
+                    "segments" : [
+                      "foo.txt"
+                    ]
+                  },
+                  "edits" : [
+                    {
+                      "range" : {
+                        "start" : { "line" : 0, "character" : 0 },
+                        "end" : { "line" : 0, "character" : 0 }
+                      },
+                      "text" : "bar"
+                    }
+                  ],
+                  "oldVersion" : "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522",
+                  "newVersion" : "7602967cab172183d1a67ea40cb8e92e23218764bc9934c3795fcea5"
+                }
+              ]
+            }
+          }
+          """)
+      // 10
+      runtimeConnectorProbe.expectMsg(
+        Api.Request(
+          Api.EditFileNotification(
+            file("foo.txt"),
+            Seq(TextEdit(Range(Position(0, 0), Position(0, 0)), "bar"))
+          )
+        )
+      )
+
+      // 11
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/save",
+            "id": 4,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              },
+              "currentVersion": "7602967cab172183d1a67ea40cb8e92e23218764bc9934c3795fcea5"
+            }
+          }
+          """)
+      client1.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 4,
+            "result": null
+          }
+          """)
+      // 12
+      runtimeConnectorProbe.expectNoMessage()
+
+      // 13
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/closeFile",
+            "id": 5,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
+      client1.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 5,
+            "result": null
+          }
+          """)
+      // 14
+      runtimeConnectorProbe.expectNoMessage()
+
+      // 15
+      client2.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/closeFile",
+            "id": 6,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
+      client2.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 6,
+            "result": null
+          }
+          """)
+      // 16
+      runtimeConnectorProbe.expectMsg(
+        Api.Request(Api.CloseFileNotification(file("foo.txt")))
+      )
+    }
+  }
+
+}

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -178,10 +178,32 @@ object Runtime {
     /**
       * Envelope for an Api request.
       *
-      * @param requestId request identifier
-      * @param payload request
+      * @param requestId optional request identifier.
+      * @param payload the request payload.
       */
-    case class Request(requestId: RequestId, payload: ApiRequest)
+    case class Request(requestId: Option[RequestId], payload: ApiRequest)
+
+    object Request {
+
+      /**
+        * A smart constructor for [[Request]].
+        *
+        * @param requestId the reqest identifier.
+        * @param payload the request payload.
+        * @return a request object with specified request id and payload.
+        */
+      def apply(requestId: RequestId, payload: ApiRequest): Request =
+        Request(Some(requestId), payload)
+
+      /**
+        * A smart constructor for [[Request]].
+        *
+        * @param payload the request payload.
+        * @return a request object without request id and specified payload.
+        */
+      def apply(payload: ApiRequest): Request =
+        Request(None, payload)
+    }
 
     /**
       * Envelope for an Api response.

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -68,10 +68,6 @@ object Runtime {
         name  = "closeFileNotification"
       ),
       new JsonSubTypes.Type(
-        value = classOf[Api.CreateFileNotification],
-        name  = "createFileNotification"
-      ),
-      new JsonSubTypes.Type(
         value = classOf[Api.ExpressionValuesComputed],
         name  = "expressionValuesComputed"
       ),
@@ -346,13 +342,6 @@ object Runtime {
       * @param path the file being closed.
       */
     case class CloseFileNotification(path: File) extends ApiRequest
-
-    /**
-      * A notification sent to the server about a file being created.
-      *
-      * @param path the newly created file.
-      */
-    case class CreateFileNotification(path: File) extends ApiRequest
 
     /**
       * Notification sent from the server to the client upon successful

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -148,10 +148,10 @@ object Runtime {
     /**
       * An update containing information about expression.
       *
-      * @param expressionId expression id
-      * @param expressionType optional type of expression
-      * @param shortValue optional value of expression
-      * @param methodCall optional pointer to a method definition
+      * @param expressionId expression id.
+      * @param expressionType the type of expression.
+      * @param shortValue the value of expression.
+      * @param methodCall the pointer to a method definition.
       */
     case class ExpressionValueUpdate(
       expressionId: ExpressionId,
@@ -174,7 +174,7 @@ object Runtime {
     /**
       * Envelope for an Api request.
       *
-      * @param requestId optional request identifier.
+      * @param requestId the request identifier.
       * @param payload the request payload.
       */
     case class Request(requestId: Option[RequestId], payload: ApiRequest)

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -124,13 +124,17 @@ public class ExecutionService {
   }
 
   /**
-   * Sets a module at a given path to use a literal source.
+   * Sets a module at a given path to use a literal source. If module not exists, it will be
+   * created.
    *
    * @param path the module path.
    * @param contents the sources to use for it.
    */
   public void setModuleSources(File path, String contents) {
     Optional<Module> module = context.getModuleForFile(path);
+    if (!module.isPresent()) {
+      module = context.createModuleForFile(path);
+    }
     module.ifPresent(mod -> mod.setLiteralSource(contents));
   }
 
@@ -142,15 +146,6 @@ public class ExecutionService {
   public void resetModuleSources(File path) {
     Optional<Module> module = context.getModuleForFile(path);
     module.ifPresent(Module::unsetLiteralSource);
-  }
-
-  /**
-   * Registers a new file as a source module.
-   *
-   * @param path the file to register.
-   */
-  public void createModule(File path) {
-    context.createModuleForFile(path);
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -124,8 +124,9 @@ public class ExecutionService {
   }
 
   /**
-   * Sets a module at a given path to use a literal source. If module not exists, it will be
-   * created.
+   * Sets a module at a given path to use a literal source.
+   *
+   * If a module does not exist it will be created.
    *
    * @param path the module path.
    * @param contents the sources to use for it.

--- a/engine/runtime/src/main/scala/org/enso/interpeter/instrument/ExecutionContext.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpeter/instrument/ExecutionContext.scala
@@ -5,17 +5,10 @@ import org.enso.polyglot.runtime.Runtime.Api.{ContextId, StackItem}
 import scala.collection.mutable.Stack
 
 /**
-  * Represents an execution context.
-  *
-  * @param id the context id.
-  */
-case class ExecutionContext(id: ContextId)
-
-/**
   * Storage for active execution contexts.
   */
 class ExecutionContextManager {
-  private var contexts: Map[ExecutionContext, Stack[StackItem]] = Map()
+  private var contexts: Map[ContextId, Stack[StackItem]] = Map()
 
   /**
     * Creates a new context with a given id.
@@ -23,14 +16,14 @@ class ExecutionContextManager {
     * @param id the context id.
     */
   def create(id: ContextId): Unit =
-    contexts += ExecutionContext(id) -> Stack.empty
+    contexts += id -> Stack.empty
 
   /**
     * Destroys a context with a given id.
     * @param id the context id.
     */
   def destroy(id: ContextId): Unit =
-    contexts -= ExecutionContext(id)
+    contexts -= id
 
   /**
     * Gets a context with a given id.
@@ -38,10 +31,10 @@ class ExecutionContextManager {
     * @param id the context id.
     * @return the context with the given id, if exists.
     */
-  def get(id: ContextId): Option[ExecutionContext] =
+  def get(id: ContextId): Option[ContextId] =
     for {
-      _ <- contexts.get(ExecutionContext(id))
-    } yield ExecutionContext(id)
+      _ <- contexts.get(id)
+    } yield id
 
   /**
     * Gets a stack for a given context id.
@@ -50,7 +43,15 @@ class ExecutionContextManager {
     * @return the stack.
     */
   def getStack(id: ContextId): Stack[StackItem] =
-    contexts.getOrElse(ExecutionContext(id), Stack())
+    contexts.getOrElse(id, Stack())
+
+  /**
+    * Gets all execution contexts.
+    *
+    * @return all currently available execution contexsts.
+    */
+  def getAll: collection.MapView[ContextId, Stack[StackItem]] =
+    contexts.view
 
   /**
     * If the context exists, push the item on the stack.
@@ -61,7 +62,7 @@ class ExecutionContextManager {
     */
   def push(id: ContextId, item: StackItem): Option[Unit] =
     for {
-      stack <- contexts.get(ExecutionContext(id))
+      stack <- contexts.get(id)
     } yield stack.push(item)
 
   /**
@@ -72,7 +73,7 @@ class ExecutionContextManager {
     */
   def pop(id: ContextId): Option[StackItem] =
     for {
-      stack <- contexts.get(ExecutionContext(id))
+      stack <- contexts.get(id)
       if stack.nonEmpty
     } yield stack.pop()
 }

--- a/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
@@ -267,7 +267,6 @@ final class Handler {
 
       case Api.OpenFileNotification(path, contents) =>
         executionService.setModuleSources(path, contents)
-        withContext(executeAll())
 
       case Api.CloseFileNotification(path) =>
         executionService.resetModuleSources(path)

--- a/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
@@ -173,8 +173,7 @@ final class Handler {
   }
 
   private def executeAll(): Unit =
-    contextManager
-      .getAll
+    contextManager.getAll
       .filter(kv => kv._2.nonEmpty)
       .mapValues(_.toList)
       .foreach(Function.tupled(execute))

--- a/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpeter/instrument/Handler.scala
@@ -167,9 +167,17 @@ final class Handler {
           unwind(xs, explicitCalls, id :: localCalls)
       }
     val (explicitCalls, localCalls) = unwind(stack, Nil, Nil)
-    val item                        = toExecutionItem(explicitCalls.head)
-    execute(item, localCalls, sendUpdate(contextId, _))
+    explicitCalls.headOption.foreach { item =>
+      execute(toExecutionItem(item), localCalls, sendUpdate(contextId, _))
+    }
   }
+
+  private def executeAll(): Unit =
+    contextManager
+      .getAll
+      .filter(kv => kv._2.nonEmpty)
+      .mapValues(_.toList)
+      .foreach(Function.tupled(execute))
 
   private def toExecutionItem(
     call: Api.StackItem.ExplicitCall
@@ -258,40 +266,16 @@ final class Handler {
           )
         }
 
-      case Api.PushContextRequest(contextId, item) =>
-        val payload = contextManager.push(contextId, item) match {
-          case Some(()) => Api.PushContextResponse(contextId)
-          case None     => Api.ContextNotExistError(contextId)
-        }
-        endpoint.sendToClient(Api.Response(requestId, payload))
-
-      case Api.PopContextRequest(contextId) =>
-        if (contextManager.get(contextId).isDefined) {
-          val payload = contextManager.pop(contextId) match {
-            case Some(_) => Api.PopContextResponse(contextId)
-            case None    => Api.EmptyStackError(contextId)
-          }
-          endpoint.sendToClient(Api.Response(requestId, payload))
-        } else {
-          endpoint.sendToClient(
-            Api.Response(requestId, Api.ContextNotExistError(contextId))
-          )
-        }
-
       case Api.OpenFileNotification(path, contents) =>
         executionService.setModuleSources(path, contents)
-
-      case Api.CreateFileNotification(path) =>
-        executionService.createModule(path)
-
-      case Api.OpenFileNotification(path, contents) =>
-        executionService.setModuleSources(path, contents)
+        withContext(executeAll())
 
       case Api.CloseFileNotification(path) =>
         executionService.resetModuleSources(path)
 
       case Api.EditFileNotification(path, edits) =>
         executionService.modifyModuleSources(path, edits.asJava)
+        withContext(executeAll())
     }
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -1,6 +1,6 @@
 package org.enso.interpreter.test.instrument
 
-import java.io.{ByteArrayOutputStream, File, OutputStream}
+import java.io.{ByteArrayOutputStream, File}
 import java.nio.ByteBuffer
 import java.nio.file.Files
 import java.util.UUID
@@ -88,7 +88,7 @@ class RuntimeServerTest
     }
   }
 
-  object Program {
+  object Main {
 
     val metadata = new Metadata
 
@@ -98,7 +98,7 @@ class RuntimeServerTest
     val idFooY  = metadata.addItem(85, 8)
     val idFooZ  = metadata.addItem(102, 5)
 
-    val text =
+    val code = metadata.appendToCode(
       """
         |main =
         |    x = 1 + 5
@@ -111,8 +111,7 @@ class RuntimeServerTest
         |    z = y * x
         |    z
         |""".stripMargin
-
-    val code = metadata.appendToCode(text)
+    )
 
     object update {
 
@@ -122,7 +121,7 @@ class RuntimeServerTest
             contextId,
             Vector(
               Api.ExpressionValueUpdate(
-                Program.idMainX,
+                Main.idMainX,
                 Some("Number"),
                 Some("6"),
                 None
@@ -137,7 +136,7 @@ class RuntimeServerTest
             contextId,
             Vector(
               Api.ExpressionValueUpdate(
-                Program.idMainY,
+                Main.idMainY,
                 Some("Number"),
                 Some("45"),
                 None
@@ -152,7 +151,7 @@ class RuntimeServerTest
             contextId,
             Vector(
               Api.ExpressionValueUpdate(
-                Program.idMainZ,
+                Main.idMainZ,
                 Some("Number"),
                 Some("50"),
                 None
@@ -167,7 +166,7 @@ class RuntimeServerTest
             contextId,
             Vector(
               Api.ExpressionValueUpdate(
-                Program.idFooY,
+                Main.idFooY,
                 Some("Number"),
                 Some("9"),
                 None
@@ -182,7 +181,7 @@ class RuntimeServerTest
             contextId,
             Vector(
               Api.ExpressionValueUpdate(
-                Program.idFooZ,
+                Main.idFooZ,
                 Some("Number"),
                 Some("45"),
                 None
@@ -199,7 +198,7 @@ class RuntimeServerTest
   }
 
   "RuntimeServer" should "push and pop functions on the stack" in {
-    val mainFile  = context.writeMain(Program.code)
+    val mainFile  = context.writeMain(Main.code)
     val contextId = UUID.randomUUID()
     val requestId = UUID.randomUUID()
 
@@ -210,7 +209,7 @@ class RuntimeServerTest
     )
 
     // push local item on top of the empty stack
-    val invalidLocalItem = Api.StackItem.LocalCall(Program.idMainY)
+    val invalidLocalItem = Api.StackItem.LocalCall(Main.idMainY)
     context.send(
       Api
         .Request(requestId, Api.PushContextRequest(contextId, invalidLocalItem))
@@ -231,21 +230,21 @@ class RuntimeServerTest
     )
     Set.fill(5)(context.receive) shouldEqual Set(
       Some(Api.Response(requestId, Api.PushContextResponse(contextId))),
-      Some(Program.update.idMainX(contextId)),
-      Some(Program.update.idMainY(contextId)),
-      Some(Program.update.idMainZ(contextId)),
+      Some(Main.update.idMainX(contextId)),
+      Some(Main.update.idMainY(contextId)),
+      Some(Main.update.idMainZ(contextId)),
       None
     )
 
     // push foo call
-    val item2 = Api.StackItem.LocalCall(Program.idMainY)
+    val item2 = Api.StackItem.LocalCall(Main.idMainY)
     context.send(
       Api.Request(requestId, Api.PushContextRequest(contextId, item2))
     )
     Set.fill(4)(context.receive) shouldEqual Set(
       Some(Api.Response(requestId, Api.PushContextResponse(contextId))),
-      Some(Program.update.idFooY(contextId)),
-      Some(Program.update.idFooZ(contextId)),
+      Some(Main.update.idFooY(contextId)),
+      Some(Main.update.idFooZ(contextId)),
       None
     )
 
@@ -270,9 +269,9 @@ class RuntimeServerTest
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
     Set.fill(5)(context.receive) shouldEqual Set(
       Some(Api.Response(requestId, Api.PopContextResponse(contextId))),
-      Some(Program.update.idMainX(contextId)),
-      Some(Program.update.idMainY(contextId)),
-      Some(Program.update.idMainZ(contextId)),
+      Some(Main.update.idMainX(contextId)),
+      Some(Main.update.idMainY(contextId)),
+      Some(Main.update.idMainZ(contextId)),
       None
     )
 
@@ -291,7 +290,7 @@ class RuntimeServerTest
     )
   }
 
-  "Runtime server" should "support file modification operations" in {
+  it should "support file modification operations" in {
     def send(msg: ApiRequest): Unit =
       context.send(Api.Request(UUID.randomUUID(), msg))
 
@@ -301,35 +300,39 @@ class RuntimeServerTest
     send(Api.CreateContextRequest(contextId))
     context.receive
 
-    def push: Unit =
-      send(
-        Api.PushContextRequest(
-          contextId,
-          Api.StackItem
-            .ExplicitCall(
-              Api.MethodPointer(fooFile, "Foo", "main"),
-              None,
-              Vector()
-            )
-        )
-      )
-    def pop: Unit = send(Api.PopContextRequest(contextId))
-
     // Create a new file
     context.writeFile(fooFile, "main = IO.println \"I'm a file!\"")
-    send(Api.CreateFileNotification(fooFile))
-    push
+
+    // Open the new file
+    send(
+      Api.OpenFileNotification(
+        fooFile,
+        "main = IO.println \"I'm a file!\""
+      )
+    )
+    context.consumeOut shouldEqual List()
+
+    // Push new item on the stack to trigger the re-execution
+    send(
+      Api.PushContextRequest(
+        contextId,
+        Api.StackItem
+          .ExplicitCall(
+            Api.MethodPointer(fooFile, "Foo", "main"),
+            None,
+            Vector()
+          )
+      )
+    )
     context.consumeOut shouldEqual List("I'm a file!")
 
-    // Open the new file and set literal source
+    // Open the new file with contents changed
     send(
       Api.OpenFileNotification(
         fooFile,
         "main = IO.println \"I'm an open file!\""
       )
     )
-    pop
-    push
     context.consumeOut shouldEqual List("I'm an open file!")
 
     // Modify the file
@@ -344,15 +347,10 @@ class RuntimeServerTest
         )
       )
     )
-    pop
-    push
     context.consumeOut shouldEqual List("I'm a modified file!")
 
     // Close the file
     send(Api.CloseFileNotification(fooFile))
-    pop
-    push
-    context.consumeOut shouldEqual List("I'm a file!")
-
+    context.consumeOut shouldEqual List()
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -333,7 +333,7 @@ class RuntimeServerTest
         "main = IO.println \"I'm an open file!\""
       )
     )
-    context.consumeOut shouldEqual List("I'm an open file!")
+    context.consumeOut shouldEqual List()
 
     // Modify the file
     send(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -326,7 +326,7 @@ class RuntimeServerTest
     )
     context.consumeOut shouldEqual List("I'm a file!")
 
-    // Open the new file with contents changed
+    // Open the file with contents changed
     send(
       Api.OpenFileNotification(
         fooFile,


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #590 

Changelog:
- update: `CollaborativeBuffer` sends notifications to the runtime
- update: runtime re-executes expressions when a text change event is received

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

`Runtime.Api.CreateFileNotification` was removed. `Runtime.Api.OpenFileNotification` implies that the file already exists.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/style-guides/scala.md), [Java](https://github.com/luna/enso/blob/master/doc/style-guides/java.md), [Rust](https://github.com/luna/enso/blob/master/doc/style-guides/rust.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/style-guides/haskell.md) style guides as appropriate.
- [x] All code has been tested where possible.

