### PR TITLE
[Tool] Move engine build after launcher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
   build-engine:
     name: Build Engine
     runs-on: ubuntu-latest
+    needs: build-launcher
     timeout-minutes: 30
     strategy:
       fail-fast: true

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ import com.typesafe.sbt.license.DepModuleInfo
 val scalacVersion = "2.13.3"
 val graalVersion  = "20.1.0"
 val javaVersion   = "11"
-val ensoVersion   = "0.0.1"
+val ensoVersion   = "0.1.0"
 organization in ThisBuild := "org.enso"
 scalaVersion in ThisBuild := scalacVersion
 val licenseSettings = Seq(


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Our builds include a version check which for stability does not rely on `build.sbt` but instead on querying `enso --version`. Building the engine takes a lot of time, so to save that time on failed builds, we ensure that the launcher is built first (which is much faster) and only if its version check succeeds, the engine build is attempted.

This makes the release fail fast if something is wrong with the version.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

- Bumps version to `0.1.0`.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
