### PR TITLE
Bugfix for `text/applyEdit` Reports Trailing Empty Line to be an Invalid Position

### DIFF
--- a/lib/text-buffer/src/main/scala/org/enso/text/buffer/Rope.scala
+++ b/lib/text-buffer/src/main/scala/org/enso/text/buffer/Rope.scala
@@ -22,7 +22,7 @@ case class StringMeasure(
     *
     * @return the number of lines.
     */
-  def linesCount: Int = fullLines + (if (endsInNewLine) 0 else 1)
+  def linesCount: Int = fullLines + (if (endsInNewLine) 1 else 0)
 }
 
 object StringMeasure {

--- a/lib/text-buffer/src/main/scala/org/enso/text/buffer/Rope.scala
+++ b/lib/text-buffer/src/main/scala/org/enso/text/buffer/Rope.scala
@@ -22,7 +22,7 @@ case class StringMeasure(
     *
     * @return the number of lines.
     */
-  def linesCount: Int = fullLines + (if (endsInNewLine) 1 else 0)
+  def linesCount: Int = fullLines + 1
 }
 
 object StringMeasure {

--- a/lib/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
+++ b/lib/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
@@ -1,6 +1,7 @@
 package org.enso.text.editing
 
-import TestData.testSnippet
+import org.enso.text.buffer.Rope
+import org.enso.text.editing.TestData.testSnippet
 import org.enso.text.editing.model.{Position, Range, TextEdit}
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
@@ -39,6 +40,23 @@ class EditorOpsSpec extends AnyFlatSpec with Matchers with EitherValues {
     val result = EditorOps.applyEdits(testSnippet, diffs)
     //then
     result mustBe Left(InvalidPosition(Position(5, 4)))
+  }
+
+  it should "apply edit when end position is an empty line" in {
+    //given
+    val codeToEdit =
+      Rope(
+        """main =
+          |    foo = "Hello"
+          |    IO.println "hello"
+          |""".stripMargin
+      )
+    val range = Range(Position(0,0), Position(3, 0))
+    val diff = TextEdit(range, "123")
+    //when
+    val result = EditorOps.applyEdits(codeToEdit, Seq(diff))
+    //then
+    result.map(_.toString) mustBe Right("123")
   }
 
 }

--- a/lib/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
+++ b/lib/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
@@ -70,4 +70,15 @@ class EditorOpsSpec extends AnyFlatSpec with Matchers with EitherValues {
     result.map(_.toString) mustBe Right("foo123")
   }
 
+  it should "be able to insert changes to the empty buffer" in {
+    //given
+    val codeToEdit = Rope("")
+    val range = Range(Position(0,0), Position(0, 0))
+    val diff = TextEdit(range, "foo")
+    //when
+    val result = EditorOps.applyEdits(codeToEdit, Seq(diff))
+    //then
+    result.map(_.toString) mustBe Right("foo")
+  }
+
 }

--- a/lib/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
+++ b/lib/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
@@ -59,4 +59,15 @@ class EditorOpsSpec extends AnyFlatSpec with Matchers with EitherValues {
     result.map(_.toString) mustBe Right("123")
   }
 
+  it should "append text at the beginning of a buffer" in {
+    //given
+    val codeToEdit = Rope("123")
+    val range = Range(Position(0,0), Position(0, 0))
+    val diff = TextEdit(range, "foo")
+    //when
+    val result = EditorOps.applyEdits(codeToEdit, Seq(diff))
+    //then
+    result.map(_.toString) mustBe Right("foo123")
+  }
+
 }


### PR DESCRIPTION
### Pull Request Description
Bugfix for `text/applyEdit` Reports Trailing Empty Line to be an Invalid Position.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All code has been tested where possible.
