### PR TITLE
Robust stoppage of the Language Server

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/LanguageServerComponent.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/LanguageServerComponent.scala
@@ -9,8 +9,8 @@ import org.enso.languageserver.boot.LifecycleComponent.{
   ComponentStopped
 }
 
-import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 /**
   * A lifecycle component used to start and stop a Language Server.
@@ -52,39 +52,48 @@ class LanguageServerComponent(config: LanguageServerConfig)
       case None =>
         Future.failed(new Exception("Server isn't running"))
 
-      case Some(serverState) =>
+      case Some(serverContext) =>
         for {
-          _ <- serverState.jsonBinding.terminate(10.seconds)
-          _ <- serverState.binaryBinding.terminate(10.seconds)
-          _ <- serverState.mainModule.system.terminate()
-          _ <- Future { serverState.mainModule.context.close(true) }
+          _ <- terminateAkka(serverContext)
+          _ <- terminateTruffle(serverContext)
           _ <- Future { maybeServerCtx = None }
         } yield ComponentStopped
     }
 
+  private def terminateAkka(serverContext: ServerContext): Future[Unit] = {
+    for {
+      _ <- serverContext.jsonBinding.terminate(2.seconds).recover(logError)
+      _ <- Future { logger.info("Terminated json connections") }
+      _ <- serverContext.binaryBinding.terminate(2.seconds).recover(logError)
+      _ <- Future { logger.info("Terminated binary connections") }
+      _ <- Await
+        .ready(
+          serverContext.mainModule.system.terminate().recover(logError),
+          2.seconds
+        )
+        .recover(logError)
+      _ <- Future { logger.info("Terminated actor system") }
+    } yield ()
+  }
+
+  private def terminateTruffle(serverContext: ServerContext): Future[Unit] = {
+    val killFiber =
+      Future {
+        serverContext.mainModule.context.close(true)
+      }
+
+    for {
+      _ <- Await.ready(killFiber, 5.seconds).recover(logError)
+      _ <- Future { logger.info("Terminated truffle context") }
+    } yield ()
+  }
+
   /** @inheritdoc **/
   override def restart(): Future[ComponentRestarted.type] =
     for {
-      _ <- forceStop()
+      _ <- stop()
       _ <- start()
     } yield ComponentRestarted
-
-  private def forceStop(): Future[Unit] = {
-    maybeServerCtx match {
-      case None =>
-        Future.successful(())
-
-      case Some(serverState) =>
-        for {
-          _ <- serverState.jsonBinding.terminate(10.seconds).recover(logError)
-          _ <- serverState.binaryBinding.terminate(10.seconds).recover(logError)
-          _ <- serverState.mainModule.system.terminate().recover(logError)
-          _ <- Future { serverState.mainModule.context.close(true) }
-            .recover(logError)
-          _ <- Future { maybeServerCtx = None }
-        } yield ()
-    }
-  }
 
   private val logError: PartialFunction[Throwable, Unit] = {
     case th => logger.error("An error occurred during stopping server", th)

--- a/lib/project-manager/src/main/resources/application.conf
+++ b/lib/project-manager/src/main/resources/application.conf
@@ -43,7 +43,7 @@ project-manager {
     io-timeout = 5 seconds
     request-timeout = 10 seconds
     boot-timeout = 40 seconds
-    stoppage-timeout = 10 seconds
+    stoppage-timeout = 15 seconds
   }
 
   tutorials {

--- a/lib/project-manager/src/main/resources/application.conf
+++ b/lib/project-manager/src/main/resources/application.conf
@@ -43,6 +43,7 @@ project-manager {
     io-timeout = 5 seconds
     request-timeout = 10 seconds
     boot-timeout = 40 seconds
+    stoppage-timeout = 10 seconds
   }
 
   tutorials {

--- a/lib/project-manager/src/main/scala/org/enso/projectmanager/boot/MainModule.scala
+++ b/lib/project-manager/src/main/scala/org/enso/projectmanager/boot/MainModule.scala
@@ -79,7 +79,12 @@ class MainModule[F[+_, +_]: Sync: ErrorChannel: Exec: CovariantFlatMap: Async](
   lazy val languageServerRegistry =
     system.actorOf(
       LanguageServerRegistry
-        .props(config.network, config.bootloader, config.supervision),
+        .props(
+          config.network,
+          config.bootloader,
+          config.supervision,
+          config.timeout
+        ),
       "language-server-registry"
     )
 

--- a/lib/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
+++ b/lib/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
@@ -50,7 +50,8 @@ object configuration {
   case class TimeoutConfig(
     ioTimeout: FiniteDuration,
     requestTimeout: FiniteDuration,
-    bootTimeout: FiniteDuration
+    bootTimeout: FiniteDuration,
+    stoppageTimeout: FiniteDuration
   )
 
   /**

--- a/lib/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerProtocol.scala
+++ b/lib/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerProtocol.scala
@@ -72,6 +72,11 @@ object LanguageServerProtocol {
   sealed trait ServerStoppageFailure extends ServerStoppageResult
 
   /**
+    * Signals that server stoppage timed out.
+    */
+  case object ServerStoppageTimedOut extends ServerStoppageFailure
+
+  /**
     * Signals that an exception was thrown during stopping a server.
     *
     * @param th an exception

--- a/lib/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerRegistry.scala
+++ b/lib/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerRegistry.scala
@@ -6,7 +6,8 @@ import akka.actor.{Actor, ActorLogging, ActorRef, Props, Terminated}
 import org.enso.projectmanager.boot.configuration.{
   BootloaderConfig,
   NetworkConfig,
-  SupervisionConfig
+  SupervisionConfig,
+  TimeoutConfig
 }
 import org.enso.projectmanager.infrastructure.languageserver.LanguageServerProtocol.{
   CheckIfServerIsRunning,
@@ -24,11 +25,14 @@ import org.enso.projectmanager.util.UnhandledLogging
   *
   * @param networkConfig a net config
   * @param bootloaderConfig a bootloader config
+  * @param supervisionConfig a supervision config
+  * @param timeoutConfig a timeout config
   */
 class LanguageServerRegistry(
   networkConfig: NetworkConfig,
   bootloaderConfig: BootloaderConfig,
-  supervisionConfig: SupervisionConfig
+  supervisionConfig: SupervisionConfig,
+  timeoutConfig: TimeoutConfig
 ) extends Actor
     with ActorLogging
     with UnhandledLogging {
@@ -44,7 +48,13 @@ class LanguageServerRegistry(
       } else {
         val controller = context.actorOf(
           LanguageServerController
-            .props(project, networkConfig, bootloaderConfig, supervisionConfig),
+            .props(
+              project,
+              networkConfig,
+              bootloaderConfig,
+              supervisionConfig,
+              timeoutConfig
+            ),
           s"language-server-controller-${project.id}"
         )
         context.watch(controller)
@@ -86,18 +96,22 @@ object LanguageServerRegistry {
     *
     * @param networkConfig a net config
     * @param bootloaderConfig a bootloader config
+    * @param supervisionConfig a supervision config
+    * @param timeoutConfig a timeout config
     * @return
     */
   def props(
     networkConfig: NetworkConfig,
     bootloaderConfig: BootloaderConfig,
-    supervisionConfig: SupervisionConfig
+    supervisionConfig: SupervisionConfig,
+    timeoutConfig: TimeoutConfig
   ): Props =
     Props(
       new LanguageServerRegistry(
         networkConfig,
         bootloaderConfig,
-        supervisionConfig
+        supervisionConfig,
+        timeoutConfig
       )
     )
 

--- a/lib/project-manager/src/main/scala/org/enso/projectmanager/protocol/ClientController.scala
+++ b/lib/project-manager/src/main/scala/org/enso/projectmanager/protocol/ClientController.scala
@@ -16,6 +16,7 @@ import org.enso.projectmanager.service.ProjectServiceApi
 import org.enso.projectmanager.util.UnhandledLogging
 
 import scala.annotation.unused
+import scala.concurrent.duration._
 
 /**
   * An actor handling communications between a single client and the project
@@ -43,7 +44,11 @@ class ClientController[F[+_, +_]: Exec](
       ProjectOpen -> ProjectOpenHandler
         .props[F](clientId, projectService, config.bootTimeout),
       ProjectClose -> ProjectCloseHandler
-        .props[F](clientId, projectService, config.requestTimeout),
+        .props[F](
+          clientId,
+          projectService,
+          config.stoppageTimeout.plus(1.second)
+        ),
       ProjectListRecent -> ProjectListRecentHandler
         .props[F](clientId, projectService, config.requestTimeout)
     )

--- a/lib/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
+++ b/lib/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
@@ -130,6 +130,9 @@ class ProjectService[F[+_, +_]: ErrorChannel: CovariantFlatMap](
   ): F[ProjectServiceFailure, Unit] = {
     log.debug(s"Closing project $projectId") *>
     languageServerService.stop(clientId, projectId).mapError {
+      case ServerStoppageTimedOut =>
+        ProjectCloseFailed("Server stoppage timed out")
+
       case FailureDuringStoppage(th)    => ProjectCloseFailed(th.getMessage)
       case ServerNotRunning             => ProjectNotOpen
       case CannotDisconnectOtherClients => ProjectOpenByOtherPeers

--- a/lib/project-manager/src/test/resources/application.conf
+++ b/lib/project-manager/src/test/resources/application.conf
@@ -43,6 +43,7 @@ project-manager {
     io-timeout = 5 seconds
     request-timeout = 10 seconds
     boot-timeout = 30 seconds
+    stoppage-timeout = 10 seconds
   }
 
   tutorials {

--- a/lib/project-manager/src/test/scala/org/enso/projectmanager/protocol/BaseServerSpec.scala
+++ b/lib/project-manager/src/test/scala/org/enso/projectmanager/protocol/BaseServerSpec.scala
@@ -66,7 +66,8 @@ class BaseServerSpec extends JsonRpcServerTestKit {
 
   lazy val bootloaderConfig = BootloaderConfig(3, 1.second)
 
-  lazy val timeoutConfig = TimeoutConfig(3.seconds, 3.seconds, 3.seconds)
+  lazy val timeoutConfig =
+    TimeoutConfig(3.seconds, 3.seconds, 3.seconds, 5.seconds)
 
   lazy val netConfig = NetworkConfig("127.0.0.1", 40000, 60000)
 
@@ -98,7 +99,7 @@ class BaseServerSpec extends JsonRpcServerTestKit {
   lazy val languageServerRegistry =
     system.actorOf(
       LanguageServerRegistry
-        .props(netConfig, bootloaderConfig, supervisionConfig)
+        .props(netConfig, bootloaderConfig, supervisionConfig, timeoutConfig)
     )
 
   lazy val languageServerService =


### PR DESCRIPTION
### Pull Request Description
This PR mitigates the problems caused by indefinite waiting on `TruffleContext.close()` method.

### Important Notes
It's not a solution for bug #793. It only forcefully stops the server.

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Scala](https://github.com/luna/enso/blob/master/docs/style-guide/scala.md) and [Java](https://github.com/luna/enso/blob/master/docs/style-guide/java.md) style guides.
- [ ] All code has been tested where possible.
