### PR TITLE
Fix double-eval of this argument

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
@@ -167,6 +167,7 @@ public abstract class InvokeCallableNode extends BaseNode {
         Stateful selfResult = thisExecutor.executeThunk((Thunk) selfArgument, state);
         selfArgument = selfResult.getValue();
         state = selfResult.getState();
+        arguments[thisArgumentPosition] = selfArgument;
       }
       Function function = methodResolverNode.execute(symbol, selfArgument);
       return this.invokeFunctionNode.execute(function, callerFrame, state, arguments);

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
@@ -13,6 +13,17 @@ class MethodsTest extends InterpreterTest {
     eval(code) shouldEqual 11
   }
 
+  "Method calls" should "execute `this` argument once" in {
+    val code =
+      """
+        |Unit.foo = 0
+        |
+        |main = (IO.println "foo").foo
+        |""".stripMargin
+    eval(code)
+    consumeOut shouldEqual List("foo")
+  }
+
   "Methods" should "be callable with dot operator" in {
     val code =
       """


### PR DESCRIPTION
### Pull Request Description
Fixes a bug where `this` argument of method calls was evaluated twice. No perf impact (except I can imagine a program that was exponential before and is linear now...).

### Important Notes


### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/style-guides/scala.md), [Java](https://github.com/luna/enso/blob/master/doc/style-guides/java.md), [Rust](https://github.com/luna/enso/blob/master/doc/style-guides/rust.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/style-guides/haskell.md) style guides as appropriate.
- [x] All code has been tested where possible.

