### PR TITLE
Add task fixing Instruments compilation.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -665,6 +665,7 @@ lazy val runtime = (project in file("engine/runtime"))
     Test / unmanagedClasspath += (`core-definition` / Compile / packageBin).value,
     Compile / compile := (Compile / compile)
       .dependsOn(`core-definition` / Compile / packageBin)
+      .dependsOn(FixInstrumentsGeneration.task)
       .value
   )
   .settings(

--- a/docs/runtime/README.md
+++ b/docs/runtime/README.md
@@ -40,3 +40,5 @@ broken up as follows:
   the features of the Enso runtime.
 - [**Unbounded Recursion:**](./unbounded-recursion.md) An exploration of
   techniques for achieving unbounded recursion on the JVM.
+- [**Instruments:**](./instruments.md) A description of instruments in the
+  language runtime.

--- a/docs/runtime/README.md
+++ b/docs/runtime/README.md
@@ -40,5 +40,5 @@ broken up as follows:
   the features of the Enso runtime.
 - [**Unbounded Recursion:**](./unbounded-recursion.md) An exploration of
   techniques for achieving unbounded recursion on the JVM.
-- [**Instruments:**](./instruments.md) A description of instruments in the
+- [**Instruments:**](./instruments.md) A description of instrumentation in the
   language runtime.

--- a/docs/runtime/instruments.md
+++ b/docs/runtime/instruments.md
@@ -1,0 +1,41 @@
+---
+layout: developer-doc
+title: Instruments
+category: runtime
+tags: [runtime, instruments]
+order: 6
+---
+
+# Instruments
+Instruments are used to track runtime events to allow for profiling, debugging
+and other kinds of runtime behavior analysis.
+
+<!-- MarkdownTOC levels="2,3" autolink="true" -->
+
+- [Naming conventions](#naming-conventions)
+- [Compilation fix](#compilation-fix)
+
+<!-- /MarkdownTOC -->
+
+## Naming conventions
+
+Instruments are implemented in Java and should all reside in the
+`org.enso.interpreter.instrument` package.
+
+Every implemented Instrument must have name that ends with `Instrument` and
+reside in the package mentioned above. This requirement is to ensure that the
+[Compilation fix](#compilation-fix) described below works.
+
+
+## Compilation fix
+
+Annotations are used to register the implemented instruments to Graal.
+The annotation processor is triggered when recompiling the Java files.
+Unfortunately, when doing an incremental compilation, only the changed files are
+recompiled and the annotation processor 'forgets' about other instruments that
+haven't been recompiled, leading to runtime errors about missing instruments.
+
+To fix that, we add
+[`FixInstrumentsGeneration.scala`](../../project/FixInstrumentsGeneration.scala)
+task which detects changes to any of the instruments and forces recompilation of
+all instruments in the project by removing their classfiles.

--- a/docs/runtime/instruments.md
+++ b/docs/runtime/instruments.md
@@ -8,34 +8,28 @@ order: 6
 
 # Instruments
 Instruments are used to track runtime events to allow for profiling, debugging
-and other kinds of runtime behavior analysis.
+and other kinds of behavior analysis at runtime.
 
 <!-- MarkdownTOC levels="2,3" autolink="true" -->
 
-- [Naming conventions](#naming-conventions)
-- [Compilation fix](#compilation-fix)
+- [Naming Conventions](#naming-conventions)
+- [Fixing Compilation](#fixing-compilation)
 
 <!-- /MarkdownTOC -->
 
-## Naming conventions
+## Naming Conventions
+Every Instrument must be implemented in Java and have name that ends with
+`Instrument`. This requirement is to ensure that the [fix](#fixing-compilation)
+described below works.
 
-Instruments are implemented in Java and should all reside in the
-`org.enso.interpreter.instrument` package.
-
-Every implemented Instrument must have name that ends with `Instrument` and
-reside in the package mentioned above. This requirement is to ensure that the
-[Compilation fix](#compilation-fix) described below works.
-
-
-## Compilation fix
-
-Annotations are used to register the implemented instruments to Graal.
+## Fixing Compilation
+Annotations are used to register the implemented instruments with Graal.
 The annotation processor is triggered when recompiling the Java files.
 Unfortunately, when doing an incremental compilation, only the changed files are
 recompiled and the annotation processor 'forgets' about other instruments that
 haven't been recompiled, leading to runtime errors about missing instruments.
 
-To fix that, we add
+To fix that, we add the
 [`FixInstrumentsGeneration.scala`](../../project/FixInstrumentsGeneration.scala)
 task which detects changes to any of the instruments and forces recompilation of
 all instruments in the project by removing their classfiles.

--- a/docs/runtime/instruments.md
+++ b/docs/runtime/instruments.md
@@ -23,8 +23,8 @@ Every Instrument must be implemented in Java and have name that ends with
 described below works.
 
 ## Fixing Compilation
-Annotations are used to register the implemented instruments with Graal.
-The annotation processor is triggered when recompiling the Java files.
+Annotations are used to register the implemented instruments with Graal. The
+annotation processor is triggered when recompiling the Java files.
 Unfortunately, when doing an incremental compilation, only the changed files are
 recompiled and the annotation processor 'forgets' about other instruments that
 haven't been recompiled, leading to runtime errors about missing instruments.

--- a/project/FixInstrumentsGeneration.scala
+++ b/project/FixInstrumentsGeneration.scala
@@ -2,23 +2,20 @@ import sbt.Keys._
 import sbt._
 
 object FixInstrumentsGeneration {
-  private val instrumentsSubPath = "org/enso/interpreter/instrument"
 
   /**
     * This task detects any changes in source files of Instruments and forces
-    * recompilation of all instruments on any change.
-    * This is to ensure that the Annotation Processor registers all of the
-    * instruments.
-    * (Without that fix, incremental compilation would not register unchanged
-    * instruments, leading to runtime errors.)
+    * recompilation of all instruments on any change. This is to ensure that the
+    * Annotation Processor registers all of the instruments.
+    *
+    * Without that fix, incremental compilation would not register unchanged
+    * instruments, leading to runtime errors.
     */
   lazy val task = Def.task {
     val root = baseDirectory.value
     val sources =
-      (file(s"$root/src/main/java/$instrumentsSubPath") ** "*Instrument.java").get
-    val baseClassDirectory = (Compile / classDirectory).value
-    val classFilesDirectory =
-      file(s"$baseClassDirectory/$instrumentsSubPath")
+      (file(s"$root/src/main/java/") ** "*Instrument.java").get
+    val classFilesDirectory = (Compile / classDirectory).value
 
     val schemaSourcesStore =
       streams.value.cacheStoreFactory.make("instruments_fixer")
@@ -31,9 +28,11 @@ object FixInstrumentsGeneration {
               s" and ${sourcesDiff.modified.size - 1} others"
             else ""
           val firstInstrument = sourcesDiff.modified.head
+          val sourcesMessage  = firstInstrument.toString + others
           println(
-            s"Instruments sources ($firstInstrument$others) have been changed.\n" +
-            s"Forcing recompilation of all instruments to maintain consistency of generated services files."
+            s"Instruments sources ($sourcesMessage) have been changed.\n" +
+            s"Forcing recompilation of all instruments to maintain " +
+            s"consistency of generated services files."
           )
 
           val instrumentRelatedClassFiles =

--- a/project/FixInstrumentsGeneration.scala
+++ b/project/FixInstrumentsGeneration.scala
@@ -1,0 +1,45 @@
+import sbt.Keys._
+import sbt._
+
+object FixInstrumentsGeneration {
+  private val instrumentsSubPath = "org/enso/interpreter/instrument"
+
+  /**
+    * This task detects any changes in source files of Instruments and forces
+    * recompilation of all instruments on any change.
+    * This is to ensure that the Annotation Processor registers all of the
+    * instruments.
+    * (Without that fix, incremental compilation would not register unchanged
+    * instruments, leading to runtime errors.)
+    */
+  lazy val task = Def.task {
+    val root = baseDirectory.value
+    val sources =
+      (file(s"$root/src/main/java/$instrumentsSubPath") ** "*Instrument.java").get
+    val baseClassDirectory = (Compile / classDirectory).value
+    val classFilesDirectory =
+      file(s"$baseClassDirectory/$instrumentsSubPath")
+
+    val schemaSourcesStore =
+      streams.value.cacheStoreFactory.make("instruments_fixer")
+
+    Tracked.diffInputs(schemaSourcesStore, FileInfo.hash)(sources.toSet) {
+      sourcesDiff: ChangeReport[File] =>
+        if (sourcesDiff.modified.nonEmpty) {
+          val others =
+            if (sourcesDiff.modified.size >= 2)
+              s" and ${sourcesDiff.modified.size - 1} others"
+            else ""
+          val firstInstrument = sourcesDiff.modified.head
+          println(
+            s"Instruments sources ($firstInstrument$others) have been changed.\n" +
+            s"Forcing recompilation of all instruments to maintain consistency of generated services files."
+          )
+
+          val instrumentRelatedClassFiles =
+            (classFilesDirectory ** "*Instrument.class").get
+          instrumentRelatedClassFiles.foreach(_.delete())
+        }
+    }
+  }
+}


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
Incremental compilation of instruments may lead to runtime errors when only some of the instruments are recompiled (because the unchanged instruments are not registered by the Annotation Processor).

To fix this, we add a task that ensures all instruments are recompiled when at least one of them changes.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->
The task fixing the issue assumes that all instruments have names ending in `Instrument` and reside in the `org.enso.interpreter.instrument` package. Those assertions are specified in the added documentation.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/docs/style-guide/scala.md) and [Java](https://github.com/luna/enso/blob/master/docs/style-guide/java.md) style guides.
- [x] All code has been tested where possible.
