### PR TITLE
Fix testOnly after Java 11 migration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -735,7 +735,8 @@ lazy val runtime = (project in file("engine/runtime"))
         .value,
     // Note [Classpath Separation]
     Test / javaOptions ++= Seq(
-        "-Dgraalvm.locatorDisabled=true"
+        "-Dgraalvm.locatorDisabled=true",
+        s"--upgrade-module-path=${file("engine/runtime/build-cache/truffle-api.jar").absolutePath}"
       ),
     bootstrap := CopyTruffleJAR.bootstrapJARs.value,
     Global / onLoad := EnvironmentCheck.addVersionCheck(

--- a/docs/infrastructure/java-11.md
+++ b/docs/infrastructure/java-11.md
@@ -41,6 +41,11 @@ that help with this process.
 ### Testing
 All tests are passing.
 
+To make sure `runtime` tests can be run both with `test` and `testOnly`,
+`--upgrade-module-path=<path-to-truffle-api.jar>` has to be added to
+`javaOptions`. It is important to note that the tests may be ran in a working
+directory different than the project root, so an absolute path should be used.
+
 ### Benchmarks
 Initially there were some regressions found in the benchmarks, but further
 investigation revealed this was caused by some issues in the methodology of how

--- a/lib/project-manager/src/test/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerSupervisorSpec.scala
+++ b/lib/project-manager/src/test/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerSupervisorSpec.scala
@@ -36,7 +36,7 @@ class LanguageServerSupervisorSpec
     with MockitoSugar
     with FlakySpec {
 
-  "A language supervisor" should "monitor language server by sending ping requests on regular basis" taggedAs (Flaky) in new TestCtx {
+  "A language supervisor" should "monitor language server by sending ping requests on regular basis" taggedAs Flaky in new TestCtx {
     //given
     val probe = TestProbe()
     fakeServer.withBehaviour {
@@ -64,7 +64,7 @@ class LanguageServerSupervisorSpec
     fakeServer.stop()
   }
 
-  it should "restart server when pong message doesn't arrive on time" in new TestCtx {
+  it should "restart server when pong message doesn't arrive on time" taggedAs Flaky in new TestCtx {
     //given
     when(serverComponent.restart())
       .thenReturn(Future.successful(ComponentRestarted))


### PR DESCRIPTION
### Pull Request Description
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
For some reason, `testOnly` uses some different logic to run tests and while tests run using `test` work fine, some of the `runtime` tests would fail with `testOnly`.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All code has been tested where possible.
