### PR TITLE
Cancel Stale CI Runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Cancel Stale Runs
         uses: khan/pull-request-workflow-cancel@1.0.0
         with:
-          workflows: "ci.yml"
+          workflows: "ci.yaml"
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: actions/checkout@v2
@@ -112,7 +112,7 @@ jobs:
       - name: Cancel Stale Runs
         uses: khan/pull-request-workflow-cancel@1.0.0
         with:
-          workflows: "ci.yml"
+          workflows: "ci.yaml"
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - name: Checkout (PR)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,12 @@ jobs:
         os: [windows-latest, macOS-latest, ubuntu-latest]
       fail-fast: false
     steps:
+      - name: Cancel Stale Runs
+        uses: khan/pull-request-workflow-cancel@1.0.0
+        with:
+          workflows: "ci.yml"
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: actions/checkout@v2
       - name: Setup conda
         uses: s-weigand/setup-conda@v1
@@ -103,6 +109,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Cancel Stale Runs
+        uses: khan/pull-request-workflow-cancel@1.0.0
+        with:
+          workflows: "ci.yml"
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - name: Checkout (PR)
         uses: actions/checkout@v2
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,12 +35,12 @@ jobs:
         os: [windows-latest, macOS-latest, ubuntu-latest]
       fail-fast: false
     steps:
-      - name: Cancel Stale Runs
-        uses: khan/pull-request-workflow-cancel@1.0.0
-        with:
-          workflows: "ci.yaml"
-        env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      # - name: Cancel Stale Runs
+        # uses: khan/pull-request-workflow-cancel@1.0.0
+        # with:
+          # workflows: "ci.yaml"
+        # env:
+          # GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: actions/checkout@v2
       - name: Setup conda
         uses: s-weigand/setup-conda@v1
@@ -109,12 +109,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Cancel Stale Runs
-        uses: khan/pull-request-workflow-cancel@1.0.0
-        with:
-          workflows: "ci.yaml"
-        env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      # - name: Cancel Stale Runs
+        # uses: khan/pull-request-workflow-cancel@1.0.0
+        # with:
+          # workflows: "ci.yaml"
+        # env:
+          # GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - name: Checkout (PR)
         uses: actions/checkout@v2
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: Enso CI
 
 on:
   push:
-    branches: [ master, release/* ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, release/* ]
+    branches: [ master ]
 
 env:
   # Please ensure that this is in sync with graalAPIVersion in build.sbt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: Enso CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release/* ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release/* ]
 
 env:
   # Please ensure that this is in sync with graalAPIVersion in build.sbt


### PR DESCRIPTION
### Pull Request Description
We keep running into the limit of MacOS runners for the project due to stale runs still trying to complete on CI. This PR adds an action to our workflows that ensures that stale runs are cancelled when a new run starts. 

### Important Notes

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/docs/style-guide/scala.md) and [Java](https://github.com/luna/enso/blob/master/docs/style-guide/java.md) style guides.
- [x] All code has been tested where possible.
