### PR TITLE
Booleans support

### DIFF
--- a/engine/runtime/src/bench/scala/org/enso/interpreter/bench/fixtures/semantic/AtomFixtures.scala
+++ b/engine/runtime/src/bench/scala/org/enso/interpreter/bench/fixtures/semantic/AtomFixtures.scala
@@ -1,7 +1,7 @@
 package org.enso.interpreter.bench.fixtures.semantic
 
-import org.enso.interpreter.runtime.Builtins
 import org.enso.interpreter.test.DefaultInterpreterRunner
+import org.enso.interpreter.runtime.builtin.Builtins
 import org.graalvm.polyglot.Value
 
 class AtomFixtures extends DefaultInterpreterRunner {
@@ -22,7 +22,7 @@ class AtomFixtures extends DefaultInterpreterRunner {
   val generateListCode =
     """
       |main = length ->
-      |    generator = acc -> i -> ifZero i acc (generator (Cons i acc) (i - 1))
+      |    generator = acc -> i -> if i == 0 then acc else generator (Cons i acc) (i - 1)
       |
       |    res = generator Nil length
       |    res

--- a/engine/runtime/src/bench/scala/org/enso/interpreter/bench/fixtures/semantic/NamedDefaultedArgumentFixtures.scala
+++ b/engine/runtime/src/bench/scala/org/enso/interpreter/bench/fixtures/semantic/NamedDefaultedArgumentFixtures.scala
@@ -9,7 +9,7 @@ class NamedDefaultedArgumentFixtures extends DefaultInterpreterRunner {
     """
       |main = sumTo ->
       |    summator = acc -> current ->
-      |        ifZero current acc (summator (current = current - 1) (acc = acc + current))
+      |        if current == 0 then acc else summator (current = current - 1) (acc = acc + current)
       |
       |    res = summator current=sumTo acc=0
       |    res
@@ -20,7 +20,7 @@ class NamedDefaultedArgumentFixtures extends DefaultInterpreterRunner {
     """
       |main = sumTo ->
       |    summator = (acc = 0) -> current ->
-      |        ifZero current acc (summator (current = current - 1) (acc = acc + current))
+      |        if current == 0 then acc else summator (current = current - 1) (acc = acc + current)
       |
       |    res = summator (current = sumTo)
       |    res

--- a/engine/runtime/src/bench/scala/org/enso/interpreter/bench/fixtures/semantic/RecursionFixtures.scala
+++ b/engine/runtime/src/bench/scala/org/enso/interpreter/bench/fixtures/semantic/RecursionFixtures.scala
@@ -12,7 +12,7 @@ class RecursionFixtures extends DefaultInterpreterRunner {
     """
       |main = sumTo ->
       |    summator = acc -> current ->
-      |        ifZero current acc (summator acc+current current-1)
+      |        if current == 0 then acc else summator acc+current current-1
       |
       |    res = summator 0 sumTo
       |    res
@@ -23,7 +23,7 @@ class RecursionFixtures extends DefaultInterpreterRunner {
     """
       |main = sumTo ->
       |    summator = acc -> i -> f ->
-      |        ifZero i acc (summator (f acc i) (i - 1) f)
+      |        if i == 0 then acc else summator (f acc i) (i - 1) f
       |    res = summator 0 sumTo (x -> y -> x + y)
       |    res
       |""".stripMargin
@@ -32,7 +32,7 @@ class RecursionFixtures extends DefaultInterpreterRunner {
   val sumRecursiveCode =
     """
       |main = sumTo ->
-      |    summator = i -> ifZero i 0 (i + summator (i - 1))
+      |    summator = i -> if i == 0 then 0 else i + summator (i - 1)
       |    res = summator sumTo
       |    res
     """.stripMargin
@@ -42,7 +42,7 @@ class RecursionFixtures extends DefaultInterpreterRunner {
     """
       |main = sumTo ->
       |    summator = acc -> i -> f ->
-      |        ifZero i acc (summator (f acc i) (i - 1) f)
+      |        if i == 0 then acc else summator (f acc i) (i - 1) f
       |    res = summator 0 sumTo (x -> y -> x + y)
       |    res
       |""".stripMargin
@@ -54,7 +54,7 @@ class RecursionFixtures extends DefaultInterpreterRunner {
       |    stateSum = n ->
       |        acc = State.get
       |        State.put (acc + n)
-      |        ifZero n State.get (stateSum (n - 1))
+      |        if n == 0 then State.get else stateSum (n - 1)
       |
       |    State.put 0
       |    res = stateSum sumTo
@@ -66,7 +66,7 @@ class RecursionFixtures extends DefaultInterpreterRunner {
     """
       |main = sumTo ->
       |    summator = acc -> current ->
-      |        ifZero current acc (Debug.eval "summator (acc + current) (current - 1)")
+      |        if current == 0 then acc else Debug.eval "summator (acc + current) (current - 1)"
       |
       |    res = summator 0 sumTo
       |    res
@@ -78,7 +78,7 @@ class RecursionFixtures extends DefaultInterpreterRunner {
       |main = n ->
       |    doNTimes = n -> ~block ->
       |        block
-      |        ifZero n-1 Unit (doNTimes n-1 block)
+      |        if n == 1 then Unit else doNTimes n-1 block
       |
       |    block =
       |        x = State.get

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.node.expression.debug.CaptureResultScopeNode;
 import org.enso.interpreter.node.expression.debug.EvalNode;
-import org.enso.interpreter.runtime.Builtins;
+import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.CallerInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.scope.FramePointer;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ExpressionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ExpressionNode.java
@@ -11,7 +11,7 @@ import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import com.oracle.truffle.api.source.SourceSection;
-import org.enso.interpreter.runtime.Builtins;
+import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/MethodResolverNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/MethodResolverNode.java
@@ -52,7 +52,7 @@ public abstract class MethodResolverNode extends Node {
   public abstract Function execute(UnresolvedSymbol symbol, Object self);
 
   @Specialization(guards = "isValidAtomCache(symbol, cachedSymbol, atom, cachedConstructor)")
-  Function resolveAtomCached(
+  Function resolveAtom(
       UnresolvedSymbol symbol,
       Atom atom,
       @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
@@ -64,7 +64,7 @@ public abstract class MethodResolverNode extends Node {
   }
 
   @Specialization(guards = {"cachedSymbol == symbol", "atomConstructor == cachedConstructor"})
-  Function resolveAtomConstructorCached(
+  Function resolveAtomConstructor(
       UnresolvedSymbol symbol,
       AtomConstructor atomConstructor,
       @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
@@ -75,7 +75,7 @@ public abstract class MethodResolverNode extends Node {
   }
 
   @Specialization(guards = "cachedSymbol == symbol")
-  Function resolveNumberCached(
+  Function resolveNumber(
       UnresolvedSymbol symbol,
       long self,
       @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
@@ -85,7 +85,7 @@ public abstract class MethodResolverNode extends Node {
   }
 
   @Specialization(guards = {"cachedSymbol == symbol", "function != null"})
-  Function resolveBooleanCached(
+  Function resolveBoolean(
       UnresolvedSymbol symbol,
       boolean self,
       @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
@@ -99,8 +99,8 @@ public abstract class MethodResolverNode extends Node {
 
   @Specialization(
       guards = {"cachedSymbol == symbol", "self"},
-      replaces = "resolveBooleanCached")
-  Function resolveTrueCached(
+      replaces = "resolveBoolean")
+  Function resolveTrue(
       UnresolvedSymbol symbol,
       boolean self,
       @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
@@ -114,8 +114,8 @@ public abstract class MethodResolverNode extends Node {
 
   @Specialization(
       guards = {"cachedSymbol == symbol", "!self"},
-      replaces = "resolveBooleanCached")
-  Function resolveFalseCached(
+      replaces = "resolveBoolean")
+  Function resolveFalse(
       UnresolvedSymbol symbol,
       boolean self,
       @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
@@ -128,7 +128,7 @@ public abstract class MethodResolverNode extends Node {
   }
 
   @Specialization(guards = "cachedSymbol == symbol")
-  Function resolveStringCached(
+  Function resolveString(
       UnresolvedSymbol symbol,
       String self,
       @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
@@ -138,7 +138,7 @@ public abstract class MethodResolverNode extends Node {
   }
 
   @Specialization(guards = "cachedSymbol == symbol")
-  Function resolveFunctionCached(
+  Function resolveFunction(
       UnresolvedSymbol symbol,
       Function self,
       @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
@@ -148,7 +148,7 @@ public abstract class MethodResolverNode extends Node {
   }
 
   @Specialization(guards = "cachedSymbol == symbol")
-  Function resolveErrorCached(
+  Function resolveError(
       UnresolvedSymbol symbol,
       RuntimeError self,
       @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
@@ -158,7 +158,7 @@ public abstract class MethodResolverNode extends Node {
   }
 
   @Specialization(guards = {"cachedSymbol == symbol", "ctx.getEnvironment().isHostObject(target)"})
-  Function resolveHostCached(
+  Function resolveHost(
       UnresolvedSymbol symbol,
       Object target,
       @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/MethodResolverNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/MethodResolverNode.java
@@ -88,9 +88,11 @@ public abstract class MethodResolverNode extends Node {
   Function resolveBooleanCached(
       UnresolvedSymbol symbol,
       boolean self,
-      @Cached("symbol") UnresolvedSymbol cachedSymbol,
+      @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
       @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextReference,
-      @Cached("resolveMethodOnPrimBoolean(cachedSymbol, contextReference.get())")
+      @Cached(
+              value = "resolveMethodOnPrimBoolean(cachedSymbol, contextReference.get())",
+              allowUncached = true)
           Function function) {
     return function;
   }
@@ -101,9 +103,11 @@ public abstract class MethodResolverNode extends Node {
   Function resolveTrueCached(
       UnresolvedSymbol symbol,
       boolean self,
-      @Cached("symbol") UnresolvedSymbol cachedSymbol,
+      @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
       @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextReference,
-      @Cached("resolveMethodOnBool(true, cachedSymbol, contextReference.get())")
+      @Cached(
+              value = "resolveMethodOnBool(true, cachedSymbol, contextReference.get())",
+              allowUncached = true)
           Function function) {
     return function;
   }
@@ -114,9 +118,11 @@ public abstract class MethodResolverNode extends Node {
   Function resolveFalseCached(
       UnresolvedSymbol symbol,
       boolean self,
-      @Cached("symbol") UnresolvedSymbol cachedSymbol,
+      @Cached(value = "symbol", allowUncached = true) UnresolvedSymbol cachedSymbol,
       @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextReference,
-      @Cached("resolveMethodOnBool(false, cachedSymbol, contextReference.get())")
+      @Cached(
+              value = "resolveMethodOnBool(false, cachedSymbol, contextReference.get())",
+              allowUncached = true)
           Function function) {
     return function;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/BooleanBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/BooleanBranchNode.java
@@ -1,0 +1,78 @@
+package org.enso.interpreter.node.controlflow;
+
+import com.oracle.truffle.api.dsl.Fallback;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameUtil;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.profiles.ConditionProfile;
+import org.enso.interpreter.node.ExpressionNode;
+import org.enso.interpreter.node.callable.ExecuteCallNode;
+import org.enso.interpreter.node.callable.ExecuteCallNodeGen;
+import org.enso.interpreter.node.callable.function.CreateFunctionNode;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+/** An implementation of the case expression specialised to working on constructors. */
+@NodeInfo(shortName = "BooleanMatch")
+public abstract class BooleanBranchNode extends BranchNode {
+  private final boolean matched;
+  private @Child ExpressionNode branch;
+  private @Child ExecuteCallNode executeCallNode = ExecuteCallNodeGen.create();
+  private final ConditionProfile profile = ConditionProfile.createCountingProfile();
+
+  BooleanBranchNode(boolean matched, CreateFunctionNode branch) {
+    this.matched = matched;
+    this.branch = branch;
+  }
+
+  /**
+   * Creates a new node for handling matching on a case expression.
+   *
+   * @param matched the expression to use for matching
+   * @param branch the expression to be executed if (@code matcher} matches
+   * @return a node for matching in a case expression
+   */
+  public static BooleanBranchNode build(boolean matched, CreateFunctionNode branch) {
+    return BooleanBranchNodeGen.create(matched, branch);
+  }
+
+  /**
+   * Handles the atom scrutinee case.
+   *
+   * <p>The atom's constructor is checked and if it matches the conditional branch is executed with
+   * all the atom's fields as arguments.
+   *
+   * @param frame the stack frame in which to execute
+   * @param target the atom to destructure
+   */
+  @Specialization
+  public void doAtom(VirtualFrame frame, boolean target) {
+    Object state = FrameUtil.getObjectSafe(frame, getStateFrameSlot());
+    if (profile.profile(matched == target)) {
+      Function function = TypesGen.asFunction(branch.executeGeneric(frame));
+
+      // Note [Caller Info For Case Branches]
+      throw new BranchSelectedException(
+          executeCallNode.executeCall(function, null, state, new Object[0]));
+    }
+  }
+
+  /**
+   * The fallback specialisation for executing the constructor branch node.
+   *
+   * @param frame the stack frame in which to execute
+   * @param target the object to execute on
+   */
+  @Fallback
+  public void doFallback(VirtualFrame frame, Object target) {}
+
+  /* Note [Caller Info For Case Branches]
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * It is assumed that functions serving as pattern match logic branches are always function
+   * literals, not references, curried functions etc. Therefore, as function literals, they
+   * have no way of accessing the caller frame and can safely be passed null.
+   */
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/BooleanBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/BooleanBranchNode.java
@@ -15,7 +15,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-/** An implementation of the case expression specialised to working on constructors. */
+/** An implementation of the case expression specialised to working on booleans. */
 @NodeInfo(shortName = "BooleanMatch")
 public abstract class BooleanBranchNode extends BranchNode {
   private final boolean matched;
@@ -40,10 +40,7 @@ public abstract class BooleanBranchNode extends BranchNode {
   }
 
   /**
-   * Handles the atom scrutinee case.
-   *
-   * <p>The atom's constructor is checked and if it matches the conditional branch is executed with
-   * all the atom's fields as arguments.
+   * Handles the boolean scrutinee case.
    *
    * @param frame the stack frame in which to execute
    * @param target the atom to destructure
@@ -61,7 +58,7 @@ public abstract class BooleanBranchNode extends BranchNode {
   }
 
   /**
-   * The fallback specialisation for executing the constructor branch node.
+   * The fallback specialisation for executing the boolean branch node.
    *
    * @param frame the stack frame in which to execute
    * @param target the object to execute on

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/AndNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/AndNode.java
@@ -1,0 +1,72 @@
+package org.enso.interpreter.node.expression.builtin.bool;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.profiles.BranchProfile;
+import org.enso.interpreter.Language;
+import org.enso.interpreter.node.expression.builtin.BuiltinRootNode;
+import org.enso.interpreter.node.expression.builtin.number.ModNode;
+import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.callable.function.FunctionSchema;
+import org.enso.interpreter.runtime.error.TypeError;
+import org.enso.interpreter.runtime.state.Stateful;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@NodeInfo(shortName = "Boolean.&&", description = "Computes the logical AND of two booleans")
+public class AndNode extends BuiltinRootNode {
+  private final BranchProfile thatOpBadTypeProfile = BranchProfile.create();
+
+  private AndNode(Language language) {
+    super(language);
+  }
+
+  /**
+   * Creates a two-argument function wrapping this node.
+   *
+   * @param language the current language instance
+   * @return a function wrapping this node
+   */
+  public static Function makeFunction(Language language) {
+    return Function.fromBuiltinRootNode(
+        new AndNode(language),
+        FunctionSchema.CallStrategy.ALWAYS_DIRECT,
+        new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE),
+        new ArgumentDefinition(1, "that", ArgumentDefinition.ExecutionMode.EXECUTE));
+  }
+
+  /**
+   * Executes this node.
+   *
+   * @param frame current execution frame
+   * @return the result of performing `op` on the operands
+   */
+  @Override
+  public final Stateful execute(VirtualFrame frame) {
+    boolean thisArg =
+        TypesGen.asBoolean(
+            Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[0]);
+
+    Object thatArg = Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[1];
+
+    if (TypesGen.isBoolean(thatArg)) {
+      boolean thatArgBool = TypesGen.asBoolean(thatArg);
+      Object state = Function.ArgumentsHelper.getState(frame.getArguments());
+
+      return new Stateful(state, thisArg && thatArgBool);
+    } else {
+      thatOpBadTypeProfile.enter();
+      throw new TypeError("Unexpected type for `that` operand in " + getName(), this);
+    }
+  }
+
+  /**
+   * Returns a language-specific name for this node.
+   *
+   * @return the name of this node
+   */
+  @Override
+  public String getName() {
+    return "Boolean.||";
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/IfThenElseNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/IfThenElseNode.java
@@ -1,0 +1,80 @@
+package org.enso.interpreter.node.expression.builtin.bool;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.profiles.ConditionProfile;
+import org.enso.interpreter.Language;
+import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
+import org.enso.interpreter.node.expression.builtin.BuiltinRootNode;
+import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
+import org.enso.interpreter.runtime.callable.argument.Thunk;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.callable.function.FunctionSchema;
+import org.enso.interpreter.runtime.state.Stateful;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+/** The root node for the basic control flow structure of the language. */
+@NodeInfo(
+    shortName = "Boolean.if_then_else",
+    description = "Performs the standard if-then-else control flow operation.")
+public class IfThenElseNode extends BuiltinRootNode {
+  private @Child ThunkExecutorNode leftThunkExecutorNode = ThunkExecutorNode.build(true);
+  private @Child ThunkExecutorNode rightThunkExecutorNode = ThunkExecutorNode.build(true);
+  private final ConditionProfile condProfile = ConditionProfile.createCountingProfile();
+
+  private IfThenElseNode(Language language) {
+    super(language);
+  }
+
+  /**
+   * Takes a number and two thunks and executes the first thunk if the number was 0 and second
+   * otherwise.
+   *
+   * <p>Assumes the number is the first argument in the current execution frame, while the first and
+   * second thunks are respectively the second and third arguments.
+   *
+   * @param frame current execution frame
+   * @return the result of executing the proper thunk
+   */
+  @Override
+  public Stateful execute(VirtualFrame frame) {
+    boolean self =
+        TypesGen.asBoolean(
+            Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[0]);
+    Thunk ifT =
+        TypesGen.asThunk(Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[1]);
+    Thunk ifF =
+        TypesGen.asThunk(Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[2]);
+    Object state = Function.ArgumentsHelper.getState(frame.getArguments());
+    if (condProfile.profile(self)) {
+      return leftThunkExecutorNode.executeThunk(ifT, state);
+    } else {
+      return rightThunkExecutorNode.executeThunk(ifF, state);
+    }
+  }
+
+  /**
+   * Creates a three-argument function wrapping this node.
+   *
+   * @param language current language instance
+   * @return a function wrapping this node
+   */
+  public static Function makeFunction(Language language) {
+    return Function.fromBuiltinRootNode(
+        new IfThenElseNode(language),
+        FunctionSchema.CallStrategy.DIRECT_WHEN_TAIL,
+        new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE),
+        new ArgumentDefinition(1, "if_true", ArgumentDefinition.ExecutionMode.PASS_THUNK),
+        new ArgumentDefinition(2, "if_false", ArgumentDefinition.ExecutionMode.PASS_THUNK));
+  }
+
+  /**
+   * Gets the source-level name of this node.
+   *
+   * @return the source-level name of the node
+   */
+  @Override
+  public String getName() {
+    return "Boolean.if_then_else";
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/IfThenElseNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/IfThenElseNode.java
@@ -18,8 +18,8 @@ import org.enso.interpreter.runtime.type.TypesGen;
     shortName = "Boolean.if_then_else",
     description = "Performs the standard if-then-else control flow operation.")
 public class IfThenElseNode extends BuiltinRootNode {
-  private @Child ThunkExecutorNode leftThunkExecutorNode = ThunkExecutorNode.build(true);
-  private @Child ThunkExecutorNode rightThunkExecutorNode = ThunkExecutorNode.build(true);
+  private @Child ThunkExecutorNode leftThunkExecutorNode = ThunkExecutorNode.build();
+  private @Child ThunkExecutorNode rightThunkExecutorNode = ThunkExecutorNode.build();
   private final ConditionProfile condProfile = ConditionProfile.createCountingProfile();
 
   private IfThenElseNode(Language language) {
@@ -47,9 +47,9 @@ public class IfThenElseNode extends BuiltinRootNode {
         TypesGen.asThunk(Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[2]);
     Object state = Function.ArgumentsHelper.getState(frame.getArguments());
     if (condProfile.profile(self)) {
-      return leftThunkExecutorNode.executeThunk(ifT, state);
+      return leftThunkExecutorNode.executeThunk(ifT, state, true);
     } else {
-      return rightThunkExecutorNode.executeThunk(ifF, state);
+      return rightThunkExecutorNode.executeThunk(ifF, state, true);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/NotNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/NotNode.java
@@ -1,0 +1,58 @@
+package org.enso.interpreter.node.expression.builtin.bool;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInfo;
+import org.enso.interpreter.Language;
+import org.enso.interpreter.node.expression.builtin.BuiltinRootNode;
+import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.callable.function.FunctionSchema.CallStrategy;
+import org.enso.interpreter.runtime.state.Stateful;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@NodeInfo(shortName = "Boolean.not", description = "Logical negation.")
+public class NotNode extends BuiltinRootNode {
+  private NotNode(Language language) {
+    super(language);
+  }
+
+  /**
+   * Creates a one-argument function wrapping this node.
+   *
+   * @param language the current language instance
+   * @return a function wrapping this node
+   */
+  public static Function makeFunction(Language language) {
+    return Function.fromBuiltinRootNode(
+        new NotNode(language),
+        CallStrategy.ALWAYS_DIRECT,
+        new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE));
+  }
+
+  /**
+   * Executes this node.
+   *
+   * @param frame current execution frame
+   * @return the result of negating the function argument
+   */
+  @Override
+  public Stateful execute(VirtualFrame frame) {
+    boolean thisArg =
+        TypesGen.asBoolean(
+            Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[0]);
+
+    Object state = Function.ArgumentsHelper.getState(frame.getArguments());
+
+    return new Stateful(state, !thisArg);
+  }
+
+  /**
+   * Returns a language-specific name for this node.
+   *
+   * @return the name of this node
+   */
+  @Override
+  public String getName() {
+    return "Boolean.not";
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/OrNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/OrNode.java
@@ -1,0 +1,71 @@
+package org.enso.interpreter.node.expression.builtin.bool;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.profiles.BranchProfile;
+import org.enso.interpreter.Language;
+import org.enso.interpreter.node.expression.builtin.BuiltinRootNode;
+import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.callable.function.FunctionSchema;
+import org.enso.interpreter.runtime.error.TypeError;
+import org.enso.interpreter.runtime.state.Stateful;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@NodeInfo(shortName = "Boolean.||", description = "Computes the logical OR of two booleans")
+public class OrNode extends BuiltinRootNode {
+  private final BranchProfile thatOpBadTypeProfile = BranchProfile.create();
+
+  private OrNode(Language language) {
+    super(language);
+  }
+
+  /**
+   * Creates a two-argument function wrapping this node.
+   *
+   * @param language the current language instance
+   * @return a function wrapping this node
+   */
+  public static Function makeFunction(Language language) {
+    return Function.fromBuiltinRootNode(
+        new OrNode(language),
+        FunctionSchema.CallStrategy.ALWAYS_DIRECT,
+        new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE),
+        new ArgumentDefinition(1, "that", ArgumentDefinition.ExecutionMode.EXECUTE));
+  }
+
+  /**
+   * Executes this node.
+   *
+   * @param frame current execution frame
+   * @return the result of performing `op` on the operands
+   */
+  @Override
+  public final Stateful execute(VirtualFrame frame) {
+    boolean thisArg =
+        TypesGen.asBoolean(
+            Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[0]);
+
+    Object thatArg = Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[1];
+
+    if (TypesGen.isBoolean(thatArg)) {
+      boolean thatArgBool = TypesGen.asBoolean(thatArg);
+      Object state = Function.ArgumentsHelper.getState(frame.getArguments());
+
+      return new Stateful(state, thisArg || thatArgBool);
+    } else {
+      thatOpBadTypeProfile.enter();
+      throw new TypeError("Unexpected type for `that` operand in " + getName(), this);
+    }
+  }
+
+  /**
+   * Returns a language-specific name for this node.
+   *
+   * @return the name of this node
+   */
+  @Override
+  public String getName() {
+    return "Boolean.||";
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/ToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/ToTextNode.java
@@ -11,8 +11,7 @@ import org.enso.interpreter.runtime.callable.function.FunctionSchema.CallStrateg
 import org.enso.interpreter.runtime.state.Stateful;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-/** An implementation of generic string conversion. */
-@NodeInfo(shortName = "Boolean.to_text", description = "Generic text conversion.")
+@NodeInfo(shortName = "Boolean.to_text", description = "Boolean to text conversion.")
 public class ToTextNode extends BuiltinRootNode {
   private ToTextNode(Language language) {
     super(language);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/ToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/ToTextNode.java
@@ -1,0 +1,58 @@
+package org.enso.interpreter.node.expression.builtin.bool;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInfo;
+import org.enso.interpreter.Language;
+import org.enso.interpreter.node.expression.builtin.BuiltinRootNode;
+import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.callable.function.FunctionSchema.CallStrategy;
+import org.enso.interpreter.runtime.state.Stateful;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+/** An implementation of generic string conversion. */
+@NodeInfo(shortName = "Boolean.to_text", description = "Generic text conversion.")
+public class ToTextNode extends BuiltinRootNode {
+  private ToTextNode(Language language) {
+    super(language);
+  }
+
+  /**
+   * Creates a function wrapping this node.
+   *
+   * @param language the current language instance
+   * @return a function wrapping this node
+   */
+  public static Function makeFunction(Language language) {
+    return Function.fromBuiltinRootNode(
+        new ToTextNode(language),
+        CallStrategy.ALWAYS_DIRECT,
+        new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE));
+  }
+
+  /**
+   * Executes the node.
+   *
+   * @param frame current execution frame.
+   * @return the result of converting input into a string.
+   */
+  @Override
+  public Stateful execute(VirtualFrame frame) {
+    boolean thisArg =
+        TypesGen.asBoolean(
+            Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[0]);
+    Object state = Function.ArgumentsHelper.getState(frame.getArguments());
+    return new Stateful(state, thisArg ? "True" : "False");
+  }
+
+  /**
+   * Returns a language-specific name for this node.
+   *
+   * @return the name of this node
+   */
+  @Override
+  public String getName() {
+    return "Boolean.to_text";
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
@@ -7,31 +7,45 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import java.io.PrintStream;
 import org.enso.interpreter.Language;
+import org.enso.interpreter.node.callable.InvokeCallableNode;
 import org.enso.interpreter.node.expression.builtin.BuiltinRootNode;
 import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
+import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.callable.function.FunctionSchema;
+import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.interpreter.runtime.state.Stateful;
 
 /** Allows for printing arbitrary values to the standard output. */
 @NodeInfo(shortName = "IO.println", description = "Prints its argument to standard out.")
 public abstract class PrintlnNode extends BuiltinRootNode {
-  PrintlnNode(Language language) {
+  private final UnresolvedSymbol toTextSym;
+  private @Child InvokeCallableNode invokeCallableNode =
+      InvokeCallableNode.build(
+          new CallArgumentInfo[] {new CallArgumentInfo()},
+          InvokeCallableNode.DefaultsExecutionMode.EXECUTE,
+          InvokeCallableNode.ArgumentsExecutionMode.PRE_EXECUTED);
+
+  PrintlnNode(Language language, ModuleScope scope) {
     super(language);
+    toTextSym = UnresolvedSymbol.build("to_text", scope);
   }
 
   @Specialization
   Stateful doPrint(VirtualFrame frame, @CachedContext(Language.class) Context ctx) {
-    print(ctx.getOut(), Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[1]);
+    Object in = Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[1];
     Object state = Function.ArgumentsHelper.getState(frame.getArguments());
+    Stateful str = invokeCallableNode.execute(toTextSym, frame, state, new Object[] {in});
+    print(ctx.getOut(), str.getValue());
 
-    return new Stateful(state, ctx.getUnit().newInstance());
+    return new Stateful(str.getState(), ctx.getUnit().newInstance());
   }
 
   @CompilerDirectives.TruffleBoundary
-  private void print(PrintStream out, Object object) {
-    out.println(object);
+  private void print(PrintStream out, Object str) {
+    out.println(str);
   }
 
   /**
@@ -41,9 +55,9 @@ public abstract class PrintlnNode extends BuiltinRootNode {
    * @param language the current {@link Language} instance
    * @return a {@link Function} object wrapping the behavior of this node
    */
-  public static Function makeFunction(Language language) {
+  public static Function makeFunction(Language language, ModuleScope scope) {
     return Function.fromBuiltinRootNode(
-        PrintlnNodeGen.create(language),
+        PrintlnNodeGen.create(language, scope),
         FunctionSchema.CallStrategy.ALWAYS_DIRECT,
         new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE),
         new ArgumentDefinition(1, "value", ArgumentDefinition.ExecutionMode.EXECUTE));

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/EqualsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/EqualsNode.java
@@ -15,8 +15,7 @@ import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.interpreter.runtime.state.Stateful;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-/** An implementation of the operator + for numbers. */
-@NodeInfo(shortName = "Number.==", description = "Addition on numbers.")
+@NodeInfo(shortName = "Number.==", description = "Equality on numbers.")
 public class EqualsNode extends BuiltinRootNode {
   private EqualsNode(Language language) {
     super(language);
@@ -40,6 +39,12 @@ public class EqualsNode extends BuiltinRootNode {
         new ArgumentDefinition(1, "that", ArgumentDefinition.ExecutionMode.EXECUTE));
   }
 
+  /**
+   * Executes the node.
+   *
+   * @param frame current execution frame
+   * @return whether or not the input arguments are equal
+   */
   @Override
   public Stateful execute(VirtualFrame frame) {
     long thisArg =
@@ -56,28 +61,6 @@ public class EqualsNode extends BuiltinRootNode {
       thatOpBadTypeProfile.enter();
       throw new TypeError("Unexpected type for `that` operand in " + getName(), this);
     }
-  }
-
-  private void initBooleans() {
-    ModuleScope scope = lookupContextReference(Language.class).get().getBuiltins().getScope();
-    tru = scope.getConstructor("True").get();
-    fls = scope.getConstructor("False").get();
-  }
-
-  private AtomConstructor getTrue() {
-    if (tru == null) {
-      CompilerDirectives.transferToInterpreterAndInvalidate();
-      initBooleans();
-    }
-    return tru;
-  }
-
-  private AtomConstructor getFalse() {
-    if (fls == null) {
-      CompilerDirectives.transferToInterpreterAndInvalidate();
-      initBooleans();
-    }
-    return fls;
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/EqualsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/EqualsNode.java
@@ -1,0 +1,92 @@
+package org.enso.interpreter.node.expression.builtin.number;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.profiles.BranchProfile;
+import org.enso.interpreter.Language;
+import org.enso.interpreter.node.expression.builtin.BuiltinRootNode;
+import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.callable.function.FunctionSchema.CallStrategy;
+import org.enso.interpreter.runtime.error.TypeError;
+import org.enso.interpreter.runtime.scope.ModuleScope;
+import org.enso.interpreter.runtime.state.Stateful;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+/** An implementation of the operator + for numbers. */
+@NodeInfo(shortName = "Number.==", description = "Addition on numbers.")
+public class EqualsNode extends BuiltinRootNode {
+  private EqualsNode(Language language) {
+    super(language);
+  }
+
+  private @CompilerDirectives.CompilationFinal AtomConstructor tru;
+  private @CompilerDirectives.CompilationFinal AtomConstructor fls;
+  private final BranchProfile thatOpBadTypeProfile = BranchProfile.create();
+
+  /**
+   * Creates a two-argument function wrapping this node.
+   *
+   * @param language the current language instance
+   * @return a function wrapping this node
+   */
+  public static Function makeFunction(Language language) {
+    return Function.fromBuiltinRootNode(
+        new EqualsNode(language),
+        CallStrategy.ALWAYS_DIRECT,
+        new ArgumentDefinition(0, "this", ArgumentDefinition.ExecutionMode.EXECUTE),
+        new ArgumentDefinition(1, "that", ArgumentDefinition.ExecutionMode.EXECUTE));
+  }
+
+  @Override
+  public Stateful execute(VirtualFrame frame) {
+    long thisArg =
+        TypesGen.asLong(Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[0]);
+
+    Object thatArg = Function.ArgumentsHelper.getPositionalArguments(frame.getArguments())[1];
+
+    if (TypesGen.isLong(thatArg)) {
+      long thatArgAsLong = TypesGen.asLong(thatArg);
+      Object state = Function.ArgumentsHelper.getState(frame.getArguments());
+
+      return new Stateful(state, thisArg == thatArgAsLong);
+    } else {
+      thatOpBadTypeProfile.enter();
+      throw new TypeError("Unexpected type for `that` operand in " + getName(), this);
+    }
+  }
+
+  private void initBooleans() {
+    ModuleScope scope = lookupContextReference(Language.class).get().getBuiltins().getScope();
+    tru = scope.getConstructor("True").get();
+    fls = scope.getConstructor("False").get();
+  }
+
+  private AtomConstructor getTrue() {
+    if (tru == null) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      initBooleans();
+    }
+    return tru;
+  }
+
+  private AtomConstructor getFalse() {
+    if (fls == null) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      initBooleans();
+    }
+    return fls;
+  }
+
+  /**
+   * Returns a language-specific name for this node.
+   *
+   * @return the name of this node
+   */
+  @Override
+  public String getName() {
+    return "Number.==";
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/constant/ConstructorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/constant/ConstructorNode.java
@@ -1,16 +1,20 @@
 package org.enso.interpreter.node.expression.constant;
 
+import com.oracle.truffle.api.dsl.CachedContext;
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
+import org.enso.interpreter.Language;
 import org.enso.interpreter.node.ExpressionNode;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 
 /** Represents a type constructor definition. */
 @NodeInfo(shortName = "Cons", description = "Represents a constructor definition")
-public class ConstructorNode extends ExpressionNode {
+public abstract class ConstructorNode extends ExpressionNode {
   private final AtomConstructor constructor;
 
-  private ConstructorNode(AtomConstructor constructor) {
+  ConstructorNode(AtomConstructor constructor) {
     this.constructor = constructor;
   }
 
@@ -21,7 +25,7 @@ public class ConstructorNode extends ExpressionNode {
    * @return a truffle node representing {@code constructor}
    */
   public static ConstructorNode build(AtomConstructor constructor) {
-    return new ConstructorNode(constructor);
+    return ConstructorNodeGen.create(constructor);
   }
 
   /**
@@ -30,12 +34,18 @@ public class ConstructorNode extends ExpressionNode {
    * @param frame the frame to execute in
    * @return the constructor of the type defined
    */
-  @Override
-  public Object executeGeneric(VirtualFrame frame) {
+  @Specialization
+  Object doExecute(VirtualFrame frame, @CachedContext(Language.class) Context ctx) {
+    if (constructor == ctx.getBuiltins().bool().getTrue()) {
+      return true;
+    }
+    if (constructor == ctx.getBuiltins().bool().getFalse()) {
+      return false;
+    }
     if (constructor.getArity() == 0) {
       return constructor.newInstance();
-    } else {
-      return constructor;
     }
+    return constructor;
+
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/BreakpointNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/BreakpointNode.java
@@ -11,7 +11,7 @@ import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import org.enso.interpreter.Language;
-import org.enso.interpreter.runtime.Builtins;
+import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.state.Stateful;
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
@@ -13,6 +13,7 @@ import org.enso.compiler.Compiler;
 import org.enso.home.HomeManager;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.OptionsHelper;
+import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.interpreter.runtime.scope.TopLevelScope;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -17,6 +17,7 @@ import org.enso.compiler.core.IR;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.node.callable.dispatch.CallOptimiserNode;
 import org.enso.interpreter.node.callable.dispatch.LoopingCallOptimiserNode;
+import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.CallerInfo;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Bool.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Bool.java
@@ -1,0 +1,48 @@
+package org.enso.interpreter.runtime.builtin;
+
+import org.enso.interpreter.Language;
+import org.enso.interpreter.node.expression.builtin.bool.*;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.scope.ModuleScope;
+
+/** A container class for all Boolean-related stdlib builtins. */
+public class Bool {
+  private final AtomConstructor tru;
+  private final AtomConstructor fls;
+  private final AtomConstructor bool;
+
+  /**
+   * Creates and registers all the boolean constructors.
+   *
+   * @param language the current language instance.
+   * @param scope the scope to register constructors and methods in.
+   */
+  public Bool(Language language, ModuleScope scope) {
+    bool = new AtomConstructor("Boolean", scope).initializeFields();
+    scope.registerConstructor(bool);
+    scope.registerMethod(bool, "if_then_else", IfThenElseNode.makeFunction(language));
+    scope.registerMethod(bool, "to_text", ToTextNode.makeFunction(language));
+    scope.registerMethod(bool, "&&", AndNode.makeFunction(language));
+    scope.registerMethod(bool, "||", OrNode.makeFunction(language));
+    scope.registerMethod(bool, "not", NotNode.makeFunction(language));
+    tru = new AtomConstructor("True", scope).initializeFields();
+    scope.registerConstructor(tru);
+    fls = new AtomConstructor("False", scope).initializeFields();
+    scope.registerConstructor(fls);
+  }
+
+  /** @return the atom constructor for {@code True}. */
+  public AtomConstructor getTrue() {
+    return tru;
+  }
+
+  /** @return the atom constructor for {@code False}. */
+  public AtomConstructor getFalse() {
+    return fls;
+  }
+
+  /** @return the atom constructor for {@code Boolean}. */
+  public AtomConstructor getBool() {
+    return bool;
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -234,6 +234,7 @@ public class Builtins {
     return number;
   }
 
+  /** @return the Boolean part of builtins. */
   public Bool bool() {
     return bool;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -1,4 +1,4 @@
-package org.enso.interpreter.runtime;
+package org.enso.interpreter.runtime.builtin;
 
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
@@ -17,14 +17,9 @@ import org.enso.interpreter.node.expression.builtin.interop.syntax.ConstructorDi
 import org.enso.interpreter.node.expression.builtin.io.PrintErrNode;
 import org.enso.interpreter.node.expression.builtin.io.PrintlnNode;
 import org.enso.interpreter.node.expression.builtin.io.ReadlnNode;
+import org.enso.interpreter.node.expression.builtin.number.*;
 import org.enso.interpreter.node.expression.builtin.system.NanoTimeNode;
 import org.enso.interpreter.node.expression.builtin.interop.java.*;
-import org.enso.interpreter.node.expression.builtin.number.AddNode;
-import org.enso.interpreter.node.expression.builtin.number.DivideNode;
-import org.enso.interpreter.node.expression.builtin.number.ModNode;
-import org.enso.interpreter.node.expression.builtin.number.MultiplyNode;
-import org.enso.interpreter.node.expression.builtin.number.NegateNode;
-import org.enso.interpreter.node.expression.builtin.number.SubtractNode;
 import org.enso.interpreter.node.expression.builtin.state.GetStateNode;
 import org.enso.interpreter.node.expression.builtin.state.PutStateNode;
 import org.enso.interpreter.node.expression.builtin.state.RunStateNode;
@@ -32,6 +27,8 @@ import org.enso.interpreter.node.expression.builtin.text.AnyToTextNode;
 import org.enso.interpreter.node.expression.builtin.text.ConcatNode;
 import org.enso.interpreter.node.expression.builtin.text.JsonSerializeNode;
 import org.enso.interpreter.node.expression.builtin.thread.WithInterruptHandlerNode;
+import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
@@ -62,6 +59,7 @@ public class Builtins {
   private final AtomConstructor syntaxError;
   private final AtomConstructor compileError;
   private final AtomConstructor inexhaustivePatternMatchError;
+  private final Bool bool;
 
   private final RootCallTarget interopDispatchRoot;
   private final FunctionSchema interopDispatchSchema;
@@ -80,6 +78,7 @@ public class Builtins {
     unit = new AtomConstructor("Unit", scope).initializeFields();
     any = new AtomConstructor("Any", scope).initializeFields();
     number = new AtomConstructor("Number", scope).initializeFields();
+    bool = new Bool(language, scope);
     function = new AtomConstructor("Function", scope).initializeFields();
     text = new AtomConstructor("Text", scope).initializeFields();
     debug = new AtomConstructor("Debug", scope).initializeFields();
@@ -130,9 +129,10 @@ public class Builtins {
 
     scope.registerConstructor(java);
     scope.registerConstructor(thread);
-    scope.registerConstructor(createPolyglot(language));
 
-    scope.registerMethod(io, "println", PrintlnNode.makeFunction(language));
+    createPolyglot(language);
+
+    scope.registerMethod(io, "println", PrintlnNode.makeFunction(language, scope));
     scope.registerMethod(io, "print_err", PrintErrNode.makeFunction(language));
     scope.registerMethod(io, "readln", ReadlnNode.makeFunction(language));
 
@@ -150,6 +150,7 @@ public class Builtins {
     scope.registerMethod(number, "/", DivideNode.makeFunction(language));
     scope.registerMethod(number, "%", ModNode.makeFunction(language));
     scope.registerMethod(number, "negate", NegateNode.makeFunction(language));
+    scope.registerMethod(number, "==", EqualsNode.makeFunction(language));
 
     scope.registerMethod(state, "get", GetStateNode.makeFunction(language));
     scope.registerMethod(state, "put", PutStateNode.makeFunction(language));
@@ -185,8 +186,9 @@ public class Builtins {
     newInstanceFunction = ConstructorDispatchNode.makeFunction(language);
   }
 
-  private AtomConstructor createPolyglot(Language language) {
+  private void createPolyglot(Language language) {
     AtomConstructor polyglot = new AtomConstructor("Polyglot", scope).initializeFields();
+    scope.registerConstructor(polyglot);
     scope.registerMethod(polyglot, "execute", ExecuteNode.makeFunction(language));
     scope.registerMethod(polyglot, "invoke", InvokeNode.makeFunction(language));
     scope.registerMethod(polyglot, "new", InstantiateNode.makeFunction(language));
@@ -194,7 +196,6 @@ public class Builtins {
     scope.registerMethod(polyglot, "get_members", GetMembersNode.makeFunction(language));
     scope.registerMethod(polyglot, "get_array_size", GetArraySizeNode.makeFunction(language));
     scope.registerMethod(polyglot, "get_array_element", GetArrayElementNode.makeFunction(language));
-    return polyglot;
   }
 
   /**
@@ -231,6 +232,10 @@ public class Builtins {
    */
   public AtomConstructor number() {
     return number;
+  }
+
+  public Bool bool() {
+    return bool;
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
@@ -16,7 +16,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.Optional;
 import org.enso.interpreter.Language;
-import org.enso.interpreter.runtime.Builtins;
+import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.data.Vector;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
@@ -26,6 +26,7 @@ import java.util.Optional;
  */
 @TypeSystem({
   long.class,
+  boolean.class,
   String.class,
   Function.class,
   Atom.class,

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -557,8 +557,15 @@ class IrToTruffle(
                   )
                 )
               } else {
-                val branchNode =
-                  ConstructorBranchNode.build(atomCons, branchCodeNode)
+                val bool = context.getBuiltins.bool()
+                val branchNode: BranchNode =
+                  if (atomCons == bool.getTrue) {
+                    BooleanBranchNode.build(true, branchCodeNode)
+                  } else if (atomCons == bool.getFalse) {
+                    BooleanBranchNode.build(false, branchCodeNode)
+                  } else {
+                    ConstructorBranchNode.build(atomCons, branchCodeNode)
+                  }
                 branchNode.setTail(branchIsTail)
 
                 Right(branchNode)

--- a/engine/runtime/src/test/scala/org/enso/std/test/BooleanTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/std/test/BooleanTest.scala
@@ -1,0 +1,95 @@
+package org.enso.std.test
+
+import org.enso.interpreter.test.InterpreterTest
+
+class BooleanTest extends InterpreterTest {
+  val subject = "Booleans"
+
+  subject should "support if_then_else" in {
+    val code =
+      """
+        |main =
+        |    if True then IO.println "true when true" else IO.println "false when true"
+        |    if False then IO.println "true when false" else IO.println "false when false"
+        |""".stripMargin
+    eval(code)
+    consumeOut shouldEqual List("true when true", "false when false")
+  }
+
+  subject should "support overriding methods on boolean" in {
+    val code =
+      """
+        |Boolean.isTrue = this
+        |
+        |main =
+        |    true = 1 == 1
+        |    false = 1 == 2
+        |    IO.println true.isTrue
+        |    IO.println false.isTrue
+        |""".stripMargin
+    eval(code)
+    consumeOut shouldEqual List("True", "False")
+  }
+
+  subject should "support pattern matching" in {
+    val code =
+      """
+        |to_num b = case b of
+        |    True -> 1
+        |    False -> 2
+        |    _ -> 10
+        |
+        |main =
+        |    here.to_num True + here.to_num False
+        |""".stripMargin
+    eval(code) shouldEqual 3
+  }
+
+  subject should "support per-constructor method overloads" in {
+    val code =
+      """
+        |True.to_num = 1
+        |False.to_num = 2
+        |
+        |main = True.to_num + False.to_num
+        |""".stripMargin
+    eval(code) shouldEqual 3
+  }
+
+  subject should "support per-single-constructor method overloads" in {
+    val code =
+      """
+        |Boolean.to_num = 2
+        |True.to_num = 1
+        |
+        |main = True.to_num + False.to_num
+        |""".stripMargin
+    eval(code) shouldEqual 3
+  }
+
+  subject should "support logical AND and OR operators" in {
+    val code =
+      """
+        |main =
+        |    IO.println True&&False
+        |    IO.println True&&True
+        |    IO.println False||False
+        |    IO.println True||False
+        |    IO.println ((True && False) || (True && True))
+        |""".stripMargin
+    eval(code)
+    consumeOut shouldEqual List("False", "True", "False", "True", "True")
+  }
+
+  subject should "support negation" in {
+    val code =
+      """
+        |main =
+        |    IO.println True.not
+        |    IO.println False.not
+        |    IO.println (not 1==2)
+        |""".stripMargin
+    eval(code)
+    consumeOut shouldEqual List("False", "True", "True")
+  }
+}

--- a/engine/runtime/src/test/scala/org/enso/std/test/BooleanTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/std/test/BooleanTest.scala
@@ -1,95 +1,100 @@
 package org.enso.std.test
 
-import org.enso.interpreter.test.InterpreterTest
+import org.enso.interpreter.test.{InterpreterContext, InterpreterTest}
 
 class BooleanTest extends InterpreterTest {
-  val subject = "Booleans"
+  override def subject = "Booleans"
 
-  subject should "support if_then_else" in {
-    val code =
-      """
-        |main =
-        |    if True then IO.println "true when true" else IO.println "false when true"
-        |    if False then IO.println "true when false" else IO.println "false when false"
-        |""".stripMargin
-    eval(code)
-    consumeOut shouldEqual List("true when true", "false when false")
-  }
+  override def specify(implicit
+    interpreterContext: InterpreterContext
+  ): Unit = {
 
-  subject should "support overriding methods on boolean" in {
-    val code =
-      """
-        |Boolean.isTrue = this
-        |
-        |main =
-        |    true = 1 == 1
-        |    false = 1 == 2
-        |    IO.println true.isTrue
-        |    IO.println false.isTrue
-        |""".stripMargin
-    eval(code)
-    consumeOut shouldEqual List("True", "False")
-  }
+    "support if_then_else" in {
+      val code =
+        """
+          |main =
+          |    if True then IO.println "true when true" else IO.println "false when true"
+          |    if False then IO.println "true when false" else IO.println "false when false"
+          |""".stripMargin
+      eval(code)
+      consumeOut shouldEqual List("true when true", "false when false")
+    }
 
-  subject should "support pattern matching" in {
-    val code =
-      """
-        |to_num b = case b of
-        |    True -> 1
-        |    False -> 2
-        |    _ -> 10
-        |
-        |main =
-        |    here.to_num True + here.to_num False
-        |""".stripMargin
-    eval(code) shouldEqual 3
-  }
+    "support overriding methods on boolean" in {
+      val code =
+        """
+          |Boolean.isTrue = this
+          |
+          |main =
+          |    true = 1 == 1
+          |    false = 1 == 2
+          |    IO.println true.isTrue
+          |    IO.println false.isTrue
+          |""".stripMargin
+      eval(code)
+      consumeOut shouldEqual List("True", "False")
+    }
 
-  subject should "support per-constructor method overloads" in {
-    val code =
-      """
-        |True.to_num = 1
-        |False.to_num = 2
-        |
-        |main = True.to_num + False.to_num
-        |""".stripMargin
-    eval(code) shouldEqual 3
-  }
+    "support pattern matching" in {
+      val code =
+        """
+          |to_num b = case b of
+          |    True -> 1
+          |    False -> 2
+          |    _ -> 10
+          |
+          |main =
+          |    here.to_num True + here.to_num False
+          |""".stripMargin
+      eval(code) shouldEqual 3
+    }
 
-  subject should "support per-single-constructor method overloads" in {
-    val code =
-      """
-        |Boolean.to_num = 2
-        |True.to_num = 1
-        |
-        |main = True.to_num + False.to_num
-        |""".stripMargin
-    eval(code) shouldEqual 3
-  }
+    "support per-constructor method overloads" in {
+      val code =
+        """
+          |True.to_num = 1
+          |False.to_num = 2
+          |
+          |main = True.to_num + False.to_num
+          |""".stripMargin
+      eval(code) shouldEqual 3
+    }
 
-  subject should "support logical AND and OR operators" in {
-    val code =
-      """
-        |main =
-        |    IO.println True&&False
-        |    IO.println True&&True
-        |    IO.println False||False
-        |    IO.println True||False
-        |    IO.println ((True && False) || (True && True))
-        |""".stripMargin
-    eval(code)
-    consumeOut shouldEqual List("False", "True", "False", "True", "True")
-  }
+    "support per-single-constructor method overloads" in {
+      val code =
+        """
+          |Boolean.to_num = 2
+          |True.to_num = 1
+          |
+          |main = True.to_num + False.to_num
+          |""".stripMargin
+      eval(code) shouldEqual 3
+    }
 
-  subject should "support negation" in {
-    val code =
-      """
-        |main =
-        |    IO.println True.not
-        |    IO.println False.not
-        |    IO.println (not 1==2)
-        |""".stripMargin
-    eval(code)
-    consumeOut shouldEqual List("False", "True", "True")
+    "support logical AND and OR operators" in {
+      val code =
+        """
+          |main =
+          |    IO.println True&&False
+          |    IO.println True&&True
+          |    IO.println False||False
+          |    IO.println True||False
+          |    IO.println ((True && False) || (True && True))
+          |""".stripMargin
+      eval(code)
+      consumeOut shouldEqual List("False", "True", "False", "True", "True")
+    }
+
+    "support negation" in {
+      val code =
+        """
+          |main =
+          |    IO.println True.not
+          |    IO.println False.not
+          |    IO.println (not 1==2)
+          |""".stripMargin
+      eval(code)
+      consumeOut shouldEqual List("False", "True", "True")
+    }
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/std/test/NumberTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/std/test/NumberTest.scala
@@ -1,0 +1,31 @@
+package org.enso.std.test
+
+import org.enso.interpreter.test.InterpreterTest
+
+class NumberTest extends InterpreterTest {
+  val subject = "Numbers"
+
+  subject should "support equality comparisons" in {
+    val code =
+      """
+        |main =
+        |    IO.println 7==5
+        |    IO.println 30==30
+        |""".stripMargin
+    eval(code)
+    consumeOut shouldEqual List("False", "True")
+  }
+
+  subject should "support a recursive sum case" in {
+    val code =
+      """
+        |main = sumTo ->
+        |    summator = acc -> current ->
+        |        if current == 0 then acc else summator acc+current current-1
+        |
+        |    res = summator 0 sumTo
+        |    res
+        |""".stripMargin
+    eval(code).call(100) shouldEqual 5050
+  }
+}

--- a/engine/runtime/src/test/scala/org/enso/std/test/NumberTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/std/test/NumberTest.scala
@@ -1,31 +1,35 @@
 package org.enso.std.test
 
-import org.enso.interpreter.test.InterpreterTest
+import org.enso.interpreter.test.{InterpreterContext, InterpreterTest}
 
 class NumberTest extends InterpreterTest {
-  val subject = "Numbers"
+  override def subject = "Numbers"
 
-  subject should "support equality comparisons" in {
-    val code =
-      """
-        |main =
-        |    IO.println 7==5
-        |    IO.println 30==30
-        |""".stripMargin
-    eval(code)
-    consumeOut shouldEqual List("False", "True")
-  }
+  override def specify(implicit
+    interpreterContext: InterpreterContext
+  ): Unit = {
+    "support equality comparisons" in {
+      val code =
+        """
+          |main =
+          |    IO.println 7==5
+          |    IO.println 30==30
+          |""".stripMargin
+      eval(code)
+      consumeOut shouldEqual List("False", "True")
+    }
 
-  subject should "support a recursive sum case" in {
-    val code =
-      """
-        |main = sumTo ->
-        |    summator = acc -> current ->
-        |        if current == 0 then acc else summator acc+current current-1
-        |
-        |    res = summator 0 sumTo
-        |    res
-        |""".stripMargin
-    eval(code).call(100) shouldEqual 5050
+    "support a recursive sum case" in {
+      val code =
+        """
+          |main = sumTo ->
+          |    summator = acc -> current ->
+          |        if current == 0 then acc else summator acc+current current-1
+          |
+          |    res = summator 0 sumTo
+          |    res
+          |""".stripMargin
+      eval(code).call(100) shouldEqual 5050
+    }
   }
 }


### PR DESCRIPTION
### Pull Request Description
Introduces language-level support for boolean expressions. Benchmarks are the same as before. Closes #115 

### Important Notes
Uses primitive booleans under the hood, but the exposed API is indistinguishable from standard Atoms. To that end, there's some cheating happening across different data-related nodes.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/luna/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All code has been tested where possible.
