### PR TITLE
Add a Hack for Unary Minus

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/NegateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/NegateNode.java
@@ -1,0 +1,57 @@
+package org.enso.interpreter.node.expression.builtin.number;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInfo;
+import org.enso.interpreter.Language;
+import org.enso.interpreter.node.expression.builtin.BuiltinRootNode;
+import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.callable.function.FunctionSchema.CallStrategy;
+import org.enso.interpreter.runtime.state.Stateful;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@NodeInfo(shortName = "Number.negate", description = "Negation for numbers.")
+public class NegateNode extends BuiltinRootNode {
+  private NegateNode(Language language) {
+    super(language);
+  }
+
+  /**
+   * Creates a one-argument function wrapping this node.
+   *
+   * @param language the current language instance
+   * @return a function wrapping this node
+   */
+  public static Function makeFunction(Language language) {
+    return Function.fromBuiltinRootNode(
+        new NegateNode(language),
+        CallStrategy.ALWAYS_DIRECT,
+        new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE));
+  }
+
+  /**
+   * Executes this node.
+   *
+   * @param frame current execution frame
+   * @return the result of negating the function argument
+   */
+  @Override
+  public Stateful execute(VirtualFrame frame) {
+    long thisArg =
+        TypesGen.asLong(Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[0]);
+
+    Object state = Function.ArgumentsHelper.getState(frame.getArguments());
+
+    return new Stateful(state, -thisArg);
+  }
+
+  /**
+   * Returns a language-specific name for this node.
+   *
+   * @return the name of this node
+   */
+  @Override
+  public String getName() {
+    return "Number.negate";
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/NumberBinaryOpMethod.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/NumberBinaryOpMethod.java
@@ -27,7 +27,7 @@ public abstract class NumberBinaryOpMethod extends BuiltinRootNode {
    * Executes this node.
    *
    * @param frame current execution frame
-   * @return the result of performing `op` on
+   * @return the result of performing `op` on the operands
    */
   @Override
   public final Stateful execute(VirtualFrame frame) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Builtins.java
@@ -21,6 +21,7 @@ import org.enso.interpreter.node.expression.builtin.number.AddNode;
 import org.enso.interpreter.node.expression.builtin.number.DivideNode;
 import org.enso.interpreter.node.expression.builtin.number.ModNode;
 import org.enso.interpreter.node.expression.builtin.number.MultiplyNode;
+import org.enso.interpreter.node.expression.builtin.number.NegateNode;
 import org.enso.interpreter.node.expression.builtin.number.SubtractNode;
 import org.enso.interpreter.node.expression.builtin.state.GetStateNode;
 import org.enso.interpreter.node.expression.builtin.state.PutStateNode;
@@ -133,6 +134,7 @@ public class Builtins {
     scope.registerMethod(number, "*", MultiplyNode.makeFunction(language));
     scope.registerMethod(number, "/", DivideNode.makeFunction(language));
     scope.registerMethod(number, "%", ModNode.makeFunction(language));
+    scope.registerMethod(number, "negate", NegateNode.makeFunction(language));
 
     scope.registerMethod(state, "get", GetStateNode.makeFunction(language));
     scope.registerMethod(state, "put", PutStateNode.makeFunction(language));

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
@@ -8,23 +8,23 @@ import org.enso.compiler.exception.UnhandledEntity
 import org.enso.interpreter.Constants
 import org.enso.syntax.text.AST
 
+import scala.annotation.tailrec
+
 /**
   * This file contains the functionality that translates from the parser's
   * [[AST]] type to the internal representation used by the compiler.
   *
-  * This representation is currently [[Expression]], but this will change as
-  * [[Core]] becomes implemented. Most function docs will refer to [[Core]]
-  * now, as this will become true soon.
+  * The current internal representation is [[IR]].
   */
 object AstToIr {
   private def getIdentifiedLocation(ast: AST): Option[IdentifiedLocation] =
     ast.location.map(IdentifiedLocation(_, ast.id))
 
   /** Translates a program represented in the parser [[AST]] to the compiler's
-    * [[Core]] internal representation.
+    * [[IR]].
     *
     * @param inputAST the [[AST]] representing the program to translate
-    * @return the [[Core]] representation of `inputAST`
+    * @return the [[IR]] representation of `inputAST`
     */
   def translate(inputAST: AST): Module = {
     inputAST match {
@@ -35,14 +35,14 @@ object AstToIr {
   }
 
   /** Translates an inline program expression represented in the parser [[AST]]
-    * into the compiler's [[Core]] representation.
+    * into the compiler's [[IR]] representation.
     *
     * Inline expressions must _only_ be expressions, and may not contain any
     * type of definition.
     *
     * @param inputAST the [[AST]] representing the expression to translate.
-    * @return the [[Core]] representation of `inputAST` if it is valid,
-    *         otherwise [[None]]
+    * @return the [[IR]] representation of `inputAST` if it is valid, otherwise
+    *         [[None]]
     */
   def translateInline(inputAST: AST): Option[Expression] = {
     inputAST match {
@@ -71,14 +71,14 @@ object AstToIr {
     }
   }
 
-  /** Translate a top-level Enso module into [[Core]].
+  /** Translate a top-level Enso module into [[IR]].
     *
     * @param module the [[AST]] representation of the module to translate
-    * @return the [[Core]] representation of `module`
+    * @return the [[IR]] representation of `module`
     */
   def translateModule(module: AST.Module): Module = {
     module match {
-      case AST.Module(blocks) => {
+      case AST.Module(blocks) =>
         val presentBlocks = blocks.collect {
           case t if t.elem.isDefined => t.elem.get
         }
@@ -102,15 +102,14 @@ object AstToIr {
 
         val statements = nonImportBlocks.map(translateModuleSymbol)
         Module(imports, statements, getIdentifiedLocation(module))
-      }
     }
   }
 
   /** Translates a module-level definition from its [[AST]] representation into
-    * [[Core]].
+    * [[IR]].
     *
     * @param inputAST the definition to be translated
-    * @return the [[Core]] representation of `inputAST`
+    * @return the [[IR]] representation of `inputAST`
     */
   def translateModuleSymbol(inputAST: AST): Module.Scope.Definition = {
     inputAST match {
@@ -159,10 +158,10 @@ object AstToIr {
     }
   }
 
-  /** Translates an arbitrary program expression from [[AST]] into [[Core]].
+  /** Translates an arbitrary program expression from [[AST]] into [[IR]].
     *
     * @param inputAST the expresion to be translated
-    * @return the [[Core]] representation of `inputAST`
+    * @return the [[IR]] representation of `inputAST`
     */
   def translateExpression(inputAST: AST): Expression = {
     inputAST match {
@@ -244,14 +243,14 @@ object AstToIr {
    */
 
   /** Translates a program literal from its [[AST]] representation into
-    * [[Core]].
+    * [[IR]].
     *
     * @param literal the literal to translate
-    * @return the [[Core]] representation of `literal`
+    * @return the [[IR]] representation of `literal`
     */
   def translateLiteral(literal: AST.Literal): Expression = {
     literal match {
-      case AST.Literal.Number(base, number) => {
+      case AST.Literal.Number(base, number) =>
         if (base.isDefined && base.get != "10") {
           Error.Syntax(
             literal,
@@ -260,7 +259,6 @@ object AstToIr {
         } else {
           Literal.Number(number, getIdentifiedLocation(literal))
         }
-      }
       case AST.Literal.Text.any(literal) =>
         literal.shape match {
           case AST.Literal.Text.Line.Raw(segments) =>
@@ -299,9 +297,9 @@ object AstToIr {
   }
 
   /**
-    * Translates a sequence literal into its [[Core]] counterpart.
+    * Translates a sequence literal into its [[IR]] counterpart.
     * @param literal the literal to translate
-    * @return the [[Core]] representation of `literal`
+    * @return the [[IR]] representation of `literal`
     */
   def translateSequenceLiteral(literal: AST.SequenceLiteral): Expression = {
     IR.Application.Literal.Sequence(
@@ -310,13 +308,13 @@ object AstToIr {
     )
   }
 
-  /** Translates an argument definition from [[AST]] into [[Core]].
+  /** Translates an argument definition from [[AST]] into [[IR]].
     *
     * @param arg the argument to translate
     * @param isSuspended `true` if the argument is suspended, otherwise `false`
-    * @return the [[Core]] representation of `arg`
+    * @return the [[IR]] representation of `arg`
     */
-  @scala.annotation.tailrec
+  @tailrec
   def translateArgumentDefinition(
     arg: AST,
     isSuspended: Boolean = false
@@ -366,10 +364,10 @@ object AstToIr {
   }
 
   /** Translates a call-site function argument from its [[AST]] representation
-    * into [[Core]].
+    * into [[IR]].
     *
     * @param arg the argument to translate
-    * @return the [[Core]] representation of `arg`
+    * @return the [[IR]] representation of `arg`
     */
   def translateCallArgument(arg: AST): CallArgument.Specified = arg match {
     case AstView.AssignedArgument(left, right) =>
@@ -407,10 +405,10 @@ object AstToIr {
   }
 
   /** Translates an arbitrary expression that takes the form of a syntactic
-    * application from its [[AST]] representation into [[Core]].
+    * application from its [[AST]] representation into [[IR]].
     *
     * @param callable the callable to translate
-    * @return the [[Core]] representation of `callable`
+    * @return the [[IR]] representation of `callable`
     */
   def translateApplicationLike(callable: AST): Expression = {
     callable match {
@@ -524,10 +522,10 @@ object AstToIr {
   }
 
   /** Translates an arbitrary program identifier from its [[AST]] representation
-    * into [[Core]].
+    * into [[IR]].
     *
     * @param identifier the identifier to translate
-    * @return the [[Core]] representation of `identifier`
+    * @return the [[IR]] representation of `identifier`
     */
   def translateIdent(identifier: AST.Ident): Expression = {
     identifier match {
@@ -559,12 +557,12 @@ object AstToIr {
   }
 
   /** Translates an arbitrary binding operation from its [[AST]] representation
-    * into [[Core]].
+    * into [[IR]].
     *
     * @param location the source location of the binding
     * @param name the name of the binding being assigned to
     * @param expr the expression being assigned to `name`
-    * @return the [[Core]] representation of `expr` being bound to `name`
+    * @return the [[IR]] representation of `expr` being bound to `name`
     */
   def translateBinding(
     location: Option[IdentifiedLocation],
@@ -582,10 +580,10 @@ object AstToIr {
   }
 
   /** Translates the branch of a case expression from its [[AST]] representation
-    * into [[Core]].
+    * into [[IR]].
     *
     * @param branch the case branch to translate
-    * @return the [[Core]] representation of `branch`
+    * @return the [[IR]] representation of `branch`
     */
   def translateCaseBranch(branch: AST): Case.Branch = {
     branch match {
@@ -606,10 +604,10 @@ object AstToIr {
   }
 
   /** Translates the fallback branch of a case expression from its [[AST]]
-    * representation into [[Core]].
+    * representation into [[IR]].
     *
     * @param branch the fallback branch to translate
-    * @return the [[Core]] representation of `branch`
+    * @return the [[IR]] representation of `branch`
     */
   def translateFallbackBranch(branch: AST): Function = {
     branch match {
@@ -625,12 +623,12 @@ object AstToIr {
   }
 
   /** Translates an arbitrary grouped piece of syntax from its [[AST]]
-    * representation into [[Core]].
+    * representation into [[IR]].
     *
     * It is currently an error to have an empty group.
     *
     * @param group the group to translate
-    * @return the [[Core]] representation of the contents of `group`
+    * @return the [[IR]] representation of the contents of `group`
     */
   def translateGroup(group: AST.Group): Expression = {
     group.body match {
@@ -640,10 +638,10 @@ object AstToIr {
   }
 
   /** Translates an import statement from its [[AST]] representation into
-    * [[Core]].
+    * [[IR]].
     *
     * @param imp the import to translate
-    * @return the [[Core]] representation of `imp`
+    * @return the [[IR]] representation of `imp`
     */
   def translateImport(imp: AST.Import): Module.Scope.Import.Module = {
     Module.Scope.Import.Module(
@@ -653,10 +651,10 @@ object AstToIr {
   }
 
   /** Translates an arbitrary invalid expression from the [[AST]] representation
-    * of the program into its [[Core]] representation.
+    * of the program into its [[IR]] representation.
     *
     * @param invalid the invalid entity to translate
-    * @return the [[Core]] representation of `invalid`
+    * @return the [[IR]] representation of `invalid`
     */
   def translateInvalid(invalid: AST.Invalid): Expression = {
     invalid match {
@@ -685,14 +683,14 @@ object AstToIr {
     }
   }
 
-  /** Translates a comment from its [[AST]] representation into its [[Core]]
+  /** Translates a comment from its [[AST]] representation into its [[IR]]
     * representation.
     *
     * Currently this only supports documentation comments, and not standarc
     * types of comments as they can't currently be represented.
     *
     * @param comment the comment to transform
-    * @return the [[Core]] representation of `comment`
+    * @return the [[IR]] representation of `comment`
     */
   def translateComment(comment: AST): Expression = {
     comment match {

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
@@ -165,6 +165,7 @@ object AstToIr {
     */
   def translateExpression(inputAST: AST): Expression = {
     inputAST match {
+      case AstView.UnaryMinus(number) => translateExpression(number)
       case AstView
             .SuspendedBlock(name, block @ AstView.Block(lines, lastLine)) =>
         Expression.Binding(

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
@@ -165,7 +165,24 @@ object AstToIr {
     */
   def translateExpression(inputAST: AST): Expression = {
     inputAST match {
-      case AstView.UnaryMinus(number) => translateExpression(number)
+      case AstView.UnaryMinus(expression) =>
+        expression match {
+          case AST.Literal.Number(base, number) =>
+            translateExpression(AST.Literal.Number(base, s"-$number"))
+          case _ =>
+            IR.Application.Prefix(
+              IR.Name.Literal("negate", None),
+              List(
+                IR.CallArgument.Specified(
+                  None,
+                  translateExpression(expression),
+                  getIdentifiedLocation(expression),
+                )
+              ),
+              hasDefaultsSuspended = false,
+              getIdentifiedLocation(expression)
+            )
+        }
       case AstView
             .SuspendedBlock(name, block @ AstView.Block(lines, lastLine)) =>
         Expression.Binding(

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
@@ -712,13 +712,13 @@ object AstView {
       * well for now. This will be improved with the new parser.
       *
       * @param ast the structure to try and match on
-      * @return the negated number
+      * @return the negated expression
       */
     def unapply(ast: AST): Option[AST] = ast match {
       case MaybeParensed(
-          AST.App.Section.Right(AST.Ident.Opr("-"), AST.Number(base, num))
+          AST.App.Section.Right(AST.Ident.Opr("-"), expression)
           ) =>
-        Some(AST.Number(base, s"$minusSymbol$num"))
+        Some(expression)
       case _ => None
     }
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
@@ -702,4 +702,24 @@ object AstView {
       case _                      => None
     }
   }
+
+  object UnaryMinus {
+    def minusSymbol: String = "-"
+
+    /** Matches a unary minus.
+      *
+      * It should be noted that this is a hack that matches a spaced section as
+      * well for now. This will be improved with the new parser.
+      *
+      * @param ast the structure to try and match on
+      * @return the negated number
+      */
+    def unapply(ast: AST): Option[AST] = ast match {
+      case MaybeParensed(
+          AST.App.Section.Right(AST.Ident.Opr("-"), AST.Number(base, num))
+          ) =>
+        Some(AST.Number(base, s"$minusSymbol$num"))
+      case _ => None
+    }
+  }
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
@@ -199,4 +199,26 @@ class AstToIrTest extends CompilerTest {
       binding.name shouldBe an[IR.Name.Blank]
     }
   }
+
+  "AST translation of unary minus" should {
+    "work when parenthesised" in {
+      val ir =
+        """
+          |(-1)
+          |""".stripMargin.toIrExpression.get
+
+      ir shouldBe an[IR.Literal.Number]
+      ir.asInstanceOf[IR.Literal.Number].value shouldEqual "-1"
+    }
+
+    "work when not parenthesised" in {
+      val ir =
+        """
+          |-100
+          |""".stripMargin.toIrExpression.get
+
+      ir shouldBe an[IR.Literal.Number]
+      ir.asInstanceOf[IR.Literal.Number].value shouldEqual "-100"
+    }
+  }
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
@@ -3,6 +3,8 @@ package org.enso.compiler.test.codegen
 import org.enso.compiler.core.IR
 import org.enso.compiler.test.CompilerTest
 
+import scala.annotation.unused
+
 class AstToIrTest extends CompilerTest {
 
   "AST translation of lambda definitions" should {
@@ -219,6 +221,22 @@ class AstToIrTest extends CompilerTest {
 
       ir shouldBe an[IR.Literal.Number]
       ir.asInstanceOf[IR.Literal.Number].value shouldEqual "-100"
+    }
+
+    "work on non-literals" in {
+      val ir =
+        """
+          |-foo
+          |""".stripMargin.toIrExpression.get
+
+      ir shouldBe an[IR.Application.Prefix]
+
+      val fn = ir.asInstanceOf[IR.Application.Prefix]
+      fn.function shouldEqual IR.Name.Literal("negate", None)
+
+      val fooArg = fn.arguments.head.asInstanceOf[IR.CallArgument.Specified]
+      fooArg.value shouldBe an[IR.Name.Literal]
+      fooArg.value.asInstanceOf[IR.Name.Literal].name shouldEqual "foo"
     }
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaTest.scala
@@ -271,7 +271,7 @@ class LambdaShorthandToLambdaTest extends CompilerTest {
 
       val ir =
         """
-          |(- _)
+          |(+ _)
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/SectionsToBinOpTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/SectionsToBinOpTest.scala
@@ -133,7 +133,7 @@ class SectionsToBinOpTest extends CompilerTest {
 
       val ir =
         """
-          |(- _)
+          |(+ _)
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
@@ -184,4 +184,23 @@ class CodeLocationsTest extends InterpreterTest {
     instrumenter.assertNodeExists(19, 7, classOf[ApplicationNode]) // 31 * 42
     eval(code)
   }
+
+  "Code locations" should "be correct for negated literals" in
+  withLocationsInstrumenter { instrumenter =>
+    val code = "main = (-1)"
+    instrumenter.assertNodeExists(8, 2, classOf[IntegerLiteralNode])
+    eval(code)
+  }
+
+  "Code locations" should "be correct for negated expressions" in
+  withLocationsInstrumenter { instrumenter =>
+    val code =
+      """
+        |main =
+        |    f = 1
+        |    -f
+        |""".stripMargin
+    instrumenter.assertNodeExists(22, 2, classOf[ApplicationNode])
+    eval(code)
+  }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/LambdaShorthandArgsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/LambdaShorthandArgsTest.scala
@@ -127,11 +127,11 @@ class LambdaShorthandArgsTest extends InterpreterTest {
     val code =
       """
         |main =
-        |    f = (- _)
+        |    f = (+ _)
         |    f 10 5
         |""".stripMargin
 
-    eval(code) shouldEqual -5
+    eval(code) shouldEqual 15
   }
 
   subject should "work properly with vector literals" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/OperatorSectionsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/OperatorSectionsTest.scala
@@ -30,10 +30,10 @@ class OperatorSectionsTest extends InterpreterTest {
     val code =
       """
         |main =
-        |    f = (- 10)
-        |    f 5
+        |    f = (/ 10)
+        |    f 20
         |""".stripMargin
 
-    eval(code) shouldEqual -5
+    eval(code) shouldEqual 2
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/SimpleArithmeticTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/SimpleArithmeticTest.scala
@@ -24,10 +24,12 @@ class SimpleArithmeticTest extends InterpreterTest {
   }
 
   "-1" should "equal -1" in {
+    pending
     eval("main = -1") shouldEqual -1
   }
 
   "1 + -1" should "equal 0" in {
+    pending
     eval("main = 1 + -1") shouldEqual 0
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/SimpleArithmeticTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/SimpleArithmeticTest.scala
@@ -24,12 +24,21 @@ class SimpleArithmeticTest extends InterpreterTest {
   }
 
   "-1" should "equal -1" in {
-    pending
     eval("main = -1") shouldEqual -1
   }
 
   "1 + -1" should "equal 0" in {
-    pending
     eval("main = 1 + -1") shouldEqual 0
+  }
+
+  "negation of expressions" should "work" in {
+    val code =
+      """
+        |main =
+        |    expr = (10 * 3+2) - 1
+        |    -expr
+        |""".stripMargin
+
+    eval(code) shouldEqual -49
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/SimpleArithmeticTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/SimpleArithmeticTest.scala
@@ -22,4 +22,12 @@ class SimpleArithmeticTest extends InterpreterTest {
   "2 * 2 / 2" should "equal 2" in {
     eval("main = 2 * 2 / 2") shouldEqual 2
   }
+
+  "-1" should "equal -1" in {
+    eval("main = -1") shouldEqual -1
+  }
+
+  "1 + -1" should "equal 0" in {
+    eval("main = 1 + -1") shouldEqual 0
+  }
 }


### PR DESCRIPTION
### Pull Request Description
This PR adds a hacky bit of support for unary minus as a right section of `-`. This does mean that we _can't_ right section `-`, but for now this is the best we can do.

Closes #717.

### Important Notes
Users will be unable to write right sections of `-` for now. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/doc/style-guides/scala.md), [Java](https://github.com/luna/enso/blob/master/doc/style-guides/java.md), [Rust](https://github.com/luna/enso/blob/master/doc/style-guides/rust.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/style-guides/haskell.md) style guides as appropriate.
- [x] All code has been tested where possible.

