### PR TITLE
[Build,Doc] Make builds work outside a repository

### DIFF
--- a/docs/getting-enso.md
+++ b/docs/getting-enso.md
@@ -9,8 +9,11 @@ order: 5
 # Getting Enso
 
 Enso packages can currently be obtained from the per-commit CI builds. See
-[the build workflow on GitHub Actions](https://github.com/enso-org/enso/actions?query=workflow%3A%22Engine+CI%22).
-The artifact of interest is `enso-<version>` (currently `enso-0.0.1`).
+[the build workflow on GitHub Actions](https://github.com/enso-org/enso/actions?query=workflow%3A%22Engine+CI%22+branch%3Amain),
+which should show a list of recent CI builds. The workflow of interest is
+`Engine CI`. You can navigate to the most recent build, which will display a
+list of attached artifacts. The artifact of interest is `enso-engine-<version>`
+(currently `enso-engine-0.1.0`).
 
 <!-- MarkdownTOC levels="2,3" autolink="true" -->
 

--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -11,24 +11,7 @@ object BuildInfo {
     scalacVersion: String,
     graalVersion: String
   ): Seq[File] = {
-    val gitHash          = ("git rev-parse HEAD" !!).trim
-    val gitBranchCommand = "git symbolic-ref -q --short HEAD"
-    val gitTagCommand    = "git describe --tags --exact-match"
-    val gitRefCommand =
-      gitBranchCommand #|| gitTagCommand
-    val gitRef =
-      try { (gitRefCommand !!).trim }
-      catch {
-        case e: Exception =>
-          log.warn(
-            "Cannot get name of git branch/tag, defaulting to \"HEAD\". " +
-            s"(Caused by: ${e.getMessage})"
-          )
-          "HEAD"
-      }
-    val isDirty          = !("git status --porcelain" !!).trim.isEmpty
-    val latestCommitDate = ("git log HEAD -1 --format=%cd" !!).trim
-
+    val gitInfo = getGitInformation(log).getOrElse(fallbackGitInformation)
     val fileContents =
       s"""
          |package buildinfo
@@ -41,14 +24,57 @@ object BuildInfo {
          |  val graalVersion  = "$graalVersion"
          |
          |  // Git Info
-         |  val commit            = "$gitHash"
-         |  val ref               = "$gitRef"
-         |  val isDirty           = $isDirty
-         |  val latestCommitDate  = "$latestCommitDate"
+         |  val commit            = "${gitInfo.commit}"
+         |  val ref               = "${gitInfo.ref}"
+         |  val isDirty           = ${gitInfo.isDirty}
+         |  val latestCommitDate  = "${gitInfo.latestCommitDate}"
          |}
          |""".stripMargin
     IO.write(file, fileContents)
     log.debug("Build info updated.")
     Seq(file)
   }
+
+  private case class GitInformation(
+    ref: String,
+    commit: String,
+    isDirty: Boolean,
+    latestCommitDate: String
+  )
+  private def getGitInformation(log: ManagedLogger): Option[GitInformation] =
+    try {
+      val hash = ("git rev-parse HEAD" !!).trim
+      val ref =
+        try {
+          val branchCommand = "git symbolic-ref -q --short HEAD"
+          val tagCommand    = "git describe --tags --exact-match"
+          val refCommand =
+            branchCommand #|| tagCommand
+          (refCommand !!).trim
+        } catch {
+          case e: Exception =>
+            log.warn(
+              "Cannot get name of git branch/tag, defaulting to \"HEAD\". " +
+              s"(Caused by: $e)"
+            )
+            "HEAD"
+        }
+      val isDirty          = !("git status --porcelain" !!).trim.isEmpty
+      val latestCommitDate = ("git log HEAD -1 --format=%cd" !!).trim
+      Some(GitInformation(ref, hash, isDirty, latestCommitDate))
+    } catch {
+      case e: Exception =>
+        log.warn(
+          "Could not get any git information. The build will proceed but it " +
+          s"will not contain the git metadata. (Caused by: $e)"
+        )
+        None
+    }
+  private def fallbackGitInformation: GitInformation =
+    GitInformation(
+      "<built outside of a git repository>",
+      "<built outside of a git repository>",
+      isDirty = false,
+      "<built outside of a git repository>"
+    )
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Makes sure that the build does not crash if run outside a `git` repository. Instead, only a warning is issued and the version string in the built artifacts will include fallback values for the git metadata.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

- Also updates the getting-enso page with up-to-date and more clarified information on downloading artifacts from the CI.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
