### PR TITLE
Upload the FlatBuffers Schemas to S3

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -156,13 +156,13 @@ jobs:
     # Artefacts
     - name: Build the Uberjar
       run: sbt --no-colors runner/assembly
+    - name: Build the Parser JS Bundle
+      run: sbt -no-colors syntaxJS/fullOptJS
     - name: Publish the Uberjar
       uses: actions/upload-artifact@v1.0.0
       with:
         name: Enso CLI
         path: ./enso.jar
-    - name: Build the Parser JS Bundle
-      run: sbt -no-colors syntaxJS/fullOptJS
     - name: Prepare the FlatBuffers Schemas for Upload
       run: |
         mkdir fbs-upload

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -153,11 +153,13 @@ jobs:
     - name: Build Enso
       run: sbt --no-colors compile
 
-    # Artefacts
+    # Build Artefacts
     - name: Build the Uberjar
       run: sbt --no-colors runner/assembly
     - name: Build the Parser JS Bundle
       run: sbt -no-colors syntaxJS/fullOptJS
+
+    # Publish
     - name: Publish the Uberjar
       uses: actions/upload-artifact@v1.0.0
       with:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -27,76 +27,76 @@ env:
 jobs:
 
   # This job is responsible for testing the codebase
-  # test:
-    # name: Test
-    # runs-on: ${{ matrix.os }}
-    # timeout-minutes: 30
-    # strategy:
-      # matrix:
-        # os: [windows-latest, macOS-latest, ubuntu-latest]
-      # fail-fast: false
-    # steps:
-    # - uses: actions/checkout@v2
-    # - name: Setup conda
-      # uses: s-weigand/setup-conda@v1
-      # with:
-        # update-conda: false
-        # conda-channels: anaconda, conda-forge
-    # - name: Setup Conda Environment on Windows
-      # if: runner.os == 'Windows'
-      # run: |
-        # conda create --name enso
-        # conda init powershell
-    # - name: Activate Conda Environment on Windows
-      # if: runner.os == 'Windows'
-      # run: conda activate enso
-    # - name: Install FlatBuffers Compiler
-      # run: conda install --freeze-installed flatbuffers=1.12.0
-    # - name: Setup GraalVM Environment
-      # uses: DeLaGuardo/setup-graalvm@2.0
-      # with:
-        # graalvm-version: ${{ env.graalVersion }}.${{ env.javaVersion }}
-    # - name: Set Up SBT
-      # run: |
-        # curl -fSL -o sbt.tgz https://piccolo.link/sbt-${{env.sbtVersion}}.tgz
-        # tar -xzf sbt.tgz
-        # echo ::add-path::$GITHUB_WORKSPACE/sbt/bin/
-#
-    # # Caches
-    # - name: Cache Ivy
-      # uses: actions/cache@v1.1.2
-      # with:
-        # path: ~/.ivy2/cache
-        # key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-        # restore-keys: ${{ runner.os }}-ivy-
-    # - name: Cache SBT
-      # uses: actions/cache@v1.1.2
-      # with:
-        # path: ~/.sbt
-        # key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-        # restore-keys: ${{ runner.os }}-sbt-
-    # - name: Cache Coursier and Mill
-      # uses: actions/cache@v1.1.2
-      # with:
-        # path: ~/.cache
-        # key: ${{ runner.os }}-coursier-${{ hashFiles('**build.sbt') }}
-        # restore-keys: ${{ runner.os }}-coursier-
-#
-    # # Build
-    # - name: Build Enso
-      # run: sbt --no-colors compile
-#
-    # # Tests
-    # - name: Test Enso
-      # run: sbt --no-colors test
-    # - name: Benchmark the Parser
-      # run: sbt -no-colors syntax/bench
-    # - name: Check Runtime Benchmark Compilation
-      # run: sbt -no-colors runtime/Benchmark/compile
-    # - name: Build the Uberjar
-      # run: sbt -no-colors runner/assembly
-    # - name: Test the Uberjar
-      # run: ./enso.jar --run tools/ci/Test.enso
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        os: [windows-latest, macOS-latest, ubuntu-latest]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup conda
+      uses: s-weigand/setup-conda@v1
+      with:
+        update-conda: false
+        conda-channels: anaconda, conda-forge
+    - name: Setup Conda Environment on Windows
+      if: runner.os == 'Windows'
+      run: |
+        conda create --name enso
+        conda init powershell
+    - name: Activate Conda Environment on Windows
+      if: runner.os == 'Windows'
+      run: conda activate enso
+    - name: Install FlatBuffers Compiler
+      run: conda install --freeze-installed flatbuffers=1.12.0
+    - name: Setup GraalVM Environment
+      uses: DeLaGuardo/setup-graalvm@2.0
+      with:
+        graalvm-version: ${{ env.graalVersion }}.${{ env.javaVersion }}
+    - name: Set Up SBT
+      run: |
+        curl -fSL -o sbt.tgz https://piccolo.link/sbt-${{env.sbtVersion}}.tgz
+        tar -xzf sbt.tgz
+        echo ::add-path::$GITHUB_WORKSPACE/sbt/bin/
+
+    # Caches
+    - name: Cache Ivy
+      uses: actions/cache@v1.1.2
+      with:
+        path: ~/.ivy2/cache
+        key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
+        restore-keys: ${{ runner.os }}-ivy-
+    - name: Cache SBT
+      uses: actions/cache@v1.1.2
+      with:
+        path: ~/.sbt
+        key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
+        restore-keys: ${{ runner.os }}-sbt-
+    - name: Cache Coursier and Mill
+      uses: actions/cache@v1.1.2
+      with:
+        path: ~/.cache
+        key: ${{ runner.os }}-coursier-${{ hashFiles('**build.sbt') }}
+        restore-keys: ${{ runner.os }}-coursier-
+
+    # Build
+    - name: Build Enso
+      run: sbt --no-colors compile
+
+    # Tests
+    - name: Test Enso
+      run: sbt --no-colors test
+    - name: Benchmark the Parser
+      run: sbt -no-colors syntax/bench
+    - name: Check Runtime Benchmark Compilation
+      run: sbt -no-colors runtime/Benchmark/compile
+    - name: Build the Uberjar
+      run: sbt -no-colors runner/assembly
+    - name: Test the Uberjar
+      run: ./enso.jar --run tools/ci/Test.enso
 
   # This job is responsible for building the artifacts
   build:
@@ -150,24 +150,19 @@ jobs:
         restore-keys: ${{ runner.os }}-coursier-
 
     # Build
-    # - name: Build Enso
-      # run: sbt --no-colors compile
+    - name: Build Enso
+      run: sbt --no-colors compile
 
     # Artefacts
-    # - name: Build the Uberjar
-      # run: sbt --no-colors runner/assembly
-    # - name: Publish the Uberjar
-      # uses: actions/upload-artifact@v1.0.0
-      # with:
-        # name: Enso CLI
-        # path: ./enso.jar
-    # - name: Build the Parser JS Bundle
-      # run: sbt -no-colors syntaxJS/fullOptJS
-    # - name: Publish the Parser JS Bundle
-      # uses: actions/upload-artifact@v1.0.0
-      # with:
-        # name: Parser JS Bundle
-        # path: ./target/scala-parser.js
+    - name: Build the Uberjar
+      run: sbt --no-colors runner/assembly
+    - name: Publish the Uberjar
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: Enso CLI
+        path: ./enso.jar
+    - name: Build the Parser JS Bundle
+      run: sbt -no-colors syntaxJS/fullOptJS
     - name: Prepare the FlatBuffers Schemas for Upload
       run: |
         mkdir fbs-upload
@@ -178,10 +173,15 @@ jobs:
       with:
         name: Engine Protocol FlatBuffers Schemas
         path: ./fbs-upload/fbs-schema.zip
-    # - name: Prepare Parser JS Bundle for Upload
-      # run: |
-        # mkdir parser-upload
-        # cp ./target/scala-parser.js parser-upload
+    - name: Prepare Parser JS Bundle for Upload
+      run: |
+        mkdir parser-upload
+        cp ./target/scala-parser.js parser-upload
+    - name: Publish the Parser JS Bundle
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: Parser JS Bundle
+        path: ./target/scala-parser.js
     - name: Prepare AWS Session
       run: |
         aws configure --profile s3-upload <<-EOF > /dev/null 2>&1
@@ -190,9 +190,9 @@ jobs:
         us-west-2
         text
         EOF
-    # - name: Upload Parser JS Bundle to S3
-      # run: |
-        # aws s3 sync ./parser-upload s3://packages-luna/parser-js/nightly/`git rev-parse HEAD` --profile s3-upload --acl public-read --delete
+    - name: Upload Parser JS Bundle to S3
+      run: |
+        aws s3 sync ./parser-upload s3://packages-luna/parser-js/nightly/`git rev-parse HEAD` --profile s3-upload --acl public-read --delete
     - name: Upload FlatBuffers Schemas to S3
       run: |
         aws s3 sync ./fbs-upload s3://packages-luna/fbs-schema/nightly/`git rev-parse HEAD` --profile s3-upload --acl public-read --delete

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -27,76 +27,76 @@ env:
 jobs:
 
   # This job is responsible for testing the codebase
-  test:
-    name: Test
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        os: [windows-latest, macOS-latest, ubuntu-latest]
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup conda
-      uses: s-weigand/setup-conda@v1
-      with:
-        update-conda: false
-        conda-channels: anaconda, conda-forge
-    - name: Setup Conda Environment on Windows
-      if: runner.os == 'Windows'
-      run: |
-        conda create --name enso
-        conda init powershell
-    - name: Activate Conda Environment on Windows
-      if: runner.os == 'Windows'
-      run: conda activate enso
-    - name: Install FlatBuffers Compiler
-      run: conda install --freeze-installed flatbuffers=1.12.0
-    - name: Setup GraalVM Environment
-      uses: DeLaGuardo/setup-graalvm@2.0
-      with:
-        graalvm-version: ${{ env.graalVersion }}.${{ env.javaVersion }}
-    - name: Set Up SBT
-      run: |
-        curl -fSL -o sbt.tgz https://piccolo.link/sbt-${{env.sbtVersion}}.tgz
-        tar -xzf sbt.tgz
-        echo ::add-path::$GITHUB_WORKSPACE/sbt/bin/
-
-    # Caches
-    - name: Cache Ivy
-      uses: actions/cache@v1.1.2
-      with:
-        path: ~/.ivy2/cache
-        key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
-        restore-keys: ${{ runner.os }}-ivy-
-    - name: Cache SBT
-      uses: actions/cache@v1.1.2
-      with:
-        path: ~/.sbt
-        key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
-        restore-keys: ${{ runner.os }}-sbt-
-    - name: Cache Coursier and Mill
-      uses: actions/cache@v1.1.2
-      with:
-        path: ~/.cache
-        key: ${{ runner.os }}-coursier-${{ hashFiles('**build.sbt') }}
-        restore-keys: ${{ runner.os }}-coursier-
-
-    # Build
-    - name: Build Enso
-      run: sbt --no-colors compile
-
-    # Tests
-    - name: Test Enso
-      run: sbt --no-colors test
-    - name: Benchmark the Parser
-      run: sbt -no-colors syntax/bench
-    - name: Check Runtime Benchmark Compilation
-      run: sbt -no-colors runtime/Benchmark/compile
-    - name: Build the Uberjar
-      run: sbt -no-colors runner/assembly
-    - name: Test the Uberjar
-      run: ./enso.jar --run tools/ci/Test.enso
+  # test:
+    # name: Test
+    # runs-on: ${{ matrix.os }}
+    # timeout-minutes: 30
+    # strategy:
+      # matrix:
+        # os: [windows-latest, macOS-latest, ubuntu-latest]
+      # fail-fast: false
+    # steps:
+    # - uses: actions/checkout@v2
+    # - name: Setup conda
+      # uses: s-weigand/setup-conda@v1
+      # with:
+        # update-conda: false
+        # conda-channels: anaconda, conda-forge
+    # - name: Setup Conda Environment on Windows
+      # if: runner.os == 'Windows'
+      # run: |
+        # conda create --name enso
+        # conda init powershell
+    # - name: Activate Conda Environment on Windows
+      # if: runner.os == 'Windows'
+      # run: conda activate enso
+    # - name: Install FlatBuffers Compiler
+      # run: conda install --freeze-installed flatbuffers=1.12.0
+    # - name: Setup GraalVM Environment
+      # uses: DeLaGuardo/setup-graalvm@2.0
+      # with:
+        # graalvm-version: ${{ env.graalVersion }}.${{ env.javaVersion }}
+    # - name: Set Up SBT
+      # run: |
+        # curl -fSL -o sbt.tgz https://piccolo.link/sbt-${{env.sbtVersion}}.tgz
+        # tar -xzf sbt.tgz
+        # echo ::add-path::$GITHUB_WORKSPACE/sbt/bin/
+#
+    # # Caches
+    # - name: Cache Ivy
+      # uses: actions/cache@v1.1.2
+      # with:
+        # path: ~/.ivy2/cache
+        # key: ${{ runner.os }}-ivy-${{ hashFiles('**/build.sbt') }}
+        # restore-keys: ${{ runner.os }}-ivy-
+    # - name: Cache SBT
+      # uses: actions/cache@v1.1.2
+      # with:
+        # path: ~/.sbt
+        # key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
+        # restore-keys: ${{ runner.os }}-sbt-
+    # - name: Cache Coursier and Mill
+      # uses: actions/cache@v1.1.2
+      # with:
+        # path: ~/.cache
+        # key: ${{ runner.os }}-coursier-${{ hashFiles('**build.sbt') }}
+        # restore-keys: ${{ runner.os }}-coursier-
+#
+    # # Build
+    # - name: Build Enso
+      # run: sbt --no-colors compile
+#
+    # # Tests
+    # - name: Test Enso
+      # run: sbt --no-colors test
+    # - name: Benchmark the Parser
+      # run: sbt -no-colors syntax/bench
+    # - name: Check Runtime Benchmark Compilation
+      # run: sbt -no-colors runtime/Benchmark/compile
+    # - name: Build the Uberjar
+      # run: sbt -no-colors runner/assembly
+    # - name: Test the Uberjar
+      # run: ./enso.jar --run tools/ci/Test.enso
 
   # This job is responsible for building the artifacts
   build:
@@ -150,28 +150,38 @@ jobs:
         restore-keys: ${{ runner.os }}-coursier-
 
     # Build
-    - name: Build Enso
-      run: sbt --no-colors compile
+    # - name: Build Enso
+      # run: sbt --no-colors compile
 
     # Artefacts
-    - name: Build the Uberjar
-      run: sbt --no-colors runner/assembly
-    - name: Publish the Uberjar
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: Enso CLI
-        path: ./enso.jar
-    - name: Build the Parser JS Bundle
-      run: sbt -no-colors syntaxJS/fullOptJS
-    - name: Publish the Parser JS Bundle
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: Parser JS Bundle
-        path: ./target/scala-parser.js
-    - name: Prepare Parser JS Bundle for Upload
+    # - name: Build the Uberjar
+      # run: sbt --no-colors runner/assembly
+    # - name: Publish the Uberjar
+      # uses: actions/upload-artifact@v1.0.0
+      # with:
+        # name: Enso CLI
+        # path: ./enso.jar
+    # - name: Build the Parser JS Bundle
+      # run: sbt -no-colors syntaxJS/fullOptJS
+    # - name: Publish the Parser JS Bundle
+      # uses: actions/upload-artifact@v1.0.0
+      # with:
+        # name: Parser JS Bundle
+        # path: ./target/scala-parser.js
+    - name: Prepare the FlatBuffers Schemas for Upload
       run: |
-        mkdir parser_upload
-        cp ./target/scala-parser.js parser_upload
+        mkdir fbs-upload
+        cp -r "engine/language-server/src/main/schema" fbs-upload/fbs-schema/
+        zip -r -m -ll "fbs-upload/fbs-schema.zip" "fbs-upload/fbs-schema/"
+    - name: Publish the FlatBuffers Schemas
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: Engine Protocol FlatBuffers Schemas
+        path: ./fbs-upload/fbs-schema.zip
+    # - name: Prepare Parser JS Bundle for Upload
+      # run: |
+        # mkdir parser-upload
+        # cp ./target/scala-parser.js parser-upload
     - name: Prepare AWS Session
       run: |
         aws configure --profile s3-upload <<-EOF > /dev/null 2>&1
@@ -180,9 +190,12 @@ jobs:
         us-west-2
         text
         EOF
-    - name: Upload Parser JS Bundle to S3
+    # - name: Upload Parser JS Bundle to S3
+      # run: |
+        # aws s3 sync ./parser-upload s3://packages-luna/parser-js/nightly/`git rev-parse HEAD` --profile s3-upload --acl public-read --delete
+    - name: Upload FlatBuffers Schemas to S3
       run: |
-        aws s3 sync ./parser_upload s3://packages-luna/parser-js/nightly/`git rev-parse HEAD` --profile s3-upload --acl public-read --delete
+        aws s3 sync ./fbs-upload s3://packages-luna/fbs-schema/nightly/`git rev-parse HEAD` --profile s3-upload --acl public-read --delete
     - name: Teardown AWS Session
       run: |
         aws configure --profile s3-upload <<-EOF > /dev/null 2>&1


### PR DESCRIPTION
### Pull Request Description
Such that the IDE team can easily depend on the schemas for the data protocol used by the engine, we upload these to S3 under the relevant commit hash such that they can get at them.

### Important Notes
While we could split them out into a separate repo and use a submodule or subtree, these have significant problems of their own. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/style-guides/scala.md), [Java](https://github.com/luna/enso/blob/master/doc/style-guides/java.md), [Rust](https://github.com/luna/enso/blob/master/doc/style-guides/rust.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/style-guides/haskell.md) style guides as appropriate.
- [x] All code has been tested where possible.

