### PR TITLE
Benchmarking Utilities

### DIFF
--- a/distribution/std-lib/Base/src/Bench_Utils.enso
+++ b/distribution/std-lib/Base/src/Bench_Utils.enso
@@ -1,0 +1,38 @@
+reverse_list = list ->
+    go = list -> acc -> case list of
+        Cons h t -> go t (Cons h acc)
+        Nil -> acc
+    go list Nil
+
+sum_list = list ->
+    go = list -> acc -> case list of
+        Cons a b -> go b (acc + a)
+        Nil -> acc
+
+    go list 0
+
+avg_list = list -> here.sum_list list / here.len_list list
+
+len_list = list ->
+    go = list -> acc -> case list of
+        Cons _ b -> go b (acc + 1)
+        Nil -> acc
+    go list 0
+
+Number.times = act ->
+    go = results -> number -> if number == 0 then results else go (Cons (act number) results) number-1
+    res = here.reverse_list (go Nil this)
+    res
+
+measure = act -> label -> iter_size -> num_iters ->
+    single_call = input ->
+        x1 = System.nano_time
+        Runtime.no_inline (act input)
+        x2 = System.nano_time
+        x2 - x1
+    iteration = it_num ->
+        act_it_num = num_iters - it_num
+        res = iter_size.times single_call
+        avg = here.avg_list res
+        IO.println (label + "/iteration:" + act_it_num.to_text + ": " + (avg/1000000).to_text + "ms")
+    num_iters.times iteration

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/runtime/NoInlineNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/runtime/NoInlineNode.java
@@ -1,0 +1,22 @@
+package org.enso.interpreter.node.expression.builtin.runtime;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.dsl.MonadicState;
+import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
+import org.enso.interpreter.runtime.callable.argument.Thunk;
+import org.enso.interpreter.runtime.state.Stateful;
+
+@BuiltinMethod(
+    type = "Runtime",
+    name = "no_inline",
+    description = "Runs its argument without the possibility of getting inlined.")
+public class NoInlineNode extends Node {
+  private @Child ThunkExecutorNode thunkExecutorNode = ThunkExecutorNode.build();
+
+  @CompilerDirectives.TruffleBoundary
+  Stateful execute(@MonadicState Object state, Object _this, Thunk action) {
+    return thunkExecutorNode.executeThunk(action, state, false);
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -12,6 +12,7 @@ import org.enso.interpreter.node.expression.builtin.interop.syntax.MethodDispatc
 import org.enso.interpreter.node.expression.builtin.interop.syntax.ConstructorDispatchNode;
 import org.enso.interpreter.node.expression.builtin.io.*;
 import org.enso.interpreter.node.expression.builtin.number.*;
+import org.enso.interpreter.node.expression.builtin.runtime.NoInlineMethodGen;
 import org.enso.interpreter.node.expression.builtin.state.*;
 import org.enso.interpreter.node.expression.builtin.system.NanoTimeMethodGen;
 import org.enso.interpreter.node.expression.builtin.interop.java.*;
@@ -93,6 +94,7 @@ public class Builtins {
                 new ArgumentDefinition(1, "rest", ArgumentDefinition.ExecutionMode.EXECUTE));
     AtomConstructor io = new AtomConstructor("IO", scope).initializeFields();
     AtomConstructor system = new AtomConstructor("System", scope).initializeFields();
+    AtomConstructor runtime = new AtomConstructor("Runtime", scope).initializeFields();
     AtomConstructor panic = new AtomConstructor("Panic", scope).initializeFields();
     AtomConstructor error = new AtomConstructor("Error", scope).initializeFields();
     AtomConstructor state = new AtomConstructor("State", scope).initializeFields();
@@ -114,6 +116,7 @@ public class Builtins {
     scope.registerConstructor(state);
     scope.registerConstructor(debug);
     scope.registerConstructor(system);
+    scope.registerConstructor(runtime);
 
     scope.registerConstructor(syntaxError);
     scope.registerConstructor(compileError);
@@ -128,6 +131,7 @@ public class Builtins {
     scope.registerMethod(io, "readln", ReadlnMethodGen.makeFunction(language));
 
     scope.registerMethod(system, "nano_time", NanoTimeMethodGen.makeFunction(language));
+    scope.registerMethod(runtime, "no_inline", NoInlineMethodGen.makeFunction(language));
 
     scope.registerMethod(panic, "throw", ThrowPanicMethodGen.makeFunction(language));
     scope.registerMethod(panic, "recover", CatchPanicMethodGen.makeFunction(language));


### PR DESCRIPTION
### Pull Request Description
Introduces a way to call a function without it being inlined and stashes some of my existing benchmark utilities into the stdlib. These are undocumented and probably will die soon (I assume things like `sum_list` are not going to live in the `Bench_Utils` file...), but I got annoyed with having them on my laptop in random places :P

### Important Notes

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All code has been tested where possible.
