### PR TITLE
Fix unbalanced parentheses parse error

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
@@ -7,8 +7,6 @@ import org.enso.compiler.core.IR.Name.MethodReference
 import org.enso.compiler.core.IR._
 import org.enso.compiler.exception.UnhandledEntity
 import org.enso.syntax.text.AST
-import org.enso.syntax.text.AST.Macro.Ambiguous
-import org.enso.syntax.text.AST.Unapply
 
 import scala.annotation.tailrec
 
@@ -407,11 +405,8 @@ object AstToIr {
         )
       case AstView.Pattern(_) =>
         Error.Syntax(inputAst, Error.Syntax.InvalidPattern)
-      case Ambiguous(_, _) =>
-        Error.Syntax(
-          inputAst,
-          Error.Syntax.AmbiguousExpression
-        )
+      case AST.Macro.Ambiguous(_, _) =>
+        Error.Syntax(inputAst, Error.Syntax.AmbiguousExpression)
       case _ =>
         throw new UnhandledEntity(inputAst, "translateExpression")
     }
@@ -659,6 +654,8 @@ object AstToIr {
           hasDefaultsSuspended = false,
           getIdentifiedLocation(callable)
         )
+      case AST.Macro.Ambiguous(_, _) =>
+        Error.Syntax(callable, Error.Syntax.AmbiguousExpression)
       case _ => throw new UnhandledEntity(callable, "translateCallable")
     }
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
@@ -407,11 +407,10 @@ object AstToIr {
         )
       case AstView.Pattern(_) =>
         Error.Syntax(inputAst, Error.Syntax.InvalidPattern)
-      // TODO ambiguous
       case Ambiguous(_, _) =>
         Error.Syntax(
           inputAst,
-          Error.Syntax.UnsupportedSyntax("non-closed paren??") // TODO
+          Error.Syntax.AmbiguousExpression
         )
       case _ =>
         throw new UnhandledEntity(inputAst, "translateExpression")

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
@@ -2,7 +2,7 @@ package org.enso.compiler.codegen
 
 import org.enso.data
 import org.enso.data.List1
-import org.enso.syntax.text.AST
+import org.enso.syntax.text.{AST, Debug}
 import org.enso.syntax.text.AST.Ident.{Opr, Var}
 
 /** This object contains view patterns that allow matching on the parser [[AST]]
@@ -25,10 +25,11 @@ object AstView {
       * @param ast the structure to try and match on
       * @return the name of the atom, and the arguments to the atom
       */
-    def unapply(ast: AST): Option[(AST.Ident, List[AST])] = ast match {
-      case AST.Def(name, args, body) if body.isEmpty => Some((name, args))
-      case _                                         => None
-    }
+    def unapply(ast: AST): Option[(AST.Ident, List[AST])] =
+      ast match {
+        case AST.Def(name, args, body) if body.isEmpty => Some((name, args))
+        case _                                         => None
+      }
   }
 
   object TypeDef {
@@ -38,11 +39,12 @@ object AstView {
       * @param ast the structure to try and match on
       * @return the name of the type, the arguments to it, and the type body
       */
-    def unapply(ast: AST): Option[(AST.Ident, List[AST], AST)] = ast match {
-      case AST.Def(name, args, body) if body.isDefined =>
-        Some((name, args, body.get))
-      case _ => None
-    }
+    def unapply(ast: AST): Option[(AST.Ident, List[AST], AST)] =
+      ast match {
+        case AST.Def(name, args, body) if body.isDefined =>
+          Some((name, args, body.get))
+        case _ => None
+      }
   }
 
   object Block {
@@ -53,16 +55,17 @@ object AstView {
       * @return a list of expressions in the block, and the final expression
       *         separately
       */
-    def unapply(ast: AST): Option[(List[AST], AST)] = ast match {
-      case AST.Block(_, _, firstLine, lines) =>
-        val actualLines = firstLine.elem :: lines.flatMap(_.elem)
-        if (actualLines.nonEmpty) {
-          Some((actualLines.dropRight(1), actualLines.last))
-        } else {
-          None
-        }
-      case _ => None
-    }
+    def unapply(ast: AST): Option[(List[AST], AST)] =
+      ast match {
+        case AST.Block(_, _, firstLine, lines) =>
+          val actualLines = firstLine.elem :: lines.flatMap(_.elem)
+          if (actualLines.nonEmpty) {
+            Some((actualLines.dropRight(1), actualLines.last))
+          } else {
+            None
+          }
+        case _ => None
+      }
   }
 
   object SuspendedBlock {
@@ -194,13 +197,14 @@ object AstView {
       * @param ast the structure to try and match on
       * @return the term being forced
       */
-    def unapply(ast: AST): Option[AST] = ast match {
-      case MaybeParensed(
-          AST.App.Section.Right(AST.Ident.Opr("~"), FunctionParam(arg))
-          ) =>
-        Some(arg)
-      case _ => None
-    }
+    def unapply(ast: AST): Option[AST] =
+      ast match {
+        case MaybeManyParensed(
+              AST.App.Section.Right(AST.Ident.Opr("~"), FunctionParam(arg))
+            ) =>
+          Some(arg)
+        case _ => None
+      }
   }
 
   object FunctionParam {
@@ -210,13 +214,14 @@ object AstView {
       * @param ast the structure to try and match on
       * @return the parameter definition
       */
-    def unapply(ast: AST): Option[AST] = ast match {
-      case LazyAssignedArgumentDefinition(_, _) => Some(ast)
-      case AssignedArgument(_, _)               => Some(ast)
-      case DefinitionArgument(_)                => Some(ast)
-      case LazyArgument(_)                      => Some(ast)
-      case _                                    => None
-    }
+    def unapply(ast: AST): Option[AST] =
+      ast match {
+        case LazyAssignedArgumentDefinition(_, _) => Some(ast)
+        case AssignedArgument(_, _)               => Some(ast)
+        case DefinitionArgument(_)                => Some(ast)
+        case LazyArgument(_)                      => Some(ast)
+        case _                                    => None
+      }
   }
 
   object FunctionParamList {
@@ -252,11 +257,12 @@ object AstView {
       * @param ast the structure to try and match on
       * @return the term and the type ascribed to it
       */
-    def unapply(ast: AST): Option[(AST, AST)] = ast match {
-      case AST.App.Infix(entity, AST.Ident.Opr(":"), signature) =>
-        Some((entity, signature))
-      case _ => None
-    }
+    def unapply(ast: AST): Option[(AST, AST)] =
+      ast match {
+        case AST.App.Infix(entity, AST.Ident.Opr(":"), signature) =>
+          Some((entity, signature))
+        case _ => None
+      }
   }
 
   object FunctionSugar {
@@ -290,9 +296,12 @@ object AstView {
     }
   }
 
-  object MaybeParensed {
+  // TODO MaybeParensed single
 
-    /** Matches on terms that _may_ be surrounded by parentheses.
+  object MaybeManyParensed {
+
+    /** Matches on terms that _may_ be surrounded by (an arbitrary amount of)
+      * parentheses.
       *
       * @param ast the structure to try and match on
       * @return the term contained in the parentheses
@@ -301,6 +310,39 @@ object AstView {
       ast match {
         case AST.Group(mExpr) => mExpr.flatMap(unapply)
         case a                => Some(a)
+      }
+    }
+  }
+
+  object Parensed {
+
+    /** Matches on terms that is surrounded by parentheses.
+      *
+      * It 'peels off' one layer of parentheses, so the returned term may still
+      * be surrounded by more parentheses.
+      *
+      * @param ast the structure to try and match on
+      * @return the term contained in the parentheses
+      */
+    def unapply(ast: AST): Option[AST] = {
+      AST.Group.unapply(ast).flatten
+    }
+  }
+
+  object ManyParensed {
+
+    /** Matches on terms that is surrounded by an arbitrary (but non-zero)
+      * amount of parentheses.
+      *
+      * The resulting term is not surrounded by any more parentheses.
+      *
+      * @param ast the structure to try and match on
+      * @return the term contained in the parentheses
+      */
+    def unapply(ast: AST): Option[AST] = { // TODO!!!
+      ast match {
+        case AST.Group(mExpr) => mExpr.flatMap(unapply)
+        case _                => None
       }
     }
   }
@@ -317,7 +359,7 @@ object AstView {
       * @return the variable name and the expression being bound to it
       */
     def unapply(ast: AST): Option[(AST.Ident, AST)] =
-      MaybeParensed.unapply(ast).flatMap(BasicAssignment.unapply)
+      MaybeManyParensed.unapply(ast).flatMap(BasicAssignment.unapply)
   }
 
   object LazyAssignedArgumentDefinition {
@@ -331,11 +373,11 @@ object AstView {
       */
     def unapply(ast: AST): Option[(AST.Ident, AST)] = {
       ast match {
-        case MaybeParensed(
-            Binding(
-              AST.App.Section.Right(AST.Ident.Opr("~"), AST.Ident.Var.any(v)),
-              r
-            )
+        case MaybeManyParensed(
+              Binding(
+                AST.App.Section.Right(AST.Ident.Opr("~"), AST.Ident.Var.any(v)),
+                r
+              )
             ) =>
           Some((v, r))
         case _ => None
@@ -351,10 +393,11 @@ object AstView {
       * @param ast the structure to try and match on
       * @return the name of the argument
       */
-    def unapply(ast: AST): Option[AST.Ident] = ast match {
-      case MaybeParensed(MaybeBlankName(ast)) => Some(ast)
-      case _                                  => None
-    }
+    def unapply(ast: AST): Option[AST.Ident] =
+      ast match {
+        case MaybeManyParensed(MaybeBlankName(ast)) => Some(ast)
+        case _                                      => None
+      }
   }
 
   object Application {
@@ -391,35 +434,38 @@ object AstView {
       * @return the `self` expression, the function name, and the arguments to
       *         the function
       */
-    def unapply(ast: AST): Option[(AST, AST.Ident, List[AST])] = ast match {
-      case OperatorDot(target, Application(ConsOrVar(ident), args)) =>
-        Some((target, ident, args))
-      case AST.App.Section.Left(
-          MethodCall(target, ident, List()),
-          susp @ SuspendDefaultsOperator(_)
-          ) =>
-        Some((target, ident, List(susp)))
-      case OperatorDot(target, ConsOrVar(ident)) =>
-        Some((target, ident, List()))
-      case _ => None
-    }
+    def unapply(ast: AST): Option[(AST, AST.Ident, List[AST])] =
+      ast match {
+        case OperatorDot(target, Application(ConsOrVar(ident), args)) =>
+          Some((target, ident, args))
+        case AST.App.Section.Left(
+              MethodCall(target, ident, List()),
+              susp @ SuspendDefaultsOperator(_)
+            ) =>
+          Some((target, ident, List(susp)))
+        case OperatorDot(target, ConsOrVar(ident)) =>
+          Some((target, ident, List()))
+        case _ => None
+      }
   }
 
   object ModulePath {
 
     /** Matches on a module path of the form `A.B.C...`, as seen in an import.
-     *
-     * @param ast the structure to try and match on
-     * @return the list of segments in the module path
-     */
-    def unapply(ast: AST): Option[List[AST.Ident]] = ast match {
-      case AST.Ident.Cons.any(name) => Some(List(name))
-      case OperatorDot(left, AST.Ident.Cons.any(name)) => left match {
-        case ModulePath(elems) => Some(elems :+ name)
+      *
+      * @param ast the structure to try and match on
+      * @return the list of segments in the module path
+      */
+    def unapply(ast: AST): Option[List[AST.Ident]] =
+      ast match {
+        case AST.Ident.Cons.any(name) => Some(List(name))
+        case OperatorDot(left, AST.Ident.Cons.any(name)) =>
+          left match {
+            case ModulePath(elems) => Some(elems :+ name)
+            case _                 => None
+          }
         case _ => None
       }
-      case _ => None
-    }
   }
 
   object SuspendDefaultsOperator {
@@ -451,15 +497,15 @@ object AstView {
 
     private[this] def matchSpacedList(ast: AST): Option[List[AST]] = {
       ast match {
-        case MaybeParensed(AST.App.Prefix(fn, arg)) =>
+        case MaybeManyParensed(AST.App.Prefix(fn, arg)) =>
           val fnRecurse = matchSpacedList(fn)
 
           fnRecurse match {
             case Some(headItems) => Some(headItems :+ arg)
             case None            => Some(List(fn, arg))
           }
-        case MaybeParensed(
-            AST.App.Section.Left(ast, SuspendDefaultsOperator(suspend))
+        case MaybeManyParensed(
+              AST.App.Section.Left(ast, SuspendDefaultsOperator(suspend))
             ) =>
           ast match {
             case ConsOrVar(_) => Some(List(ast, suspend))
@@ -537,11 +583,12 @@ object AstView {
       * @param arg the structure to try and match on
       * @return the identifier matched on
       */
-    def unapply(arg: AST): Option[AST.Ident] = arg match {
-      case AST.Ident.Var.any(arg)  => Some(arg)
-      case AST.Ident.Cons.any(arg) => Some(arg)
-      case _                       => None
-    }
+    def unapply(arg: AST): Option[AST.Ident] =
+      arg match {
+        case AST.Ident.Var.any(arg)  => Some(arg)
+        case AST.Ident.Cons.any(arg) => Some(arg)
+        case _                       => None
+      }
   }
 
   object OperatorDot {
@@ -552,11 +599,13 @@ object AstView {
       * @param ast the structure to try and match on
       * @return the left- and right-hand sides of the operator
       */
-    def unapply(ast: AST): Option[(AST, AST)] = ast match {
-      case AST.App.Infix(left, AST.Ident.Opr("."), right) => Some((left, right))
-      case _ =>
-        None
-    }
+    def unapply(ast: AST): Option[(AST, AST)] =
+      ast match {
+        case AST.App.Infix(left, AST.Ident.Opr("."), right) =>
+          Some((left, right))
+        case _ =>
+          None
+      }
   }
 
   object DotChain {
@@ -711,10 +760,23 @@ object AstView {
       */
     def unapply(ast: AST): Option[AST] = {
       ast match {
-        case ConstructorPattern(_, _)  => Some(ast)
-        case CatchAllPattern(pat)      => Some(pat)
-        case MaybeParensed(Pattern(p)) => Some(p)
-        case _                         => None
+        case ConstructorPattern(_, _) => Some(ast)
+        case CatchAllPattern(pat)     => Some(pat)
+        /*        case Parensed(parensed) =>
+          if (parensed.toString == ast.toString) {
+            println("Reached a fixpoint")
+            println(Debug.pretty(ast.toString))
+            throw new RuntimeException("cycle")
+          }
+
+          parensed match {
+            case Pattern(p) => Some(p)
+            case _          => None
+          }*/
+        case Parensed(Pattern(p)) =>
+          println(p)
+          Some(p)
+        case _ => None
       }
     }
   }
@@ -731,7 +793,7 @@ object AstView {
       * @return the pattern
       */
     def unapply(ast: AST): Option[(AST.Ident, List[AST])] = {
-      MaybeParensed.unapply(ast).getOrElse(ast) match {
+      MaybeManyParensed.unapply(ast).getOrElse(ast) match {
         case AST.Ident.Cons.any(cons) => Some((cons, List()))
         case SpacedList(elems) if elems.nonEmpty =>
           elems.head match {
@@ -763,7 +825,7 @@ object AstView {
       * @return the pattern
       */
     def unapply(ast: AST): Option[AST.Ident] = {
-      MaybeParensed.unapply(ast).getOrElse(ast) match {
+      MaybeManyParensed.unapply(ast).getOrElse(ast) match {
         case AST.Ident.any(ident) => Some(ident)
         case _                    => None
       }
@@ -781,13 +843,14 @@ object AstView {
       * @param ast the structure to try and match on
       * @return the negated expression
       */
-    def unapply(ast: AST): Option[AST] = ast match {
-      case MaybeParensed(
-          AST.App.Section.Right(AST.Ident.Opr("-"), expression)
-          ) =>
-        Some(expression)
-      case _ => None
-    }
+    def unapply(ast: AST): Option[AST] =
+      ast match {
+        case MaybeManyParensed(
+              AST.App.Section.Right(AST.Ident.Opr("-"), expression)
+            ) =>
+          Some(expression)
+        case _ => None
+      }
   }
 
   object TypeAscription {
@@ -797,10 +860,11 @@ object AstView {
       * @param ast the structure to try and match on
       * @return the typed expression, and the ascribed type
       */
-    def unapply(ast: AST): Option[(AST, AST)] = ast match {
-      case MaybeParensed(AST.App.Infix(typed, AST.Ident.Opr(":"), sig)) =>
-        Some((typed, sig))
-      case _ => None
-    }
+    def unapply(ast: AST): Option[(AST, AST)] =
+      ast match {
+        case MaybeManyParensed(AST.App.Infix(typed, AST.Ident.Opr(":"), sig)) =>
+          Some((typed, sig))
+        case _ => None
+      }
   }
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala
@@ -2,7 +2,7 @@ package org.enso.compiler.codegen
 
 import org.enso.data
 import org.enso.data.List1
-import org.enso.syntax.text.{AST, Debug}
+import org.enso.syntax.text.AST
 import org.enso.syntax.text.AST.Ident.{Opr, Var}
 
 /** This object contains view patterns that allow matching on the parser [[AST]]
@@ -296,24 +296,6 @@ object AstView {
     }
   }
 
-  // TODO MaybeParensed single
-
-  object MaybeManyParensed {
-
-    /** Matches on terms that _may_ be surrounded by (an arbitrary amount of)
-      * parentheses.
-      *
-      * @param ast the structure to try and match on
-      * @return the term contained in the parentheses
-      */
-    def unapply(ast: AST): Option[AST] = {
-      ast match {
-        case AST.Group(mExpr) => mExpr.flatMap(unapply)
-        case a                => Some(a)
-      }
-    }
-  }
-
   object Parensed {
 
     /** Matches on terms that is surrounded by parentheses.
@@ -329,6 +311,25 @@ object AstView {
     }
   }
 
+  object MaybeParensed {
+
+    /** Matches on terms that _may_ be surrounded by (an arbitrary amount of)
+      * parentheses.
+      *
+      * It 'peels off' one layer of parentheses, so the returned term may still
+      * be surrounded by more parentheses.
+      *
+      * @param ast the structure to try and match on
+      * @return the term contained in the parentheses
+      */
+    def unapply(ast: AST): Option[AST] = {
+      ast match {
+        case AST.Group(mExpr) => mExpr
+        case a                => Some(a)
+      }
+    }
+  }
+
   object ManyParensed {
 
     /** Matches on terms that is surrounded by an arbitrary (but non-zero)
@@ -339,10 +340,28 @@ object AstView {
       * @param ast the structure to try and match on
       * @return the term contained in the parentheses
       */
-    def unapply(ast: AST): Option[AST] = { // TODO!!!
+    def unapply(ast: AST): Option[AST] = {
+      ast match {
+        case Parensed(MaybeManyParensed(p)) => Some(p)
+        case _                              => None
+      }
+    }
+  }
+
+  object MaybeManyParensed {
+
+    /** Matches on terms that _may_ be surrounded by (an arbitrary amount of)
+      * parentheses.
+      *
+      * The resulting term is not surrounded by any more parentheses.
+      *
+      * @param ast the structure to try and match on
+      * @return the term contained in the parentheses
+      */
+    def unapply(ast: AST): Option[AST] = {
       ast match {
         case AST.Group(mExpr) => mExpr.flatMap(unapply)
-        case _                => None
+        case a                => Some(a)
       }
     }
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -4972,6 +4972,10 @@ object IR {
         override def explanation: String = "Unexpected expression."
       }
 
+      case object AmbiguousExpression extends Reason {
+        override def explanation: String = "Ambiguous expression."
+      }
+
       case object UnrecognizedToken extends Reason {
         override def explanation: String = "Unrecognized token."
       }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
@@ -783,4 +783,25 @@ class AstToIrTest extends CompilerTest {
         .name shouldEqual "!"
     }
   }
+
+  "AST translation" should {
+    "result in syntax error when encountering unbalanced parentheses" in {
+
+      val ir =
+        """type MyAtom
+          |
+          |main =
+          |    f = case _ of
+          |        Cons (Cons MyAtom Nil) Nil -> 100
+          |        _ -> 50
+          |    f (Cons (Cons MyAtom Nil) Nil
+          |""".stripMargin.toIrExpression.get
+
+      ir shouldBe an[IR.Error.Syntax]
+
+      println(ir.asInstanceOf[IR.Error.Syntax].message)
+      // ir.asInstanceOf[IR.Error.Syntax].message shouldEqual "TODO"
+
+    }
+  }
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
@@ -3,9 +3,6 @@ package org.enso.compiler.test.codegen
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.Error.Syntax
 import org.enso.compiler.test.CompilerTest
-import org.enso.syntax.text.Debug
-
-import scala.annotation.unused
 
 class AstToIrTest extends CompilerTest {
 

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
@@ -795,13 +795,21 @@ class AstToIrTest extends CompilerTest {
           |        Cons (Cons MyAtom Nil) Nil -> 100
           |        _ -> 50
           |    f (Cons (Cons MyAtom Nil) Nil
-          |""".stripMargin.toIrExpression.get
+          |""".stripMargin.toIrModule
 
-      ir shouldBe an[IR.Error.Syntax]
-
-      println(ir.asInstanceOf[IR.Error.Syntax].message)
-      // ir.asInstanceOf[IR.Error.Syntax].message shouldEqual "TODO"
-
+      ir.bindings(1) shouldBe an[IR.Module.Scope.Definition.Method.Binding]
+      val binding =
+        ir.bindings(1).asInstanceOf[IR.Module.Scope.Definition.Method.Binding]
+      binding.body shouldBe an[IR.Expression.Block]
+      val block = binding.body.asInstanceOf[IR.Expression.Block]
+      block.returnValue shouldBe an[IR.Application.Prefix]
+      val application = block.returnValue.asInstanceOf[IR.Application.Prefix]
+      application.arguments.head shouldBe an[IR.CallArgument.Specified]
+      val argument =
+        application.arguments.head.asInstanceOf[IR.CallArgument.Specified]
+      argument.value shouldBe an[IR.Error.Syntax]
+      val error = argument.value.asInstanceOf[IR.Error.Syntax]
+      error.reason shouldBe IR.Error.Syntax.AmbiguousExpression
     }
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/MatchersTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/MatchersTest.scala
@@ -1,0 +1,122 @@
+package org.enso.compiler.test.codegen
+
+import org.enso.compiler.codegen.AstView
+import org.enso.compiler.test.CompilerTest
+import org.enso.data.List1
+import org.enso.syntax.text.AST
+import org.enso.syntax.text.AST.Module
+import org.scalatest.Inside
+import org.scalatest.matchers.{BeMatcher, MatchResult}
+
+class MatchersTest extends CompilerTest with Inside {
+  implicit class ToSimpleAST(source: String) {
+
+    /** Produces the [[AST]] representation of [[source]] and strips the outer Module.
+      *
+      * @return [[source]] as an AST expression
+      */
+    def toSimpleAst: AST = {
+      val ast = source.toAst
+
+      inside(ast) {
+        case Module(List1(line, _)) => line.elem.get
+      }
+    }
+  }
+
+  class GroupMatcher extends BeMatcher[AST] {
+    def apply(left: AST) =
+      MatchResult(
+        AST.Group.unapply(left).flatten.isDefined,
+        left.toString + " was not a group",
+        left.toString + " was a group"
+      )
+  }
+
+  val group = new GroupMatcher
+
+  "Parensed" should {
+    "match a single paren" in {
+      inside("(x)".toSimpleAst) { case AstView.Parensed(_) => }
+    }
+
+    "not match an expression without parentheses" in {
+      "x".toSimpleAst match {
+        case AstView.Parensed(_) => fail("should not match")
+        case _                   =>
+      }
+    }
+
+    "peel-off exactly one paren" in {
+      val twoParens = "((x))".toSimpleAst
+      inside(twoParens) {
+        case AstView.Parensed(oneParen) =>
+          inside(oneParen) {
+            case AstView.Parensed(zeroParens) =>
+              zeroParens should not be group
+          }
+      }
+    }
+  }
+
+  "MaybeParensed" should {
+    "match a single paren" in {
+      inside("(x)".toSimpleAst) { case AstView.MaybeParensed(_) => }
+    }
+
+    "also match an expression without parens" in {
+      inside("x".toSimpleAst) { case AstView.MaybeParensed(_) => }
+    }
+
+    "peel-off at-most one paren" in {
+      val twoParens = "((x))".toSimpleAst
+      inside(twoParens) {
+        case AstView.MaybeParensed(oneParen) =>
+          oneParen shouldBe group
+          inside(oneParen) {
+            case AstView.MaybeParensed(zeroParens) =>
+              zeroParens should not be group
+          }
+      }
+    }
+  }
+
+  "ManyParensed" should {
+    "match a single paren" in {
+      inside("(x)".toSimpleAst) { case AstView.ManyParensed(_) => }
+    }
+
+    "not match an expression without parentheses" in {
+      "x".toSimpleAst match {
+        case AstView.ManyParensed(_) => fail("should not match")
+        case _                       =>
+      }
+    }
+
+    "peel-off all parens" in {
+      val twoParens = "((x))".toSimpleAst
+      inside(twoParens) {
+        case AstView.ManyParensed(zeroParens) =>
+          zeroParens should not be group
+      }
+    }
+  }
+
+  "MaybeManyParensed" should {
+    "match a single paren" in {
+      inside("(x)".toSimpleAst) { case AstView.MaybeManyParensed(_) => }
+    }
+
+    "also match an expression without parens" in {
+      inside("x".toSimpleAst) { case AstView.MaybeManyParensed(_) => }
+    }
+
+    "peel-off all parens" in {
+      val twoParens = "((x))".toSimpleAst
+      inside(twoParens) {
+        case AstView.MaybeManyParensed(zeroParens) =>
+          zeroParens.shape should not be group
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
Avoids an infinite loop in Pattern unapply and handles the unbalanced parentheses with `IR.Error.Syntax.AmbiguousExpression` to close #448 

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->
More variants of matchers matching expressions surrounded with parentheses were added (variants that match exactly one, at least one, zero or one and zero or more).

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All code has been tested where possible.
