### PR TITLE
Add workflow to update `luna.github.io` on docs push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,8 +18,8 @@ jobs:
       run: git config --global user.name "GitHub Actions"
     - name: Fetch
       run: git fetch
-    - name: Checkout gh-pages
-      run: git checkout gh-pages 
+    - name: Checkout gh-pages-sources
+      run: git checkout gh-pages-sources 
     - name: Checkout docs in master
       run: git checkout master -- docs
     - name: Stage changed files
@@ -27,5 +27,5 @@ jobs:
     - name: Commit changes
       run: git commit -m "Updating docs"
     - name: Push to gh-pages
-      run: git push origin gh-pages
+      run: git push origin gh-pages-sources
     

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Enso dev docs
+name: Publish Enso Dev Docs
 
 on:
   push:
@@ -12,20 +12,28 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
     - uses: actions/checkout@v2
+      with:
+        repository: 'luna/luna.github.io'
+        ref: 'sources'
+        token: ${{ secrets.Enso_PAT }}
     - name: set identity email
       run: git config --global user.email "actions@github.com"
     - name: set identity name
       run: git config --global user.name "GitHub Actions"
-    - name: Fetch
-      run: git fetch
-    - name: Checkout gh-pages-sources
-      run: git checkout gh-pages-sources 
-    - name: Checkout docs in master
-      run: git checkout master -- docs
-    - name: Stage changed files
-      run: git add . 
-    - name: Commit changes
-      run: git commit -m "Updating docs"
-    - name: Push to gh-pages
-      run: git push origin gh-pages-sources
-    
+    - name: Checkout submodules
+      run: git submodule update --init 
+    - name: Update submodules
+      id: status
+      run: |
+        git submodule update --init 
+        git submodule update --remote --merge
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "::set-output name=has_changes::1"
+        fi
+    - name: Push changes
+      run: |
+        git add .
+        git commit -m "Update submodules"
+        git push origin sources
+      if: steps.status.outputs.has_changes == '1'
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Enso dev docs
+
+on:
+  push:
+    branches: 
+      - master
+    paths:
+      - 'docs/**'
+    
+jobs:
+  checkout:
+    runs-on: ubuntu-16.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: set identity email
+      run: git config --global user.email "actions@github.com"
+    - name: set identity name
+      run: git config --global user.name "GitHub Actions"
+    - name: Fetch
+      run: git fetch
+    - name: Checkout gh-pages
+      run: git checkout gh-pages 
+    - name: Checkout docs in master
+      run: git checkout master -- docs
+    - name: Stage changed files
+      run: git add . 
+    - name: Commit changes
+      run: git commit -m "Updating docs"
+    - name: Push to gh-pages
+      run: git push origin gh-pages
+    

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Publish Enso Dev Docs
+name: Publish Developer Docs
 
 on:
   push:
@@ -36,4 +36,3 @@ jobs:
         git commit -m "Update submodules"
         git push origin sources
       if: steps.status.outputs.has_changes == '1'
-

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
     
 jobs:
   checkout:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
### Pull Request Description
This workflow updates the submodules in [luna.github.io](https://github.com/luna/luna.github.io) when there is a push to `docs`. The updated submodules are then pushed to the repo, [triggering a build of the site](https://github.com/luna/luna.github.io/actions/runs/108210889), causing the latest docs to be published. 

### Important Notes
- [x] Requires a PAT with `public_repo` scope, currently in the workflow it's looking for `ENSO_PAT`, either add a secret with that name or substitute for an existing appropriate secret. The default `github.token` is NOT sufficient. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/docs/style-guide/scala.md) and [Java](https://github.com/luna/enso/blob/master/docs/style-guide/java.md) style guides.
- [x] All code has been tested where possible.
