### PR TITLE
Add Syntax Sugar for Defining Functions and Methods

### DIFF
--- a/docs/syntax/README.md
+++ b/docs/syntax/README.md
@@ -38,7 +38,7 @@ The various components of Enso's syntax are described below:
 - [**Top-Level Syntax:**](./top-level.md) The syntax at the top-level of an Enso
   file.
 - [**Functions:**](./functions.md) The syntax for writing functions in Enso.
-- [**Function Arguments:**](./function-arguments.ms) The syntax for function
+- [**Function Arguments:**](./function-arguments.md) The syntax for function
   arguments in Enso.
 - [**Field Access:**](./projections.md) The syntax for working with fields of
   data types in Enso.

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/MethodNames.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/MethodNames.java
@@ -23,5 +23,7 @@ public class MethodNames {
 
   public static class Function {
     public static final String EQUALS = "equals";
+    public static final String GET_SOURCE_START = "get_source_start";
+    public static final String GET_SOURCE_LENGTH = "get_source_length";
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ClosureRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ClosureRootNode.java
@@ -84,9 +84,4 @@ public class ClosureRootNode extends EnsoRootNode {
   public String getQualifiedName() {
     return qualifiedName;
   }
-
-  @Override
-  protected boolean isInstrumentable() {
-    return true;
-  }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ClosureRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ClosureRootNode.java
@@ -18,7 +18,7 @@ import org.enso.interpreter.runtime.state.Stateful;
  * determined by the API provided by Truffle.
  */
 @ReportPolymorphism
-@NodeInfo(shortName = "Closure", description = "A root node for Enso closures")
+@NodeInfo(shortName = "Closure", description = "A root node for Enso closures.")
 public class ClosureRootNode extends EnsoRootNode {
 
   @Child private ExpressionNode body;
@@ -83,5 +83,10 @@ public class ClosureRootNode extends EnsoRootNode {
   @Override
   public String getQualifiedName() {
     return qualifiedName;
+  }
+
+  @Override
+  protected boolean isInstrumentable() {
+    return true;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
@@ -216,9 +216,26 @@ public final class Function implements TruffleObject {
   @ExportMessage
   Object invokeMember(String member, Object... args)
       throws ArityException, UnknownIdentifierException, UnsupportedTypeException {
-    if (member.equals(MethodNames.Function.EQUALS)) {
-      Object that = Types.extractArguments(args, Object.class);
-      return this == that;
+    switch (member) {
+      case MethodNames.Function.EQUALS:
+        Object that = Types.extractArguments(args, Object.class);
+        return this == that;
+      case MethodNames.Function.GET_SOURCE_START:
+        {
+          SourceSection sect = getSourceSection();
+          if (sect == null) {
+            return null;
+          }
+          return sect.getCharIndex();
+        }
+      case MethodNames.Function.GET_SOURCE_LENGTH:
+        {
+          SourceSection sect = getSourceSection();
+          if (sect == null) {
+            return null;
+          }
+          return sect.getCharLength();
+        }
     }
     throw UnknownIdentifierException.create(member);
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -48,8 +48,8 @@ class Compiler(
     * they nevertheless exist.
     */
   val compilerPhaseOrdering: List[IRPass] = List(
-    GenerateMethodBodies,
     FunctionBinding,
+    GenerateMethodBodies,
     SectionsToBinOp,
     OperatorToFunction,
     LambdaShorthandToLambda,

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -49,6 +49,7 @@ class Compiler(
     */
   val compilerPhaseOrdering: List[IRPass] = List(
     GenerateMethodBodies,
+    FunctionBinding,
     SectionsToBinOp,
     OperatorToFunction,
     LambdaShorthandToLambda,

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
@@ -181,6 +181,9 @@ object AstToIr {
       .getOrElse(maybeParensedInput)
 
     inputAST match {
+      case AST.Def(consName, _, _) =>
+        IR.Error
+          .Syntax(inputAST, IR.Error.Syntax.TypeDefinedInline(consName.name))
       case AstView.UnaryMinus(expression) =>
         expression match {
           case AST.Literal.Number(base, number) =>
@@ -224,6 +227,11 @@ object AstToIr {
         )
       case AstView.Assignment(name, expr) =>
         translateBinding(getIdentifiedLocation(inputAST), name, expr)
+      case AstView.MethodDefinition(_, name, _, _) =>
+        IR.Error.Syntax(
+          inputAST,
+          IR.Error.Syntax.MethodDefinedInline(name.asInstanceOf[AST.Ident].name)
+        )
       case AstView.MethodCall(target, name, args) =>
         val (validArguments, hasDefaultsSuspended) =
           calculateDefaultsSuspension(args)

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
@@ -148,22 +148,13 @@ object AstToIr {
 
         val nameStr = name match { case AST.Ident.Var.any(name) => name }
 
-        if (args.isEmpty) {
-          Module.Scope.Definition.Method.Explicit(
-            Name.Literal(path, pathLoc.map(IdentifiedLocation(_))),
-            Name.Literal(nameStr.name, getIdentifiedLocation(nameStr)),
-            translateExpression(definition),
-            getIdentifiedLocation(inputAST)
-          )
-        } else {
-          Module.Scope.Definition.Method.Binding(
-            Name.Literal(path, pathLoc.map(IdentifiedLocation(_))),
-            Name.Literal(nameStr.name, getIdentifiedLocation(nameStr)),
-            args.map(translateArgumentDefinition(_)),
-            translateExpression(definition),
-            getIdentifiedLocation(inputAST)
-          )
-        }
+        Module.Scope.Definition.Method.Binding(
+          Name.Literal(path, pathLoc.map(IdentifiedLocation(_))),
+          Name.Literal(nameStr.name, getIdentifiedLocation(nameStr)),
+          args.map(translateArgumentDefinition(_)),
+          translateExpression(definition),
+          getIdentifiedLocation(inputAST)
+        )
 
       case _ =>
         throw new UnhandledEntity(inputAST, "translateModuleSymbol")

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
@@ -461,8 +461,8 @@ object AstView {
       * arbitrary program expression.
       *
       * @param ast the structure to try and match on
-      * @return the path segments of the type reference, the function name, and
-      *         the bound expression
+      * @return the path segments of the type reference, the function name, the
+     *          arguments to the method, and the bound expression
       */
     def unapply(ast: AST): Option[(List[AST], AST, List[AST], AST)] = {
       ast match {

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
@@ -2,10 +2,8 @@ package org.enso.compiler.codegen
 
 import org.enso.data
 import org.enso.data.List1
-import org.enso.syntax.text.{AST, Debug}
+import org.enso.syntax.text.AST
 import org.enso.syntax.text.AST.Ident.{Opr, Var}
-
-import scala.annotation.unused
 
 /** This object contains view patterns that allow matching on the parser [[AST]]
   * for more sophisticated constructs.
@@ -462,7 +460,7 @@ object AstView {
       *
       * @param ast the structure to try and match on
       * @return the path segments of the type reference, the function name, the
-     *          arguments to the method, and the bound expression
+      *         arguments to the method, and the bound expression
       */
     def unapply(ast: AST): Option[(List[AST], AST, List[AST], AST)] = {
       ast match {

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IRToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IRToTruffle.scala
@@ -233,7 +233,7 @@ class IRToTruffle(
           )
       }
 
-      // TODO [AA] Remove this
+      // TODO [AA] Remove this and run bench
       funNode.setTail(methodFunIsTail)
 
       val function = new RuntimeFunction(

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IRToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IRToTruffle.scala
@@ -221,7 +221,7 @@ class IRToTruffle(
           expressionProcessor.processFunctionBody(
             fn.arguments,
             fn.body,
-            fn.location,
+            methodDef.location,
             Some(methodDef.methodName.name)
           )
         case _ =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IRToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IRToTruffle.scala
@@ -216,9 +216,6 @@ class IRToTruffle(
         dataflowInfo
       )
 
-      val methodFunIsTail = methodDef.body
-        .unsafeGetMetadata(TailCall, "Method body missing tail call info.")
-
       val funNode = methodDef.body match {
         case fn: IR.Function =>
           expressionProcessor.processFunctionBody(
@@ -232,9 +229,6 @@ class IRToTruffle(
             "Method bodies must be functions at the point of codegen."
           )
       }
-
-      // TODO [AA] Remove this and run bench
-      funNode.setTail(methodFunIsTail)
 
       val function = new RuntimeFunction(
         funNode.getCallTarget,
@@ -607,21 +601,15 @@ class IRToTruffle(
         case Error.InvalidIR(_, _, _) =>
           throw new CompilerError("Unexpected Invalid IR during codegen.")
         case err: Error.Syntax =>
-          context.getBuiltins
-            .syntaxError()
-            .newInstance(err.message)
+          context.getBuiltins.syntaxError().newInstance(err.message)
         case err: Error.Redefined.Binding =>
-          context.getBuiltins
-            .compileError()
-            .newInstance(err.message)
+          context.getBuiltins.compileError().newInstance(err.message)
         case err: Error.Redefined.Method =>
-          context.getBuiltins
-            .compileError()
-            .newInstance(err.message)
+          context.getBuiltins.compileError().newInstance(err.message)
         case err: Error.Redefined.Atom =>
-          context.getBuiltins
-            .compileError()
-            .newInstance(err.message)
+          context.getBuiltins.compileError().newInstance(err.message)
+        case err: Error.Redefined.ThisArg =>
+          context.getBuiltins.compileError().newInstance(err.message)
       }
       setLocation(ErrorNode.build(payload), error.location)
     }

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IRToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IRToTruffle.scala
@@ -233,6 +233,7 @@ class IRToTruffle(
           )
       }
 
+      // TODO [AA] Remove this
       funNode.setTail(methodFunIsTail)
 
       val function = new RuntimeFunction(

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -479,6 +479,7 @@ object IR {
           override def children: List[IR] = name :: arguments
         }
 
+        /** A trait representing method definitions in Enso. */
         sealed trait Method extends Definition {
           val typeName: IR.Name
           val methodName: IR.Name

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -2899,17 +2899,17 @@ object IR {
   }
   object Diagnostic {
 
-    /** Represents the various kinds of errors in the IR. */
+    /** Represents the various kinds of diagnostics in the IR. */
     sealed trait Kind
     object Kind {
 
-      /** Errors that should be reported during the static compilation phase of
-        * execution.
+      /** Diagnostics that should be reported during the static compilation
+        * phase of execution.
         */
       sealed trait Static extends Kind
 
-      /** Errors that should remain at runtime for display during interactive
-        * execution.
+      /** Diagnostics that should remain at runtime for display during
+        * interactive execution.
         */
       sealed trait Interactive extends Kind
     }
@@ -3159,6 +3159,8 @@ object IR {
       */
     sealed trait Redefined extends Error
     object Redefined {
+
+      // TODO [AA] An error for redefining `this` that blocks the whole method.
 
       /** An error representing the redefinition of a method in a given module.
         * This is also known as a method overload.

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -3160,7 +3160,50 @@ object IR {
     sealed trait Redefined extends Error
     object Redefined {
 
-      // TODO [AA] An error for redefining `this` that blocks the whole method.
+      /** An error representing the redefinition or incorrect positioning of
+        * the `this` argument to methods.
+        *
+        * @param location the source location of the error
+        * @param passData the pass metadata for this node
+        * @param diagnostics compiler diagnostics associated with the node
+        */
+      sealed case class ThisArg(
+        override val location: Option[IdentifiedLocation],
+        override val passData: MetadataStorage      = MetadataStorage(),
+        override val diagnostics: DiagnosticStorage = DiagnosticStorage()
+      ) extends Redefined
+          with Diagnostic.Kind.Interactive
+          with IRKind.Primitive {
+        override protected var id: Identifier = randomId
+
+        /** Creates a copy of `this`.
+          *
+          * @param location the source location of the error
+          * @param passData the pass metadata for this node
+          * @param diagnostics compiler diagnostics associated with the node
+          * @param id the node's identifier
+          * @return a copy of `this`, with the specified values updated
+          */
+        def copy(
+          location: Option[IdentifiedLocation],
+          passData: MetadataStorage      = passData,
+          diagnostics: DiagnosticStorage = diagnostics,
+          id: Identifier                 = id
+        ): ThisArg = {
+          val res = ThisArg(location, passData, diagnostics)
+          res.id = id
+          res
+        }
+
+        override def mapExpressions(fn: Expression => Expression): ThisArg =
+          this
+
+        override def message: String =
+          "Methods must have only one definition of the `this` argument, and " +
+          "it must be the first."
+
+        override def children: List[IR] = List()
+      }
 
       /** An error representing the redefinition of a method in a given module.
         * This is also known as a method overload.

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -3064,6 +3064,18 @@ object IR {
           s"Syntax is not supported yet: $syntaxName."
       }
 
+      case class MethodDefinedInline(methodName: String) extends Reason {
+        override def explanation: String =
+          s"Cannot define $methodName, methods are not supported in the " +
+          s"inline flow."
+      }
+
+      case class TypeDefinedInline(typeName: String) extends Reason {
+        override def explanation: String =
+          s"Cannot define $typeName, type definitions are not supported " +
+          s"in the inline flow."
+      }
+
       case object EmptyParentheses extends Reason {
         override def explanation: String = "Parentheses can't be empty."
       }

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -41,6 +41,13 @@ sealed trait IR {
   /** The source location that the node corresponds to. */
   val location: Option[IdentifiedLocation]
 
+  /** Sets the location for an IR node.
+    *
+    * @param location the new location for the IR node
+    * @return the IR node with its location set to `location`
+    */
+  def setLocation(location: Option[IdentifiedLocation]): IR
+
   /** Gets the external identifier from an IR node, if it is present.
     *
     * @return the external identifier for this IR node
@@ -175,6 +182,9 @@ object IR {
       res
     }
 
+    override def setLocation(location: Option[IdentifiedLocation]): Empty =
+      copy(location = location)
+
     override def mapExpressions(fn: Expression => Expression): Empty = this
 
     override def toString: String =
@@ -239,6 +249,9 @@ object IR {
       res
     }
 
+    override def setLocation(location: Option[IdentifiedLocation]): Module =
+      copy(location = location)
+
     override def mapExpressions(fn: Expression => Expression): Module = {
       copy(
         imports  = imports.map(_.mapExpressions(fn)),
@@ -274,13 +287,15 @@ object IR {
       * module scope
       */
     sealed trait Scope extends IR {
-      override def mapExpressions(fn: Expression => Expression): Scope
+      override def mapExpressions(fn: Expression => Expression):      Scope
+      override def setLocation(location: Option[IdentifiedLocation]): Scope
     }
     object Scope {
 
       /** Module-level import statements. */
       sealed trait Import extends Scope {
-        override def mapExpressions(fn: Expression => Expression): Import
+        override def mapExpressions(fn: Expression => Expression):      Import
+        override def setLocation(location: Option[IdentifiedLocation]): Import
       }
 
       object Import {
@@ -321,6 +336,11 @@ object IR {
             res.id = id
             res
           }
+
+          override def setLocation(
+            location: Option[IdentifiedLocation]
+          ): Module =
+            copy(location = location)
 
           override def mapExpressions(
             fn: Expression => Expression
@@ -380,7 +400,7 @@ object IR {
             * @return a copy of `this`, updated with the specified values
             */
           def copy(
-            entity: Polyglot.Entity,
+            entity: Polyglot.Entity              = entity,
             location: Option[IdentifiedLocation] = location,
             passData: MetadataStorage            = passData,
             diagnostics: DiagnosticStorage       = diagnostics,
@@ -391,6 +411,10 @@ object IR {
             res.id = id
             res
           }
+
+          override def setLocation(
+            location: Option[IdentifiedLocation]
+          ): Polyglot = copy(location = location)
 
           override def mapExpressions(fn: Expression => Expression): Polyglot =
             this
@@ -413,6 +437,9 @@ object IR {
       /** A representation of top-level definitions. */
       sealed trait Definition extends Scope {
         override def mapExpressions(fn: Expression => Expression): Definition
+        override def setLocation(
+          location: Option[IdentifiedLocation]
+        ): Definition
       }
       object Definition {
 
@@ -457,6 +484,9 @@ object IR {
             res
           }
 
+          override def setLocation(location: Option[IdentifiedLocation]): Atom =
+            copy(location = location)
+
           override def mapExpressions(fn: Expression => Expression): Atom = {
             copy(
               name      = name.mapExpressions(fn),
@@ -485,7 +515,8 @@ object IR {
           val methodName: IR.Name
           val body: Expression
 
-          override def mapExpressions(fn: Expression => Expression): Method
+          override def setLocation(location: Option[IdentifiedLocation]): Method
+          override def mapExpressions(fn: Expression => Expression):      Method
         }
         object Method {
 
@@ -543,6 +574,11 @@ object IR {
               res.id = id
               res
             }
+
+            override def setLocation(
+              location: Option[IdentifiedLocation]
+            ): Explicit =
+              copy(location = location)
 
             override def mapExpressions(
               fn: Expression => Expression
@@ -607,7 +643,7 @@ object IR {
               * @param passData the pass metadata associated with this node
               * @param diagnostics compiler diagnostics for this node
               * @param id the identifier for the new node
-              * @return a copy of `this`, updated with the specified values`
+              * @return a copy of `this`, updated with the specified values
               */
             def copy(
               typeName: IR.Name                      = typeName,
@@ -631,6 +667,11 @@ object IR {
               res.id = id
               res
             }
+
+            override def setLocation(
+              location: Option[IdentifiedLocation]
+            ): Binding =
+              copy(location = location)
 
             override def mapExpressions(
               fn: Expression => Expression
@@ -685,7 +726,8 @@ object IR {
       }
     }
 
-    override def mapExpressions(fn: Expression => Expression): Expression
+    override def mapExpressions(fn: Expression => Expression):      Expression
+    override def setLocation(location: Option[IdentifiedLocation]): Expression
   }
   object Expression {
 
@@ -741,6 +783,9 @@ object IR {
         res.id = id
         res
       }
+
+      override def setLocation(location: Option[IdentifiedLocation]): Block =
+        copy(location = location)
 
       override def mapExpressions(fn: Expression => Expression): Block = {
         copy(
@@ -809,6 +854,9 @@ object IR {
         res
       }
 
+      override def setLocation(location: Option[IdentifiedLocation]): Binding =
+        copy(location = location)
+
       override def mapExpressions(fn: Expression => Expression): Binding = {
         copy(name = name.mapExpressions(fn), expression = fn(expression))
       }
@@ -833,7 +881,8 @@ object IR {
 
   /** Enso literals. */
   sealed trait Literal extends Expression with IRKind.Primitive {
-    override def mapExpressions(fn: Expression => Expression): Literal
+    override def mapExpressions(fn: Expression => Expression):      Literal
+    override def setLocation(location: Option[IdentifiedLocation]): Literal
   }
   object Literal {
 
@@ -872,6 +921,9 @@ object IR {
         res.id = id
         res
       }
+
+      override def setLocation(location: Option[IdentifiedLocation]): Number =
+        copy(location = location)
 
       override def mapExpressions(fn: Expression => Expression): Number = this
 
@@ -924,6 +976,9 @@ object IR {
         res
       }
 
+      override def setLocation(location: Option[IdentifiedLocation]): Text =
+        copy(location = location)
+
       override def mapExpressions(fn: Expression => Expression): Text = this
 
       override def toString: String =
@@ -947,7 +1002,8 @@ object IR {
   sealed trait Name extends Expression with IRKind.Primitive {
     val name: String
 
-    override def mapExpressions(fn: Expression => Expression): Name
+    override def mapExpressions(fn: Expression => Expression):      Name
+    override def setLocation(location: Option[IdentifiedLocation]): Name
   }
   object Name {
 
@@ -966,6 +1022,14 @@ object IR {
       override val name: String             = "_"
       override protected var id: Identifier = randomId
 
+      /** Creates a copy of `this`.`
+        *
+        * @param location the soure location that the node corresponds to.
+        * @param passData the pass metadata associated with this node
+        * @param diagnostics compiler diagnostics for this node
+        * @param id the identifier for the node
+        * @return a copy of `this`, updated with the specified values
+        */
       def copy(
         location: Option[IdentifiedLocation] = location,
         passData: MetadataStorage            = passData,
@@ -979,6 +1043,9 @@ object IR {
 
       override def mapExpressions(fn: Expression => Expression): Blank =
         this
+
+      override def setLocation(location: Option[IdentifiedLocation]): Blank =
+        copy(location = location)
 
       override def toString: String =
         s"""
@@ -1029,6 +1096,9 @@ object IR {
         res
       }
 
+      override def setLocation(location: Option[IdentifiedLocation]): Literal =
+        copy(location = location)
+
       override def mapExpressions(fn: Expression => Expression): Literal = this
 
       override def toString: String =
@@ -1077,6 +1147,9 @@ object IR {
         res.id = id
         res
       }
+
+      override def setLocation(location: Option[IdentifiedLocation]): This =
+        copy(location = location)
 
       override def mapExpressions(fn: Expression => Expression): This = this
 
@@ -1127,6 +1200,9 @@ object IR {
         res
       }
 
+      override def setLocation(location: Option[IdentifiedLocation]): Here =
+        copy(location = location)
+
       override def mapExpressions(fn: Expression => Expression): Here = this
 
       override def toString: String =
@@ -1146,7 +1222,8 @@ object IR {
 
   /** Constructs that operate on types. */
   sealed trait Type extends Expression {
-    override def mapExpressions(fn: Expression => Expression): Type
+    override def mapExpressions(fn: Expression => Expression):      Type
+    override def setLocation(location: Option[IdentifiedLocation]): Type
   }
   object Type {
 
@@ -1195,6 +1272,10 @@ object IR {
         res.id = id
         res
       }
+
+      override def setLocation(
+        location: Option[IdentifiedLocation]
+      ): Ascription = copy(location = location)
 
       override def mapExpressions(fn: Expression => Expression): Ascription = {
         copy(typed = fn(typed), signature = fn(signature))
@@ -1259,6 +1340,9 @@ object IR {
         res
       }
 
+      override def setLocation(location: Option[IdentifiedLocation]): Context =
+        copy(location = location)
+
       override def mapExpressions(fn: Expression => Expression): Context = {
         copy(typed = fn(typed), context = fn(context))
       }
@@ -1283,7 +1367,8 @@ object IR {
 
     /** IR nodes for dealing with typesets. */
     sealed trait Set extends Type {
-      override def mapExpressions(fn: Expression => Expression): Set
+      override def mapExpressions(fn: Expression => Expression):      Set
+      override def setLocation(location: Option[IdentifiedLocation]): Set
     }
     object Set {
 
@@ -1332,6 +1417,9 @@ object IR {
           res.id = id
           res
         }
+
+        override def setLocation(location: Option[IdentifiedLocation]): Member =
+          copy(location = location)
 
         override def mapExpressions(fn: Expression => Expression): Member = {
           copy(
@@ -1402,6 +1490,10 @@ object IR {
           res
         }
 
+        override def setLocation(
+          location: Option[IdentifiedLocation]
+        ): Subsumption = copy(location = location)
+
         override def mapExpressions(
           fn: Expression => Expression
         ): Subsumption = {
@@ -1467,6 +1559,10 @@ object IR {
           res
         }
 
+        override def setLocation(
+          location: Option[IdentifiedLocation]
+        ): Equality = copy(location = location)
+
         override def mapExpressions(fn: Expression => Expression): Equality = {
           copy(left = fn(left), right = fn(right))
         }
@@ -1529,6 +1625,9 @@ object IR {
           res.id = id
           res
         }
+
+        override def setLocation(location: Option[IdentifiedLocation]): Concat =
+          copy(location = location)
 
         override def mapExpressions(fn: Expression => Expression): Concat = {
           copy(left = fn(left), right = fn(right))
@@ -1593,6 +1692,9 @@ object IR {
           res
         }
 
+        override def setLocation(location: Option[IdentifiedLocation]): Union =
+          copy(location = location)
+
         override def mapExpressions(fn: Expression => Expression): Union = {
           copy(left = fn(left), right = fn(right))
         }
@@ -1655,6 +1757,10 @@ object IR {
           res.id = id
           res
         }
+
+        override def setLocation(
+          location: Option[IdentifiedLocation]
+        ): Intersection = copy(location = location)
 
         override def mapExpressions(
           fn: Expression => Expression
@@ -1721,6 +1827,10 @@ object IR {
           res
         }
 
+        override def setLocation(
+          location: Option[IdentifiedLocation]
+        ): Subtraction = copy(location = location)
+
         override def mapExpressions(
           fn: Expression => Expression
         ): Subtraction = {
@@ -1769,7 +1879,8 @@ object IR {
       */
     val canBeTCO: Boolean
 
-    override def mapExpressions(fn: Expression => Expression): Function
+    override def mapExpressions(fn: Expression => Expression):      Function
+    override def setLocation(location: Option[IdentifiedLocation]): Function
   }
   object Function {
 
@@ -1822,6 +1933,9 @@ object IR {
         res.id = id
         res
       }
+
+      override def setLocation(location: Option[IdentifiedLocation]): Lambda =
+        copy(location = location)
 
       override def mapExpressions(fn: Expression => Expression): Lambda = {
         copy(arguments = arguments.map(_.mapExpressions(fn)), body = fn(body))
@@ -1901,7 +2015,10 @@ object IR {
         res
       }
 
-      override def mapExpressions(fn: Expression => Expression): Function =
+      override def setLocation(location: Option[IdentifiedLocation]): Binding =
+        copy(location = location)
+
+      override def mapExpressions(fn: Expression => Expression): Binding =
         copy(
           name      = name.mapExpressions(fn),
           arguments = arguments.map(_.mapExpressions(fn)),
@@ -1942,6 +2059,10 @@ object IR {
 
     override def mapExpressions(
       fn: Expression => Expression
+    ): DefinitionArgument
+
+    override def setLocation(
+      location: Option[IdentifiedLocation]
     ): DefinitionArgument
   }
   object DefinitionArgument {
@@ -2002,6 +2123,10 @@ object IR {
         res
       }
 
+      override def setLocation(
+        location: Option[IdentifiedLocation]
+      ): Specified = copy(location = location)
+
       def mapExpressions(fn: Expression => Expression): Specified = {
         copy(
           name         = name.mapExpressions(fn),
@@ -2030,7 +2155,8 @@ object IR {
 
   /** All function applications in Enso. */
   sealed trait Application extends Expression {
-    override def mapExpressions(fn: Expression => Expression): Application
+    override def mapExpressions(fn: Expression => Expression):      Application
+    override def setLocation(location: Option[IdentifiedLocation]): Application
   }
   object Application {
 
@@ -2088,6 +2214,9 @@ object IR {
         res.id = id
         res
       }
+
+      override def setLocation(location: Option[IdentifiedLocation]): Prefix =
+        copy(location = location)
 
       override def mapExpressions(fn: Expression => Expression): Prefix = {
         copy(function = fn(function), arguments.map(_.mapExpressions(fn)))
@@ -2147,6 +2276,9 @@ object IR {
         res
       }
 
+      override def setLocation(location: Option[IdentifiedLocation]): Force =
+        copy(location = location)
+
       override def mapExpressions(fn: Expression => Expression): Force = {
         copy(target = fn(target))
       }
@@ -2168,7 +2300,8 @@ object IR {
 
     /** Literal applications in Enso. */
     sealed trait Literal extends Application {
-      override def mapExpressions(fn: Expression => Expression): Literal
+      override def mapExpressions(fn: Expression => Expression):      Literal
+      override def setLocation(location: Option[IdentifiedLocation]): Literal
     }
 
     object Literal {
@@ -2213,6 +2346,10 @@ object IR {
           res
         }
 
+        override def setLocation(
+          location: Option[IdentifiedLocation]
+        ): Sequence = copy(location = location)
+
         override def toString: String =
           s"""
           |IR.Application.Literal.Vector(
@@ -2230,7 +2367,8 @@ object IR {
 
     /** Operator applications in Enso. */
     sealed trait Operator extends Application {
-      override def mapExpressions(fn: Expression => Expression): Operator
+      override def mapExpressions(fn: Expression => Expression):      Operator
+      override def setLocation(location: Option[IdentifiedLocation]): Operator
     }
     object Operator {
 
@@ -2280,6 +2418,9 @@ object IR {
           res
         }
 
+        override def setLocation(location: Option[IdentifiedLocation]): Binary =
+          copy(location = location)
+
         override def mapExpressions(fn: Expression => Expression): Binary = {
           copy(left = left.mapExpressions(fn), right = right.mapExpressions(fn))
         }
@@ -2303,7 +2444,8 @@ object IR {
 
       /** Operator sections. */
       sealed trait Section extends Operator {
-        override def mapExpressions(fn: Expression => Expression): Section
+        override def mapExpressions(fn: Expression => Expression):      Section
+        override def setLocation(location: Option[IdentifiedLocation]): Section
       }
       object Section {
 
@@ -2347,6 +2489,9 @@ object IR {
             res.id = id
             res
           }
+
+          override def setLocation(location: Option[IdentifiedLocation]): Left =
+            copy(location = location)
 
           override def mapExpressions(fn: Expression => Expression): Section =
             copy(
@@ -2406,6 +2551,10 @@ object IR {
             res
           }
 
+          override def setLocation(
+            location: Option[IdentifiedLocation]
+          ): Sides = copy(location = location)
+
           override def mapExpressions(fn: Expression => Expression): Section =
             copy(operator = operator.mapExpressions(fn))
 
@@ -2464,6 +2613,10 @@ object IR {
             res
           }
 
+          override def setLocation(
+            location: Option[IdentifiedLocation]
+          ): Right = copy(location = location)
+
           override def mapExpressions(fn: Expression => Expression): Section = {
             copy(
               operator = operator.mapExpressions(fn),
@@ -2509,7 +2662,8 @@ object IR {
       */
     val shouldBeSuspended: Option[Boolean]
 
-    override def mapExpressions(fn: Expression => Expression): CallArgument
+    override def mapExpressions(fn: Expression => Expression):      CallArgument
+    override def setLocation(location: Option[IdentifiedLocation]): CallArgument
   }
   object CallArgument {
 
@@ -2570,6 +2724,10 @@ object IR {
         res
       }
 
+      override def setLocation(
+        location: Option[IdentifiedLocation]
+      ): Specified = copy(location = location)
+
       override def mapExpressions(fn: Expression => Expression): Specified = {
         copy(name = name.map(n => n.mapExpressions(fn)), value = fn(value))
       }
@@ -2595,7 +2753,8 @@ object IR {
 
   /** The Enso case expression. */
   sealed trait Case extends Expression {
-    override def mapExpressions(fn: Expression => Expression): Case
+    override def mapExpressions(fn: Expression => Expression):      Case
+    override def setLocation(location: Option[IdentifiedLocation]): Case
   }
   object Case {
 
@@ -2644,6 +2803,9 @@ object IR {
         res.id = id
         res
       }
+
+      override def setLocation(location: Option[IdentifiedLocation]): Expr =
+        copy(location = location)
 
       override def mapExpressions(fn: Expression => Expression): Expr = {
         copy(
@@ -2712,6 +2874,9 @@ object IR {
         res
       }
 
+      override def setLocation(location: Option[IdentifiedLocation]): Branch =
+        copy(location = location)
+
       override def mapExpressions(fn: Expression => Expression): Branch = {
         copy(pattern = fn(pattern), expression = fn(expression))
       }
@@ -2745,7 +2910,8 @@ object IR {
 
   /** Enso comment entities. */
   sealed trait Comment extends Expression {
-    override def mapExpressions(fn: Expression => Expression): Comment
+    override def mapExpressions(fn: Expression => Expression):      Comment
+    override def setLocation(location: Option[IdentifiedLocation]): Comment
 
     /** The expression being commented. */
     val commented: Expression
@@ -2793,6 +2959,10 @@ object IR {
         res
       }
 
+      override def setLocation(
+        location: Option[IdentifiedLocation]
+      ): Documentation = copy(location = location)
+
       override def mapExpressions(
         fn: Expression => Expression
       ): Documentation = {
@@ -2820,7 +2990,8 @@ object IR {
 
   /** Foreign code entities. */
   sealed trait Foreign extends Expression {
-    override def mapExpressions(fn: Expression => Expression): Foreign
+    override def mapExpressions(fn: Expression => Expression):      Foreign
+    override def setLocation(location: Option[IdentifiedLocation]): Foreign
   }
   object Foreign {
 
@@ -2864,6 +3035,10 @@ object IR {
         res.id = id
         res
       }
+
+      override def setLocation(
+        location: Option[IdentifiedLocation]
+      ): Definition = copy(location = location)
 
       override def mapExpressions(fn: Expression => Expression): Definition =
         this
@@ -2984,7 +3159,8 @@ object IR {
 
   /** A trait for all errors in Enso's IR. */
   sealed trait Error extends Expression with Diagnostic {
-    override def mapExpressions(fn: Expression => Expression): Error
+    override def mapExpressions(fn: Expression => Expression):      Error
+    override def setLocation(location: Option[IdentifiedLocation]): Error
   }
   object Error {
 
@@ -3025,6 +3201,9 @@ object IR {
         res.id = id
         res
       }
+
+      override def setLocation(location: Option[IdentifiedLocation]): Syntax =
+        this
 
       override val location: Option[IdentifiedLocation] =
         ast.location.map(IdentifiedLocation(_, ast.id))
@@ -3144,6 +3323,10 @@ object IR {
         res
       }
 
+      override def setLocation(
+        location: Option[IdentifiedLocation]
+      ): InvalidIR = this
+
       override val location: Option[IdentifiedLocation] = ir.location
 
       override def mapExpressions(fn: Expression => Expression): InvalidIR =
@@ -3170,7 +3353,9 @@ object IR {
     /** Errors pertaining to the redefinition of language constructs that are
       * not allowed to be.
       */
-    sealed trait Redefined extends Error
+    sealed trait Redefined extends Error {
+      override def setLocation(location: Option[IdentifiedLocation]): Redefined
+    }
     object Redefined {
 
       /** An error representing the redefinition or incorrect positioning of
@@ -3207,6 +3392,10 @@ object IR {
           res.id = id
           res
         }
+
+        override def setLocation(
+          location: Option[IdentifiedLocation]
+        ): ThisArg = copy(location = location)
 
         override def mapExpressions(fn: Expression => Expression): ThisArg =
           this
@@ -3264,6 +3453,9 @@ object IR {
           res.id = id
           res
         }
+
+        override def setLocation(location: Option[IdentifiedLocation]): Method =
+          copy(location = location)
 
         override def message: String =
           s"Method overloads are not supported: ${atomName.name}." +
@@ -3329,6 +3521,9 @@ object IR {
           res
         }
 
+        override def setLocation(location: Option[IdentifiedLocation]): Atom =
+          copy(location = location)
+
         override def message: String =
           s"Redefining atoms is not supported: ${atomName.name} is " +
           s"defined multiple times in this module."
@@ -3385,6 +3580,10 @@ object IR {
           res.id = id
           res
         }
+
+        override def setLocation(
+          location: Option[IdentifiedLocation]
+        ): Binding = this
 
         override val location: Option[IdentifiedLocation] =
           invalidBinding.location

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -47,6 +47,7 @@ import scala.reflect.ClassTag
   * It must have the following passes run before it:
   *
   * - [[org.enso.compiler.pass.desugar.GenerateMethodBodies]]
+  * - [[org.enso.compiler.pass.desugar.FunctionBinding]]
   * - [[org.enso.compiler.pass.desugar.SectionsToBinOp]]
   * - [[org.enso.compiler.pass.desugar.OperatorToFunction]]
   * - [[org.enso.compiler.pass.desugar.LambdaShorthandToLambda]],
@@ -129,7 +130,8 @@ case object AliasAnalysis extends IRPass {
     val topLevelGraph = new Graph
 
     ir match {
-      case m @ IR.Module.Scope.Definition.Method(_, _, body, _, _, _) =>
+      case m @ IR.Module.Scope.Definition.Method
+            .Explicit(_, _, body, _, _, _) =>
         body match {
           case _: IR.Function =>
             m.copy(
@@ -147,6 +149,10 @@ case object AliasAnalysis extends IRPass {
               "The body of a method should always be a function."
             )
         }
+      case _: IR.Module.Scope.Definition.Method.Binding =>
+        throw new CompilerError(
+          "Method definition sugar should not occur during alias analysis."
+        )
       case a @ IR.Module.Scope.Definition.Atom(_, args, _, _, _) =>
         a.copy(
             arguments =
@@ -419,6 +425,10 @@ case object AliasAnalysis extends IRPass {
             )
           )
           .updateMetadata(this -->> Info.Scope.Child(graph, currentScope))
+      case _: IR.Function.Binding =>
+        throw new CompilerError(
+          "Function sugar should not be present during alias analysis."
+        )
     }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -46,8 +46,8 @@ import scala.reflect.ClassTag
   *
   * It must have the following passes run before it:
   *
-  * - [[org.enso.compiler.pass.desugar.GenerateMethodBodies]]
   * - [[org.enso.compiler.pass.desugar.FunctionBinding]]
+  * - [[org.enso.compiler.pass.desugar.GenerateMethodBodies]]
   * - [[org.enso.compiler.pass.desugar.SectionsToBinOp]]
   * - [[org.enso.compiler.pass.desugar.OperatorToFunction]]
   * - [[org.enso.compiler.pass.desugar.LambdaShorthandToLambda]],

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
@@ -129,6 +129,10 @@ case object DemandAnalysis extends IRPass {
           isInsideCallArgument = false
         )
       )
+    case _: IR.Function.Binding =>
+      throw new CompilerError(
+        "Function sugar should not be present during demand analysis."
+      )
   }
 
   /** Performs demand analysis for a name.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
@@ -19,6 +19,7 @@ import org.enso.compiler.pass.IRPass
   * It must have the following passes run before it:
   *
   * - [[org.enso.compiler.pass.desugar.GenerateMethodBodies]]
+  * - [[org.enso.compiler.pass.desugar.FunctionBinding]]
   * - [[org.enso.compiler.pass.desugar.SectionsToBinOp]]
   * - [[org.enso.compiler.pass.desugar.OperatorToFunction]]
   * - [[org.enso.compiler.pass.desugar.LambdaShorthandToLambda]]
@@ -76,12 +77,18 @@ case object TailCall extends IRPass {
     definition: IR.Module.Scope.Definition
   ): IR.Module.Scope.Definition = {
     definition match {
-      case method @ IR.Module.Scope.Definition.Method(_, _, body, _, _, _) =>
+      case method @ IR.Module.Scope.Definition.Method
+            .Explicit(_, _, body, _, _, _) =>
         method
           .copy(
             body = analyseExpression(body, isInTailPosition = true)
           )
           .updateMetadata(this -->> TailPosition.Tail)
+      case _: IR.Module.Scope.Definition.Method.Binding =>
+        throw new CompilerError(
+          "Sugared method definitions should not occur during tail call " +
+          "analysis."
+        )
       case atom @ IR.Module.Scope.Definition.Atom(_, args, _, _, _) =>
         atom
           .copy(
@@ -340,6 +347,10 @@ case object TailCall extends IRPass {
         lambda.copy(
           arguments = args.map(analyseDefArgument),
           body      = analyseExpression(body, isInTailPosition = markAsTail)
+        )
+      case _: IR.Function.Binding =>
+        throw new CompilerError(
+          "Function sugar should not be present during tail call analysis."
         )
     }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
@@ -18,8 +18,8 @@ import org.enso.compiler.pass.IRPass
   *
   * It must have the following passes run before it:
   *
-  * - [[org.enso.compiler.pass.desugar.GenerateMethodBodies]]
   * - [[org.enso.compiler.pass.desugar.FunctionBinding]]
+  * - [[org.enso.compiler.pass.desugar.GenerateMethodBodies]]
   * - [[org.enso.compiler.pass.desugar.SectionsToBinOp]]
   * - [[org.enso.compiler.pass.desugar.OperatorToFunction]]
   * - [[org.enso.compiler.pass.desugar.LambdaShorthandToLambda]]

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
@@ -75,7 +75,7 @@ case object FunctionBinding extends IRPass {
   /** Performs desugaring on a module definition.
     *
     * @param definition the module definition to desugar
-    * @return `defition`, with any function definition sugar removed
+    * @return `definition`, with any function definition sugar removed
     */
   def desugarModuleSymbol(
     definition: IR.Module.Scope.Definition

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
@@ -2,25 +2,26 @@ package org.enso.compiler.pass.desugar
 
 import org.enso.compiler.context.{FreshNameSupply, InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
+import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.IRPass
 
 import scala.annotation.unused
 
 /** This pass handles the desugaring of long-form function and method
- * definitions into standard bindings using lambdas.
- *
- * This works for any definition of the form `f <args> = <body>`.
- *
- * This pass has no configuration.
- *
- * This pass requires the context to provide:
- *
- * - Nothing
- *
- * It must have the following passes run before it:
- *
- * - [[org.enso.compiler.pass.desugar.GenerateMethodBodies]]
- */
+  * definitions into standard bindings using lambdas.
+  *
+  * This works for any definition of the form `f <args> = <body>`.
+  *
+  * This pass has no configuration.
+  *
+  * This pass requires the context to provide:
+  *
+  * - Nothing
+  *
+  * It must have the following passes run before it:
+  *
+  * - [[org.enso.compiler.pass.desugar.GenerateMethodBodies]]
+  */
 case object FunctionBinding extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
@@ -30,8 +31,31 @@ case object FunctionBinding extends IRPass {
     @unused moduleContext: ModuleContext
   ): IR.Module = ir
 
+  /** Runs desugaring of function bindings on an arbitrary expression.
+    *
+    * @param ir the Enso IR to process
+    * @param inlineContext a context object that contains the information needed
+    *                      for inline evaluation
+    * @return `ir`, possibly having made transformations or annotations to that
+    *         IR.
+    */
   override def runExpression(
     ir: IR.Expression,
     @unused inlineContext: InlineContext
-  ): IR.Expression = ir
+  ): IR.Expression = ir.transformExpressions {
+    case IR.Function.Binding(name, args, body, location, canBeTCO, _, _) =>
+      if (args.isEmpty) {
+        throw new CompilerError("The arguments list should not be empty.")
+      }
+
+      val lambda = args
+        .map(_.mapExpressions(runExpression(_, inlineContext)))
+        .foldRight(runExpression(body, inlineContext))((arg, body) =>
+          IR.Function.Lambda(List(arg), body, None)
+        )
+        .asInstanceOf[IR.Function.Lambda]
+        .copy(location = location, canBeTCO = canBeTCO)
+
+      IR.Expression.Binding(name, lambda, None)
+  }
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
@@ -23,7 +23,7 @@ import scala.annotation.unused
   *
   * It must have the following passes run before it:
   *
-  * - [[org.enso.compiler.pass.desugar.GenerateMethodBodies]]
+  * - None
   */
 case object FunctionBinding extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
@@ -52,7 +52,7 @@ case object FunctionBinding extends IRPass {
     */
   override def runExpression(
     ir: IR.Expression,
-    @unused inlineContext: InlineContext
+    inlineContext: InlineContext
   ): IR.Expression = ir.transformExpressions {
     case IR.Function.Binding(name, args, body, location, canBeTCO, _, _) =>
       if (args.isEmpty) {
@@ -65,9 +65,9 @@ case object FunctionBinding extends IRPass {
           IR.Function.Lambda(List(arg), body, None)
         )
         .asInstanceOf[IR.Function.Lambda]
-        .copy(location = location, canBeTCO = canBeTCO)
+        .copy(canBeTCO = canBeTCO)
 
-      IR.Expression.Binding(name, lambda, None)
+      IR.Expression.Binding(name, lambda, location)
   }
 
   // === Pass Internals =======================================================
@@ -99,7 +99,7 @@ case object FunctionBinding extends IRPass {
           .asInstanceOf[IR.Function.Lambda]
           .copy(location = loc, canBeTCO = true)
 
-        Method.Explicit(typeName, methName, newBody, loc)
+        Method.Explicit(typeName, methName, newBody, None)
       case e: Redefined => e
     }
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
@@ -102,7 +102,7 @@ case object FunctionBinding extends IRPass {
             IR.Function.Lambda(List(arg), body, None)
           )
           .asInstanceOf[IR.Function.Lambda]
-          .copy(location = loc, canBeTCO = true)
+          .copy(location = loc)
 
         Method.Explicit(typeName, methName, newBody, None)
       case e: Redefined => e

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
@@ -1,7 +1,10 @@
 package org.enso.compiler.pass.desugar
 
-import org.enso.compiler.context.{FreshNameSupply, InlineContext, ModuleContext}
+import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
+import org.enso.compiler.core.IR.Error.Redefined
+import org.enso.compiler.core.IR.Module.Scope.Definition
+import org.enso.compiler.core.IR.Module.Scope.Definition.Method
 import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.IRPass
 
@@ -26,10 +29,18 @@ case object FunctionBinding extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
+  /** Rusn desugaring of sugared method and function bindings on a module.
+    *
+    * @param ir the Enso IR to process
+    * @param moduleContext a context object that contains the information needed
+    *                      to process a module
+    * @return `ir`, possibly having made transformations or annotations to that
+    *         IR.
+    */
   override def runModule(
     ir: IR.Module,
     @unused moduleContext: ModuleContext
-  ): IR.Module = ir
+  ): IR.Module = ir.copy(bindings = ir.bindings.map(desugarModuleSymbol))
 
   /** Runs desugaring of function bindings on an arbitrary expression.
     *
@@ -57,5 +68,39 @@ case object FunctionBinding extends IRPass {
         .copy(location = location, canBeTCO = canBeTCO)
 
       IR.Expression.Binding(name, lambda, None)
+  }
+
+  // === Pass Internals =======================================================
+
+  /** Performs desugaring on a module definition.
+    *
+    * @param definition the module definition to desugar
+    * @return `defition`, with any function definition sugar removed
+    */
+  def desugarModuleSymbol(
+    definition: IR.Module.Scope.Definition
+  ): IR.Module.Scope.Definition = {
+    definition match {
+      case a @ Definition.Atom(_, arguments, _, _, _) =>
+        a.copy(
+          arguments =
+            arguments.map(_.mapExpressions(runExpression(_, InlineContext())))
+        )
+      case method @ Method.Explicit(_, _, body, _, _, _) =>
+        method.copy(
+          body = runExpression(body, InlineContext())
+        )
+      case Method.Binding(typeName, methName, args, body, loc, _, _) =>
+        val newBody = args
+          .map(_.mapExpressions(runExpression(_, InlineContext())))
+          .foldRight(runExpression(body, InlineContext()))((arg, body) =>
+            IR.Function.Lambda(List(arg), body, None)
+          )
+          .asInstanceOf[IR.Function.Lambda]
+          .copy(location = loc, canBeTCO = true)
+
+        Method.Explicit(typeName, methName, newBody, loc)
+      case e: Redefined => e
+    }
   }
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
@@ -1,0 +1,37 @@
+package org.enso.compiler.pass.desugar
+
+import org.enso.compiler.context.{FreshNameSupply, InlineContext, ModuleContext}
+import org.enso.compiler.core.IR
+import org.enso.compiler.pass.IRPass
+
+import scala.annotation.unused
+
+/** This pass handles the desugaring of long-form function and method
+ * definitions into standard bindings using lambdas.
+ *
+ * This works for any definition of the form `f <args> = <body>`.
+ *
+ * This pass has no configuration.
+ *
+ * This pass requires the context to provide:
+ *
+ * - Nothing
+ *
+ * It must have the following passes run before it:
+ *
+ * - [[org.enso.compiler.pass.desugar.GenerateMethodBodies]]
+ */
+case object FunctionBinding extends IRPass {
+  override type Metadata = IRPass.Metadata.Empty
+  override type Config   = IRPass.Configuration.Default
+
+  override def runModule(
+    ir: IR.Module,
+    @unused moduleContext: ModuleContext
+  ): IR.Module = ir
+
+  override def runExpression(
+    ir: IR.Expression,
+    @unused inlineContext: InlineContext
+  ): IR.Expression = ir
+}

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.pass.desugar
 
 import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
+import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.IRPass
 
 /** This pass is responsible for ensuring that method bodies are in the correct
@@ -19,7 +20,7 @@ import org.enso.compiler.pass.IRPass
   *
   * It must have the following passes run before it:
   *
-  * - None
+  * - [[FunctionBinding]]
   */
 case object GenerateMethodBodies extends IRPass {
 
@@ -66,12 +67,10 @@ case object GenerateMethodBodies extends IRPass {
             case expression       => processBodyExpression(expression)
           }
         )
-      case ir: IR.Module.Scope.Definition.Method.Binding =>
-        ir.copy(
-          body = ir.body match {
-            case fun: IR.Function => processBodyFunction(fun)
-            case expression       => processBodyExpression(expression)
-          }
+      case _: IR.Module.Scope.Definition.Method.Binding =>
+        throw new CompilerError(
+          "Method definition sugar should not be present during method body " +
+          "generation."
         )
     }
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
@@ -54,15 +54,26 @@ case object GenerateMethodBodies extends IRPass {
     * @return `ir` potentially with alterations to ensure that it's in the
     *         correct format
     */
+  //noinspection DuplicatedCode
   def processMethodDef(
     ir: IR.Module.Scope.Definition.Method
   ): IR.Module.Scope.Definition.Method = {
-    ir.copy(
-      body = ir.body match {
-        case fun: IR.Function => processBodyFunction(fun)
-        case expression       => processBodyExpression(expression)
-      }
-    )
+    ir match {
+      case ir: IR.Module.Scope.Definition.Method.Explicit =>
+        ir.copy(
+          body = ir.body match {
+            case fun: IR.Function => processBodyFunction(fun)
+            case expression       => processBodyExpression(expression)
+          }
+        )
+      case ir: IR.Module.Scope.Definition.Method.Binding =>
+        ir.copy(
+          body = ir.body match {
+            case fun: IR.Function => processBodyFunction(fun)
+            case expression       => processBodyExpression(expression)
+          }
+        )
+    }
   }
 
   /** Processes the method body if it's a function.
@@ -77,6 +88,10 @@ case object GenerateMethodBodies extends IRPass {
     fun match {
       case lam @ IR.Function.Lambda(args, _, _, _, _, _) =>
         lam.copy(
+          arguments = genThisArgument :: args
+        )
+      case sugar @ IR.Function.Binding(_, args, _, _, _, _, _) =>
+        sugar.copy(
           arguments = genThisArgument :: args
         )
     }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
@@ -94,9 +94,10 @@ case object GenerateMethodBodies extends IRPass {
           lam.copy(
             arguments = genThisArgument :: args
           )
-        case sugar @ IR.Function.Binding(_, args, _, _, _, _, _) =>
-          sugar.copy(
-            arguments = genThisArgument :: args
+        case _: IR.Function.Binding =>
+          throw new CompilerError(
+            "Function definition sugar should not be present during method " +
+            "body generation."
           )
       }
     } else {

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
@@ -88,6 +88,7 @@ case object GenerateMethodBodies extends IRPass {
       case lam @ IR.Function.Lambda(args, _, _, _, _, _) =>
         lam.copy(
           // TODO [AA] This is wrong, need to check it hasn't been defined too
+          // TODO [AA] Should create an error.
           arguments = genThisArgument :: args
         )
       case sugar @ IR.Function.Binding(_, args, _, _, _, _, _) =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
@@ -87,10 +87,12 @@ case object GenerateMethodBodies extends IRPass {
     fun match {
       case lam @ IR.Function.Lambda(args, _, _, _, _, _) =>
         lam.copy(
+          // TODO [AA] This is wrong, need to check it hasn't been defined too
           arguments = genThisArgument :: args
         )
       case sugar @ IR.Function.Binding(_, args, _, _, _, _, _) =>
         sugar.copy(
+          // TODO [AA] This is wrong, need to check if `this` is defined
           arguments = genThisArgument :: args
         )
     }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.pass.lint
 
 import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
+import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.analyse.AliasAnalysis
 import org.enso.compiler.pass.resolve.IgnoredBindings
@@ -113,6 +114,10 @@ case object UnusedBindings extends IRPass {
         lam.copy(
           arguments = args.map(lintFunctionArgument(_, context)),
           body      = runExpression(body, context)
+        )
+      case _: IR.Function.Binding =>
+        throw new CompilerError(
+          "Function sugar should not be present during unused bindings linting."
         )
     }
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
@@ -158,6 +158,10 @@ case object LambdaConsolidate extends IRPass {
           canBeTCO  = chainedLambdas.last.canBeTCO,
           passData  = MetadataStorage()
         )
+      case _: IR.Function.Binding =>
+        throw new CompilerError(
+          "Function sugar should not be present during lambda consolidation."
+        )
     }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
@@ -141,6 +141,11 @@ case object IgnoredBindings extends IRPass {
           arguments = newArgs,
           body      = desugarExpression(body, supply)
         )
+      case _: IR.Function.Binding =>
+        throw new CompilerError(
+          "Function sugar should not be present during ignored " +
+          "bindings desugaring."
+        )
     }
   }
 

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/CompilerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/CompilerTest.scala
@@ -163,7 +163,7 @@ trait CompilerRunner {
       */
     def asMethod: IR.Module.Scope.Definition.Method = {
       IR.Module.Scope.Definition
-        .Method(
+        .Method.Explicit(
           IR.Name.Literal("TestType", None),
           IR.Name.Literal("testMethod", None),
           ir,

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
@@ -304,4 +304,28 @@ class AstToIrTest extends CompilerTest {
       ir shouldBe an[IR.Function.Binding]
     }
   }
+
+  "AST translation for the inline flow" should {
+    "disallow method definitions without exploding" in {
+      val ir =
+        """
+          |Unit.foo a b = a + b
+          |""".stripMargin.toIrExpression.get
+
+      ir shouldBe an[IR.Error.Syntax]
+      ir.asInstanceOf[IR.Error.Syntax]
+        .reason shouldBe an[IR.Error.Syntax.MethodDefinedInline]
+    }
+
+    "disallow type definitions without explocing" in {
+      val ir =
+        """
+          |type MyAtom a b
+          |""".stripMargin.toIrExpression.get
+
+      ir shouldBe an[IR.Error.Syntax]
+      ir.asInstanceOf[IR.Error.Syntax]
+        .reason shouldBe an[IR.Error.Syntax.TypeDefinedInline]
+    }
+  }
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
@@ -239,4 +239,69 @@ class AstToIrTest extends CompilerTest {
       fooArg.value.asInstanceOf[IR.Name.Literal].name shouldEqual "foo"
     }
   }
+
+  "AST translation of function sugar" should {
+    "work for function definitions" in {
+      val ir =
+        """
+          |f a b = a + b
+          |""".stripMargin.toIrExpression.get
+
+      ir shouldBe an[IR.Function.Binding]
+    }
+
+    "work for method definitions" in {
+      val ir =
+        """
+          |Foo.bar a b = a + b
+          |""".stripMargin.toIrModule
+
+      ir.bindings.head shouldBe an[IR.Module.Scope.Definition.Method.Binding]
+    }
+
+    "work for method definitions with involved arguments" in {
+      val ir =
+        """
+          |Foo.bar _ (b = 1) ~c = b + c
+          |""".stripMargin.toIrModule
+
+      ir.bindings.head shouldBe an[IR.Module.Scope.Definition.Method.Binding]
+    }
+
+    "not recognise pattern match bindings" in {
+      val ir =
+        """
+          |F a b = a + b
+          |""".stripMargin.toIrExpression.get
+
+      ir should not be an[IR.Function.Binding]
+    }
+
+    "work with ignored arguments" in {
+      val ir =
+        """
+          |f _ b = a + b
+          |""".stripMargin.toIrExpression.get
+
+      ir shouldBe an[IR.Function.Binding]
+    }
+
+    "work with defaulted arguments" in {
+      val ir =
+        """
+          |f (a = 1) b = a + b
+          |""".stripMargin.toIrExpression.get
+
+      ir shouldBe an[IR.Function.Binding]
+    }
+
+    "work with lazy arguments" in {
+      val ir =
+        """
+          |f ~a b = a + b
+          |""".stripMargin.toIrExpression.get
+
+      ir shouldBe an[IR.Function.Binding]
+    }
+  }
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/AliasAnalysisTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/AliasAnalysisTest.scala
@@ -7,12 +7,7 @@ import org.enso.compiler.pass.PassConfiguration._
 import org.enso.compiler.pass.analyse.AliasAnalysis
 import org.enso.compiler.pass.analyse.AliasAnalysis.Graph.{Link, Occurrence}
 import org.enso.compiler.pass.analyse.AliasAnalysis.{Graph, Info}
-import org.enso.compiler.pass.desugar.{
-  GenerateMethodBodies,
-  LambdaShorthandToLambda,
-  OperatorToFunction,
-  SectionsToBinOp
-}
+import org.enso.compiler.pass.desugar._
 import org.enso.compiler.pass.{IRPass, PassConfiguration, PassManager}
 import org.enso.compiler.test.CompilerTest
 
@@ -22,6 +17,7 @@ class AliasAnalysisTest extends CompilerTest {
 
   /** The passes that need to be run before the alias analysis pass. */
   val precursorPasses: List[IRPass] = List(
+    FunctionBinding,
     GenerateMethodBodies,
     SectionsToBinOp,
     OperatorToFunction,

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
@@ -5,13 +5,8 @@ import org.enso.compiler.core.IR
 import org.enso.compiler.pass.PassConfiguration._
 import org.enso.compiler.pass.analyse.DataflowAnalysis.DependencyInfo
 import org.enso.compiler.pass.analyse.DataflowAnalysis.DependencyInfo.Type.asStatic
-import org.enso.compiler.pass.analyse.{
-  AliasAnalysis,
-  DataflowAnalysis,
-  DemandAnalysis,
-  TailCall
-}
-import org.enso.compiler.pass.desugar.{GenerateMethodBodies, OperatorToFunction}
+import org.enso.compiler.pass.analyse.{AliasAnalysis, DataflowAnalysis, DemandAnalysis, TailCall}
+import org.enso.compiler.pass.desugar.{FunctionBinding, GenerateMethodBodies, OperatorToFunction}
 import org.enso.compiler.pass.optimise.LambdaConsolidate
 import org.enso.compiler.pass.{IRPass, PassConfiguration, PassManager}
 import org.enso.compiler.test.CompilerTest
@@ -25,6 +20,7 @@ class DataflowAnalysisTest extends CompilerTest {
 
   /** The passes that must be run before the dataflow analysis pass. */
   val precursorPasses: List[IRPass] = List(
+    FunctionBinding,
     GenerateMethodBodies,
     OperatorToFunction,
     AliasAnalysis,

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
@@ -72,8 +72,10 @@ class GatherDiagnosticsTest extends CompilerTest {
             ),
             None
           ),
-          IR.Module.Scope.Definition.Method(typeName, method1Name, lam, None),
-          IR.Module.Scope.Definition.Method(typeName, method2Name, error3, None)
+          IR.Module.Scope.Definition.Method
+            .Explicit(typeName, method1Name, lam, None),
+          IR.Module.Scope.Definition.Method
+            .Explicit(typeName, method2Name, error3, None)
         ),
         None
       )

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallTest.scala
@@ -6,10 +6,7 @@ import org.enso.compiler.core.IR.Module.Scope.Definition.Method
 import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.analyse.TailCall.TailPosition
 import org.enso.compiler.pass.analyse.{AliasAnalysis, TailCall}
-import org.enso.compiler.pass.desugar.{
-  GenerateMethodBodies,
-  OperatorToFunction
-}
+import org.enso.compiler.pass.desugar.{FunctionBinding, GenerateMethodBodies, OperatorToFunction}
 import org.enso.compiler.pass.{IRPass, PassConfiguration, PassManager}
 import org.enso.compiler.test.CompilerTest
 import org.enso.interpreter.runtime.scope.LocalScope
@@ -32,6 +29,7 @@ class TailCallTest extends CompilerTest {
   )
 
   val precursorPasses: List[IRPass] = List(
+    FunctionBinding,
     GenerateMethodBodies,
     OperatorToFunction,
     AliasAnalysis

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/FunctionBindingTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/FunctionBindingTest.scala
@@ -1,0 +1,165 @@
+package org.enso.compiler.test.pass.desugar
+
+import org.enso.compiler.context.{InlineContext, ModuleContext}
+import org.enso.compiler.core.IR
+import org.enso.compiler.pass.desugar.FunctionBinding
+import org.enso.compiler.pass.{IRPass, PassConfiguration, PassManager}
+import org.enso.compiler.test.CompilerTest
+
+class FunctionBindingTest extends CompilerTest {
+
+  // === Test Setup ===========================================================
+
+  val precursorPasses: List[IRPass] = List()
+  val passConfig: PassConfiguration = PassConfiguration()
+
+  implicit val passManager: PassManager =
+    new PassManager(precursorPasses, passConfig)
+
+  /** Adds an extension method to run method and function desugaring on an
+    * [[IR.Module]].
+    *
+    * @param ir the module to run desugaring on
+    */
+  implicit class DesugarModule(ir: IR.Module) {
+
+    /** Runs desugaring on a module.
+      *
+      * @param moduleContext the module context in which desugaring is taking
+      *                      place
+      * @return [[ir]], with any sugared function and method definitions
+      *        desugared
+      */
+    def desugar(implicit moduleContext: ModuleContext): IR.Module = {
+      FunctionBinding.runModule(ir, moduleContext)
+    }
+  }
+
+  /** Adds an extension method to run function desugaring on an arbitrary
+    * expression.
+    *
+    * @param ir the expression to desugar
+    */
+  implicit class DesugarExpression(ir: IR.Expression) {
+
+    /** Runs desgaring on an expression.
+      *
+      * @param inlineContext the inline context in which the desugaring is
+      *                      taking place
+      * @return [[ir]], with any sugared function definitions desugared
+      */
+    def desugar(implicit inlineContext: InlineContext): IR.Expression = {
+      FunctionBinding.runExpression(ir, inlineContext)
+    }
+  }
+
+  /** Creates a defaulted module context.
+    *
+    * @return a defaulted module context
+    */
+  def mkModuleContext: ModuleContext = {
+    ModuleContext()
+  }
+
+  /** Creates a defaulted inline context.
+    *
+    * @return a defaulted inline context
+    */
+  def mkInlineContext: InlineContext = {
+    InlineContext()
+  }
+
+  // === The Tests ============================================================
+
+  "Sugared method definitions" should {
+    "desugar to standard method definitions" in {
+      pending
+    }
+
+    "have the function arguments in the body function" in {
+      pending
+    }
+
+    "not have the `this` argument attached" in {
+      // This pass runs before GenerateMethodBodies, which is responsible for
+      // prepending `this`.
+      pending
+    }
+
+    "work properly with complex argument definition types" in {
+      pending
+    }
+
+    "desugar nested sugared functions" in {
+      pending
+    }
+  }
+
+  "Sugared function definitions" should {
+    implicit val ctx: InlineContext = mkInlineContext
+
+    val ir =
+      """
+        |f ~a _ (c = 1) = a + b * c
+        |""".stripMargin.preprocessExpression.get.desugar
+
+    "desugar to a binding with a lambda" in {
+      ir shouldBe an[IR.Expression.Binding]
+      val binding = ir.asInstanceOf[IR.Expression.Binding]
+
+      binding.name.name shouldEqual "f"
+      binding.expression shouldBe an[IR.Function.Lambda]
+    }
+
+    "work properly for complex argument definition types" in {
+      val lambda1 = ir
+        .asInstanceOf[IR.Expression.Binding]
+        .expression
+        .asInstanceOf[IR.Function.Lambda]
+      val lambda2 = lambda1.body.asInstanceOf[IR.Function.Lambda]
+      val lambda3 = lambda2.body.asInstanceOf[IR.Function.Lambda]
+      val cArg =
+        lambda3.arguments.head.asInstanceOf[IR.DefinitionArgument.Specified]
+
+      lambda1.arguments.head
+        .asInstanceOf[IR.DefinitionArgument.Specified]
+        .suspended shouldEqual true
+      lambda2.arguments.head
+        .asInstanceOf[IR.DefinitionArgument.Specified]
+        .name shouldBe an[IR.Name.Blank]
+      cArg.name.name shouldEqual "c"
+      cArg.defaultValue shouldBe defined
+    }
+
+    "work recursively" in {
+      val ir =
+        """
+          |f (a = (f a = a)) =
+          |    g b = b
+          |    g 1
+          |""".stripMargin.preprocessExpression.get.desugar
+          .asInstanceOf[IR.Expression.Binding]
+
+      val aArg = ir.expression
+        .asInstanceOf[IR.Function.Lambda]
+        .arguments
+        .head
+        .asInstanceOf[IR.DefinitionArgument.Specified]
+      aArg.name.name shouldEqual "a"
+      aArg.defaultValue.get
+        .asInstanceOf[IR.Expression.Binding]
+        .name
+        .name shouldEqual "f"
+
+      val body = ir.expression
+        .asInstanceOf[IR.Function.Lambda]
+        .body
+        .asInstanceOf[IR.Expression.Block]
+      body.expressions.head shouldBe an[IR.Expression.Binding]
+
+      val gBinding = body.expressions.head.asInstanceOf[IR.Expression.Binding]
+      gBinding.name.name shouldEqual "g"
+      gBinding.expression shouldBe an[IR.Function.Lambda]
+    }
+  }
+}

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/GenerateMethodBodiesTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/GenerateMethodBodiesTest.scala
@@ -78,4 +78,6 @@ class GenerateMethodBodiesTest extends CompilerTest {
       irMethod.body.location shouldEqual irResultMethod.body.location
     }
   }
+
+  // TODO [AA] Test with sugared methods
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/GenerateMethodBodiesTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/GenerateMethodBodiesTest.scala
@@ -9,7 +9,7 @@ import org.enso.compiler.test.CompilerTest
 class GenerateMethodBodiesTest extends CompilerTest {
 
   // === Test Setup ===========================================================
-  val ctx = ModuleContext()
+  val ctx: ModuleContext = ModuleContext()
 
   // === The Tests ============================================================
 
@@ -76,6 +76,20 @@ class GenerateMethodBodiesTest extends CompilerTest {
 
     "have the body function's location equivalent to the original body" in {
       irMethod.body.location shouldEqual irResultMethod.body.location
+    }
+  }
+
+  "Methods that redefine `this`" should {
+    val ir =
+      """Unit.method = this -> this + 1
+        |""".stripMargin.toIrModule
+
+    val irResult = GenerateMethodBodies.runModule(ir, ctx)
+    val method =
+      irResult.bindings.head.asInstanceOf[IR.Module.Scope.Definition.Method]
+
+    "have their bodies replaced by an error" in {
+      method.body shouldBe an[IR.Error.Redefined.ThisArg]
     }
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/GenerateMethodBodiesTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/GenerateMethodBodiesTest.scala
@@ -78,6 +78,4 @@ class GenerateMethodBodiesTest extends CompilerTest {
       irMethod.body.location shouldEqual irResultMethod.body.location
     }
   }
-
-  // TODO [AA] Test with sugared methods
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/GenerateMethodBodiesTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/GenerateMethodBodiesTest.scala
@@ -1,15 +1,41 @@
 package org.enso.compiler.test.pass.desugar
 
-import org.enso.compiler.context.ModuleContext
+import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.Module.Scope.Definition.Method
-import org.enso.compiler.pass.desugar.GenerateMethodBodies
+import org.enso.compiler.pass.{IRPass, PassConfiguration, PassManager}
+import org.enso.compiler.pass.desugar.{FunctionBinding, GenerateMethodBodies}
 import org.enso.compiler.test.CompilerTest
 
 class GenerateMethodBodiesTest extends CompilerTest {
 
   // === Test Setup ===========================================================
-  val ctx: ModuleContext = ModuleContext()
+
+  implicit val ctx: ModuleContext = ModuleContext()
+
+  val precursorPasses: List[IRPass] = List(FunctionBinding)
+  val passConfig: PassConfiguration = PassConfiguration()
+
+  implicit val passManager: PassManager =
+    new PassManager(precursorPasses, passConfig)
+
+  /** Adds an extension method to run method and method body generation on an
+   * [[IR.Module]].
+   *
+   * @param ir the module to run desugaring on
+   */
+  implicit class DesugarModule(ir: IR.Module) {
+
+    /** Runs desugaring on a module.
+     *
+     * @param moduleContext the module context in which desugaring is taking
+     *                      place
+     * @return [[ir]], with any method bodies desugared
+     */
+    def desugar(implicit moduleContext: ModuleContext): IR.Module = {
+      GenerateMethodBodies.runModule(ir, moduleContext)
+    }
+  }
 
   // === The Tests ============================================================
 
@@ -17,10 +43,10 @@ class GenerateMethodBodiesTest extends CompilerTest {
     val ir =
       """
         |Unit.method = a -> b -> c -> a + b + c
-        |""".stripMargin.toIrModule
+        |""".stripMargin.preprocessModule
     val irMethod = ir.bindings.head.asInstanceOf[Method]
 
-    val irResult       = GenerateMethodBodies.runModule(ir, ctx)
+    val irResult       = ir.desugar
     val irResultMethod = irResult.bindings.head.asInstanceOf[Method]
 
     "have the `this` argument prepended to the argument list" in {
@@ -48,10 +74,10 @@ class GenerateMethodBodiesTest extends CompilerTest {
     val ir =
       """
         |Unit.method = 1
-        |""".stripMargin.toIrModule
+        |""".stripMargin.preprocessModule
     val irMethod = ir.bindings.head.asInstanceOf[Method]
 
-    val irResult       = GenerateMethodBodies.runModule(ir, ctx)
+    val irResult       = ir.desugar
     val irResultMethod = irResult.bindings.head.asInstanceOf[Method]
 
     "have the expression converted into a function" in {
@@ -81,12 +107,12 @@ class GenerateMethodBodiesTest extends CompilerTest {
 
   "Methods that redefine `this`" should {
     val ir =
-      """Unit.method = this -> this + 1
-        |""".stripMargin.toIrModule
+      """
+        |Unit.method = this -> this + 1
+        |""".stripMargin.preprocessModule.desugar
 
-    val irResult = GenerateMethodBodies.runModule(ir, ctx)
     val method =
-      irResult.bindings.head.asInstanceOf[IR.Module.Scope.Definition.Method]
+      ir.bindings.head.asInstanceOf[IR.Module.Scope.Definition.Method]
 
     "have their bodies replaced by an error" in {
       method.body shouldBe an[IR.Error.Redefined.ThisArg]

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/resolve/OverloadsResolutionTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/resolve/OverloadsResolutionTest.scala
@@ -1,19 +1,18 @@
 package org.enso.compiler.test.pass.resolve
 
-import org.enso.compiler.context.{FreshNameSupply, InlineContext, ModuleContext}
+import org.enso.compiler.context.ModuleContext
 import org.enso.compiler.core.IR
-import org.enso.compiler.pass.desugar.GenerateMethodBodies
+import org.enso.compiler.pass.desugar.{FunctionBinding, GenerateMethodBodies}
 import org.enso.compiler.pass.resolve.OverloadsResolution
 import org.enso.compiler.pass.{IRPass, PassConfiguration, PassManager}
 import org.enso.compiler.test.CompilerTest
-
-import scala.annotation.unused
 
 class OverloadsResolutionTest extends CompilerTest {
 
   // === Test Setup ===========================================================
 
   val passes: List[IRPass] = List(
+    FunctionBinding,
     GenerateMethodBodies
   )
 
@@ -52,15 +51,15 @@ class OverloadsResolutionTest extends CompilerTest {
   "Method overload resolution" should {
     implicit val ctx: ModuleContext = mkModuleContext
 
-    val atomName = "Unit"
+    val atomName   = "Unit"
     val methodName = "foo"
 
     val ir =
       s"""
-        |$atomName.$methodName = x -> x
-        |$atomName.$methodName = x -> y -> x + y
-        |$atomName.$methodName = 10
-        |""".stripMargin.preprocessModule.resolve
+         |$atomName.$methodName = x -> x
+         |$atomName.$methodName = x -> y -> x + y
+         |$atomName.$methodName = 10
+         |""".stripMargin.preprocessModule.resolve
 
     "detect overloads within a given module" in {
       exactly(2, ir.bindings) shouldBe an[IR.Error.Redefined.Method]
@@ -87,10 +86,10 @@ class OverloadsResolutionTest extends CompilerTest {
 
     val ir =
       s"""
-        |type $atomName a b c
-        |type $atomName a b
-        |type $atomName a
-        |""".stripMargin.preprocessModule.resolve
+         |type $atomName a b c
+         |type $atomName a b
+         |type $atomName a
+         |""".stripMargin.preprocessModule.resolve
 
     "detect overloads within a given module" in {
       exactly(2, ir.bindings) shouldBe an[IR.Error.Redefined.Atom]

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
@@ -9,6 +9,7 @@ import org.enso.interpreter.test.InterpreterTest
 import org.enso.polyglot.MethodNames
 
 class CodeLocationsTest extends InterpreterTest {
+
   def debugPrintCodeLocations(code: String): Unit = {
     var off = 0
     code.linesIterator.toList.foreach { line =>

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
@@ -1,11 +1,12 @@
 package org.enso.interpreter.test.semantic
-import org.enso.interpreter.node.callable.{ApplicationNode, SequenceLiteralNode}
 import org.enso.interpreter.node.callable.function.CreateFunctionNode
 import org.enso.interpreter.node.callable.thunk.ForceNode
+import org.enso.interpreter.node.callable.{ApplicationNode, SequenceLiteralNode}
 import org.enso.interpreter.node.controlflow.MatchNode
 import org.enso.interpreter.node.expression.literal.IntegerLiteralNode
 import org.enso.interpreter.node.scope.{AssignmentNode, ReadLocalVariableNode}
 import org.enso.interpreter.test.InterpreterTest
+import org.enso.polyglot.MethodNames
 
 class CodeLocationsTest extends InterpreterTest {
   def debugPrintCodeLocations(code: String): Unit = {
@@ -201,6 +202,40 @@ class CodeLocationsTest extends InterpreterTest {
         |    -f
         |""".stripMargin
     instrumenter.assertNodeExists(22, 2, classOf[ApplicationNode])
+    eval(code)
+  }
+
+  "Sugared method definitions" should "get the right locations" in
+  withLocationsInstrumenter { instrumenter =>
+    val code =
+      """
+        |Test.foo a b = a * b - a
+        |
+        |main = Test.foo 2 3
+        |""".stripMargin
+
+    val mod    = executionContext.evalModule(code, "Test")
+    val tpe    = mod.getAssociatedConstructor
+    val method = mod.getMethod(tpe, "foo")
+    method.value.invokeMember(MethodNames.Function.GET_SOURCE_START) shouldEqual 1
+    method.value.invokeMember(MethodNames.Function.GET_SOURCE_LENGTH) shouldEqual 24
+
+    instrumenter.assertNodeExists(16, 9, classOf[ApplicationNode])
+
+    eval(code)
+  }
+
+  "Sugared function definitions" should "get the right locations" in
+  withLocationsInstrumenter { instrumenter =>
+    val code =
+      """
+        |main =
+        |    f a b = a - b
+        |    f 10 20
+        |""".stripMargin
+
+    instrumenter.assertNodeExists(12, 13, classOf[AssignmentNode])
+    instrumenter.assertNodeExists(20, 5, classOf[ApplicationNode])
     eval(code)
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/FunctionSugarTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/FunctionSugarTest.scala
@@ -1,11 +1,6 @@
 package org.enso.interpreter.test.semantic
 
-import org.enso.interpreter.node.ClosureRootNode
-import org.enso.interpreter.node.callable.ApplicationNode
-import org.enso.interpreter.node.callable.function.CreateFunctionNode
-import org.enso.interpreter.node.scope.AssignmentNode
 import org.enso.interpreter.test.InterpreterTest
-import org.enso.polyglot.MethodNames
 
 class FunctionSugarTest extends InterpreterTest {
 
@@ -20,19 +15,6 @@ class FunctionSugarTest extends InterpreterTest {
     eval(code) shouldEqual -10
   }
 
-  "Sugared function definitions" should "get the right locations" in
-  withLocationsInstrumenter { instrumenter =>
-    val code =
-      """
-        |main =
-        |    f a b = a - b
-        |    f 10 20
-        |""".stripMargin
-
-    instrumenter.assertNodeExists(12, 13, classOf[AssignmentNode])
-    eval(code)
-  }
-
   "Sugared method definitions" should "work" in {
     val code =
       """
@@ -42,24 +24,5 @@ class FunctionSugarTest extends InterpreterTest {
         |""".stripMargin
 
     eval(code) shouldEqual 4
-  }
-
-  "Sugared method definitions" should "get the right locations" in
-  withLocationsInstrumenter { _ =>
-    val code =
-      """
-        |Test.foo a b = a * b - a
-        |
-        |main = Test.foo 2 3
-        |""".stripMargin
-
-//    instrumenter.assertNodeExists(1, 25, classOf[ClosureRootNode])
-    val mod = executionContext.evalModule(code, "Test")
-    val tpe = mod.getAssociatedConstructor
-    val method = mod.getMethod(tpe, "foo")
-    method.value.invokeMember(MethodNames.Function.GET_SOURCE_START) shouldEqual 1
-    method.value.invokeMember(MethodNames.Function.GET_SOURCE_LENGTH) shouldEqual 24
-
-    eval(code)
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/FunctionSugarTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/FunctionSugarTest.scala
@@ -5,6 +5,7 @@ import org.enso.interpreter.node.callable.ApplicationNode
 import org.enso.interpreter.node.callable.function.CreateFunctionNode
 import org.enso.interpreter.node.scope.AssignmentNode
 import org.enso.interpreter.test.InterpreterTest
+import org.enso.polyglot.MethodNames
 
 class FunctionSugarTest extends InterpreterTest {
 
@@ -44,15 +45,21 @@ class FunctionSugarTest extends InterpreterTest {
   }
 
   "Sugared method definitions" should "get the right locations" in
-  withLocationsInstrumenter { instrumenter =>
+  withLocationsInstrumenter { _ =>
     val code =
       """
-        |Unit.foo a b = a * b - a
+        |Test.foo a b = a * b - a
         |
-        |main = Unit.foo 2 3
+        |main = Test.foo 2 3
         |""".stripMargin
 
-    instrumenter.assertNodeExists(1, 24, classOf[ClosureRootNode])
+//    instrumenter.assertNodeExists(1, 25, classOf[ClosureRootNode])
+    val mod = executionContext.evalModule(code, "Test")
+    val tpe = mod.getAssociatedConstructor
+    val method = mod.getMethod(tpe, "foo")
+    method.value.invokeMember(MethodNames.Function.GET_SOURCE_START) shouldEqual 1
+    method.value.invokeMember(MethodNames.Function.GET_SOURCE_LENGTH) shouldEqual 24
+
     eval(code)
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/FunctionSugarTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/FunctionSugarTest.scala
@@ -1,0 +1,58 @@
+package org.enso.interpreter.test.semantic
+
+import org.enso.interpreter.node.ClosureRootNode
+import org.enso.interpreter.node.callable.ApplicationNode
+import org.enso.interpreter.node.callable.function.CreateFunctionNode
+import org.enso.interpreter.node.scope.AssignmentNode
+import org.enso.interpreter.test.InterpreterTest
+
+class FunctionSugarTest extends InterpreterTest {
+
+  "Sugared function definitions" should "work" in {
+    val code =
+      """
+        |main =
+        |    f a b = a - b
+        |    f 10 20
+        |""".stripMargin
+
+    eval(code) shouldEqual -10
+  }
+
+  "Sugared function definitions" should "get the right locations" in
+  withLocationsInstrumenter { instrumenter =>
+    val code =
+      """
+        |main =
+        |    f a b = a - b
+        |    f 10 20
+        |""".stripMargin
+
+    instrumenter.assertNodeExists(12, 13, classOf[AssignmentNode])
+    eval(code)
+  }
+
+  "Sugared method definitions" should "work" in {
+    val code =
+      """
+        |Unit.foo a b = a * b - a
+        |
+        |main = Unit.foo 2 3
+        |""".stripMargin
+
+    eval(code) shouldEqual 4
+  }
+
+  "Sugared method definitions" should "get the right locations" in
+  withLocationsInstrumenter { instrumenter =>
+    val code =
+      """
+        |Unit.foo a b = a * b - a
+        |
+        |main = Unit.foo 2 3
+        |""".stripMargin
+
+    instrumenter.assertNodeExists(1, 24, classOf[ClosureRootNode])
+    eval(code)
+  }
+}


### PR DESCRIPTION
### Pull Request Description
This PR introduces syntax sugar for the definition of functions and methods, in keeping with the language's syntax specification. It also fixes some potential bugs in the inline flow and with method body generation. 

Closes #496.

### Important Notes
None of the miscellaneous code cleanups affect performance. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/docs/style-guide/scala.md) and [Java](https://github.com/luna/enso/blob/master/docs/style-guide/java.md) style guides.
- [x] All code has been tested where possible.
