### PR TITLE
Emit Value Updates Only When There is a Change

### DIFF
--- a/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
@@ -75,7 +75,6 @@ class ContextEventsListenerSpec
             Api.ExpressionValueUpdate(
               Suggestions.method.externalId.get,
               None,
-              None,
               None
             )
           )
@@ -117,7 +116,6 @@ class ContextEventsListenerSpec
             Api.ExpressionValueUpdate(
               Suggestions.method.externalId.get,
               None,
-              None,
               None
             )
           )
@@ -128,7 +126,6 @@ class ContextEventsListenerSpec
           Vector(
             Api.ExpressionValueUpdate(
               Suggestions.local.externalId.get,
-              None,
               None,
               None
             )

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -240,13 +240,11 @@ object Runtime {
       *
       * @param expressionId expression id.
       * @param expressionType the type of expression.
-      * @param shortValue the value of expression.
       * @param methodCall the pointer to a method definition.
       */
     case class ExpressionValueUpdate(
       expressionId: ExpressionId,
       expressionType: Option[String],
-      shortValue: Option[String],
       methodCall: Option[MethodPointer]
     )
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
@@ -232,8 +232,8 @@ public class IdExecutionInstrument extends TruffleInstrument {
      * @param cache the precomputed expression values.
      * @param nextExecutionItem the next item scheduled for execution.
      * @param functionCallCallback the consumer of function call events.
-     * @param onComputedCallback the consumer of the node value events.
-     * @param onCachedCallback the consumer of the node visualisation events.
+     * @param onComputedCallback the consumer of the computed value events.
+     * @param onCachedCallback the consumer of the cached value events.
      */
     public IdExecutionEventListener(
         CallTarget entryCallTarget,
@@ -369,8 +369,8 @@ public class IdExecutionInstrument extends TruffleInstrument {
    * @param funSourceLength the length of the observed source range.
    * @param cache the precomputed expression values.
    * @param nextExecutionItem the next item scheduled for execution.
-   * @param valueCallback the consumer of the node value events.
-   * @param visualisationCallback the consumer of the node visualisation events.
+   * @param onComputedCallback the consumer of the computed value events.
+   * @param onCachedCallback the consumer of the cached value events.
    * @param functionCallCallback the consumer of function call events.
    * @return a reference to the attached event listener.
    */
@@ -380,8 +380,8 @@ public class IdExecutionInstrument extends TruffleInstrument {
       int funSourceLength,
       RuntimeCache cache,
       UUID nextExecutionItem,
-      Consumer<ExpressionValue> valueCallback,
-      Consumer<IdExecutionInstrument.ExpressionValue> visualisationCallback,
+      Consumer<ExpressionValue> onComputedCallback,
+      Consumer<IdExecutionInstrument.ExpressionValue> onCachedCallback,
       Consumer<ExpressionCall> functionCallCallback) {
     SourceSectionFilter filter =
         SourceSectionFilter.newBuilder()
@@ -399,8 +399,8 @@ public class IdExecutionInstrument extends TruffleInstrument {
                     cache,
                     nextExecutionItem,
                     functionCallCallback,
-                    valueCallback,
-                    visualisationCallback));
+                    onComputedCallback,
+                    onCachedCallback));
     return binding;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
@@ -60,6 +60,11 @@ public class RuntimeCache {
     return types.put(key, typeName);
   }
 
+  /** @return the cached type of the expression */
+  public String getType(UUID key) {
+    return types.get(key);
+  }
+
   /** Remove the type associated with the provided key. */
   public void removeType(UUID key) {
     types.remove(key);

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 public class RuntimeCache {
 
   private final Map<UUID, SoftReference<Object>> cache = new HashMap<>();
+  private final Map<UUID, String> types = new HashMap<>();
   private Map<UUID, Double> weights = new HashMap<>();
 
   /**
@@ -48,6 +49,25 @@ public class RuntimeCache {
   /** Clear the cached values. */
   public void clear() {
     cache.clear();
+  }
+
+  /**
+   * Cache the type of expression.
+   *
+   * @return the previously cached type.
+   */
+  public String putType(UUID key, String typeName) {
+    return types.put(key, typeName);
+  }
+
+  /** Remove the type associated with the provided key. */
+  public void removeType(UUID key) {
+    types.remove(key);
+  }
+
+  /** Clear the cached types. */
+  public void clearTypes() {
+    types.clear();
   }
 
   /** @return the weights of this cache. */

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
@@ -11,6 +11,7 @@ public class RuntimeCache {
 
   private final Map<UUID, SoftReference<Object>> cache = new HashMap<>();
   private final Map<UUID, String> types = new HashMap<>();
+  private final Map<UUID, IdExecutionInstrument.FunctionCallInfo> calls = new HashMap<>();
   private Map<UUID, Double> weights = new HashMap<>();
 
   /**
@@ -63,6 +64,28 @@ public class RuntimeCache {
   /** @return the cached type of the expression */
   public String getType(UUID key) {
     return types.get(key);
+  }
+
+  /**
+   * Cache the function call
+   *
+   * @param key the expression associated with the function call.
+   * @param call the function call.
+   * @return the function call that was previously associated with this expression.
+   */
+  public IdExecutionInstrument.FunctionCallInfo putCall(
+      UUID key, IdExecutionInstrument.FunctionCallInfo call) {
+    return calls.put(key, call);
+  }
+
+  /** @return the cached function call associated with the expression. */
+  public IdExecutionInstrument.FunctionCallInfo getCall(UUID key) {
+    return calls.get(key);
+  }
+
+  /** Clear the cached calls. */
+  public void clearCalls() {
+    calls.clear();
   }
 
   /** Remove the type associated with the provided key. */

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
@@ -101,23 +101,27 @@ public class Types {
    * @param value an object of interest.
    * @return the string representation of object's type.
    */
-  public static Optional<String> getName(Object value) {
-    if (TypesGen.isLong(value)) {
-      return Optional.of("Number");
+  public static String getName(Object value) {
+    if (TypesGen.isLong(value) || TypesGen.isImplicitLong(value)) {
+      return "Number";
+    } else if (TypesGen.isBoolean(value)) {
+      return "Boolean";
     } else if (TypesGen.isString(value)) {
-      return Optional.of("Text");
+      return "Text";
     } else if (TypesGen.isFunction(value)) {
-      return Optional.of("Function");
+      return "Function";
     } else if (TypesGen.isAtom(value)) {
-      return Optional.of(TypesGen.asAtom(value).getConstructor().getName());
+      return TypesGen.asAtom(value).getConstructor().getName();
     } else if (TypesGen.isAtomConstructor(value)) {
-      return Optional.of(TypesGen.asAtomConstructor(value).getName());
+      return TypesGen.asAtomConstructor(value).getName();
     } else if (TypesGen.isThunk(value)) {
-      return Optional.of("Thunk");
+      return "Thunk";
     } else if (TypesGen.isRuntimeError(value)) {
-      return Optional.of("Error " + TypesGen.asRuntimeError(value).getPayload().toString());
+      return "Error " + TypesGen.asRuntimeError(value).getPayload().toString();
+    } else if (TypesGen.isVector(value)) {
+      return "Vector";
     } else {
-      return Optional.empty();
+      return null;
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -84,16 +84,16 @@ public class ExecutionService {
    * @param call the call metadata.
    * @param cache the precomputed expression values.
    * @param nextExecutionItem the next item scheduled for execution.
-   * @param valueCallback the consumer for expression value events.
-   * @param visualisationCallback the consumer of the node visualisation events.
+   * @param onComputedCallback the consumer of the computed value events.
+   * @param onCachedCallback the consumer of the cached value events.
    * @param funCallCallback the consumer for function call events.
    */
   public void execute(
       FunctionCallInstrumentationNode.FunctionCall call,
       RuntimeCache cache,
       UUID nextExecutionItem,
-      Consumer<IdExecutionInstrument.ExpressionValue> valueCallback,
-      Consumer<IdExecutionInstrument.ExpressionValue> visualisationCallback,
+      Consumer<IdExecutionInstrument.ExpressionValue> onComputedCallback,
+      Consumer<IdExecutionInstrument.ExpressionValue> onCachedCallback,
       Consumer<IdExecutionInstrument.ExpressionCall> funCallCallback)
       throws UnsupportedMessageException, ArityException, UnsupportedTypeException {
 
@@ -108,8 +108,8 @@ public class ExecutionService {
             src.getCharLength(),
             cache,
             nextExecutionItem,
-            valueCallback,
-            visualisationCallback,
+            onComputedCallback,
+            onCachedCallback,
             funCallCallback);
     interopLibrary.execute(call);
     listener.dispose();
@@ -124,8 +124,8 @@ public class ExecutionService {
    * @param methodName the method name.
    * @param cache the precomputed expression values.
    * @param nextExecutionItem the next item scheduled for execution.
-   * @param valueCallback the consumer for expression value events.
-   * @param visualisationCallback the consumer of the node visualisation events.
+   * @param onComputedCallback the consumer of the computed value events.
+   * @param onCachedCallback the consumer of the cached value events.
    * @param funCallCallback the consumer for function call events.
    */
   public void execute(
@@ -134,8 +134,8 @@ public class ExecutionService {
       String methodName,
       RuntimeCache cache,
       UUID nextExecutionItem,
-      Consumer<IdExecutionInstrument.ExpressionValue> valueCallback,
-      Consumer<IdExecutionInstrument.ExpressionValue> visualisationCallback,
+      Consumer<IdExecutionInstrument.ExpressionValue> onComputedCallback,
+      Consumer<IdExecutionInstrument.ExpressionValue> onCachedCallback,
       Consumer<IdExecutionInstrument.ExpressionCall> funCallCallback)
       throws UnsupportedMessageException, ArityException, UnsupportedTypeException {
     Optional<FunctionCallInstrumentationNode.FunctionCall> callMay =
@@ -149,8 +149,8 @@ public class ExecutionService {
         callMay.get(),
         cache,
         nextExecutionItem,
-        valueCallback,
-        visualisationCallback,
+        onComputedCallback,
+        onCachedCallback,
         funCallCallback);
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/Changeset.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/Changeset.scala
@@ -33,10 +33,12 @@ final class Changeset[A: TextEditor: IndexedSource](val source: A, val ir: IR) {
         DataflowAnalysis,
         "Empty dataflow analysis metadata during changeset calculation."
       )
-    invalidated(edits)
+    val direct = invalidated(edits)
+    val transitive = direct
       .map(Changeset.toDataflowDependencyType)
       .flatMap(metadata.getExternal)
       .flatten
+    direct.flatMap(_.externalId) ++ transitive
   }
 
   /** Traverses the IR and returns a list of the most specific (the innermost)

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/CacheInvalidation.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/CacheInvalidation.scala
@@ -34,6 +34,9 @@ object CacheInvalidation {
 
     /** Invalidate the types index. */
     case object Types extends IndexSelector
+
+    /** Invalidate the weights index. */
+    case object Weights extends IndexSelector
   }
 
   /** Base trait for cache invalidation commands. Commands describe how the
@@ -99,7 +102,7 @@ object CacheInvalidation {
     elements: StackSelector,
     command: Command
   ): CacheInvalidation =
-    new CacheInvalidation(elements, command, Set(IndexSelector.Types))
+    new CacheInvalidation(elements, command, Set())
 
   /** Run a sequence of invalidation instructions on an execution stack.
     *
@@ -179,10 +182,12 @@ object CacheInvalidation {
     */
   private def clearIndex(selector: IndexSelector, cache: RuntimeCache): Unit =
     selector match {
-      case IndexSelector.Types =>
-        cache.clearTypes()
       case IndexSelector.All =>
         cache.clearTypes()
         cache.clearWeights()
+      case IndexSelector.Weights =>
+        cache.clearWeights()
+      case IndexSelector.Types =>
+        cache.clearTypes()
     }
 }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/CacheInvalidation.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/CacheInvalidation.scala
@@ -35,6 +35,9 @@ object CacheInvalidation {
     /** Invalidate the types index. */
     case object Types extends IndexSelector
 
+    /** Invalidate the calls index. */
+    case object Calls extends IndexSelector
+
     /** Invalidate the weights index. */
     case object Weights extends IndexSelector
   }
@@ -185,9 +188,12 @@ object CacheInvalidation {
       case IndexSelector.All =>
         cache.clearTypes()
         cache.clearWeights()
+        cache.clearCalls()
       case IndexSelector.Weights =>
         cache.clearWeights()
       case IndexSelector.Types =>
         cache.clearTypes()
+      case IndexSelector.Calls =>
+        cache.clearCalls()
     }
 }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -155,10 +155,15 @@ class EnsureCompiledJob(protected val files: List[File])
       .map(_._2)
     val invalidateStaleCommand =
       CacheInvalidation.Command.InvalidateStale(scopeIds)
-    Seq(invalidateExpressionsCommand, invalidateStaleCommand).map(
+    Seq(
       CacheInvalidation(
         CacheInvalidation.StackSelector.All,
-        _,
+        invalidateExpressionsCommand,
+        Set(CacheInvalidation.IndexSelector.Weights)
+      ),
+      CacheInvalidation(
+        CacheInvalidation.StackSelector.All,
+        invalidateStaleCommand,
         Set(CacheInvalidation.IndexSelector.All)
       )
     )

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -173,7 +173,7 @@ class EnsureCompiledJob(protected val files: List[File])
   private def runInvalidationCommands(
     invalidationCommands: Iterable[CacheInvalidation]
   )(implicit ctx: RuntimeContext): Unit = {
-    ctx.contextManager.getAll.valuesIterator
+    ctx.contextManager.getAll.values
       .collect {
         case stack if stack.nonEmpty =>
           CacheInvalidation.runAll(stack, invalidationCommands)

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -137,23 +137,24 @@ trait ProgramExecutionSupport {
     val (explicitCallOpt, localCalls) = unwind(stack, Nil, Nil)
     for {
       stackItem <- Either.fromOption(explicitCallOpt, "stack is empty")
-      _ <- Either
-        .catchNonFatal(
-          runProgram(
-            stackItem,
-            localCalls,
-            onExpressionValueComputed(contextId, _),
-            visualisationUpdateCallback
+      _ <-
+        Either
+          .catchNonFatal(
+            runProgram(
+              stackItem,
+              localCalls,
+              onExpressionValueComputed(contextId, _),
+              visualisationUpdateCallback
+            )
           )
-        )
-        .leftMap { ex =>
-          ctx.executionService.getLogger.log(
-            Level.FINE,
-            s"Error executing a function '${getName(stackItem.item)}'",
-            ex
-          )
-          s"error in function: ${getName(stackItem.item)}"
-        }
+          .leftMap { ex =>
+            ctx.executionService.getLogger.log(
+              Level.FINE,
+              s"Error executing a function '${getName(stackItem.item)}'",
+              ex
+            )
+            s"error in function: ${getName(stackItem.item)}"
+          }
     } yield ()
   }
 
@@ -183,7 +184,6 @@ trait ProgramExecutionSupport {
             Api.ExpressionValueUpdate(
               value.getExpressionId,
               OptionConverters.toScala(value.getType),
-              Some(value.getValue.toString),
               toMethodPointer(value)
             )
           )
@@ -253,10 +253,10 @@ trait ProgramExecutionSupport {
     value: ExpressionValue
   )(implicit ctx: RuntimeContext): Option[Api.MethodPointer] =
     for {
-      call          <- Option(value.getCallInfo)
-      moduleName    <- Option(call.getModuleName)
-      functionName  = call.getFunctionName
-      typeName      <- Option(call.getTypeName).map(_.item)
+      call       <- Option(value.getCallInfo)
+      moduleName <- Option(call.getModuleName)
+      functionName = call.getFunctionName
+      typeName <- Option(call.getTypeName).map(_.item)
       module <- OptionConverters.toScala(
         ctx.executionService.getContext.getTopScope
           .getModule(moduleName.toString)

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -38,19 +38,19 @@ trait ProgramExecutionSupport {
     *
     * @param executionFrame an execution frame
     * @param callStack a call stack
-    * @param valueCallback a listener of computed values
-    * @param visualisationCallback a listener of fired visualisations
+    * @param onComputedCallback a listener of computed values
+    * @param onCachedCallback a listener of cached values
     */
   @scala.annotation.tailrec
   final private def runProgram(
     executionFrame: ExecutionFrame,
     callStack: List[LocalCallFrame],
-    valueCallback: Consumer[ExpressionValue],
-    visualisationCallback: Consumer[ExpressionValue]
+    onComputedCallback: Consumer[ExpressionValue],
+    onCachedCallback: Consumer[ExpressionValue]
   )(implicit ctx: RuntimeContext): Unit = {
     var enterables: Map[UUID, FunctionCall] = Map()
-    val valsCallback: Consumer[ExpressionValue] =
-      if (callStack.isEmpty) valueCallback else _ => ()
+    val computedCallback: Consumer[ExpressionValue] =
+      if (callStack.isEmpty) onComputedCallback else _ => ()
     val callablesCallback: Consumer[ExpressionCall] = fun =>
       if (callStack.headOption.exists(_.expressionId == fun.getExpressionId)) {
         enterables += fun.getExpressionId -> fun.getCall
@@ -63,8 +63,8 @@ trait ProgramExecutionSupport {
           function,
           cache,
           callStack.headOption.map(_.expressionId).orNull,
-          valsCallback,
-          visualisationCallback,
+          computedCallback,
+          onCachedCallback,
           callablesCallback
         )
       case ExecutionFrame(ExecutionItem.CallData(callData), cache) =>
@@ -72,8 +72,8 @@ trait ProgramExecutionSupport {
           callData,
           cache,
           callStack.headOption.map(_.expressionId).orNull,
-          valsCallback,
-          visualisationCallback,
+          computedCallback,
+          onCachedCallback,
           callablesCallback
         )
     }
@@ -86,8 +86,8 @@ trait ProgramExecutionSupport {
             runProgram(
               ExecutionFrame(ExecutionItem.CallData(call), item.cache),
               tail,
-              valueCallback,
-              visualisationCallback
+              onComputedCallback,
+              onCachedCallback
             )
           case None =>
             ()

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -176,20 +176,22 @@ trait ProgramExecutionSupport {
     contextId: ContextId,
     value: ExpressionValue
   )(implicit ctx: RuntimeContext): Unit = {
-    ctx.endpoint.sendToClient(
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              value.getExpressionId,
-              OptionConverters.toScala(value.getType),
-              toMethodPointer(value)
+    if (value.getType ne null) {
+      ctx.endpoint.sendToClient(
+        Api.Response(
+          Api.ExpressionValuesComputed(
+            contextId,
+            Vector(
+              Api.ExpressionValueUpdate(
+                value.getExpressionId,
+                Some(value.getType),
+                toMethodPointer(value)
+              )
             )
           )
         )
       )
-    )
+    }
   }
 
   private def fireVisualisationUpdates(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeCacheTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeCacheTest.scala
@@ -13,7 +13,7 @@ class RuntimeCacheTest extends AnyFlatSpec with Matchers {
 
   "RutimeCache" should "cache items" in {
     val cache = new RuntimeCache
-    val key   = UUID.randomUUID
+    val key   = UUID.randomUUID()
     val obj   = 42
 
     cache.offer(key, obj) shouldEqual false
@@ -28,7 +28,7 @@ class RuntimeCacheTest extends AnyFlatSpec with Matchers {
 
   it should "remove items" in {
     val cache = new RuntimeCache
-    val key   = UUID.randomUUID
+    val key   = UUID.randomUUID()
     val obj   = new Object
 
     cache.setWeights(
@@ -37,5 +37,17 @@ class RuntimeCacheTest extends AnyFlatSpec with Matchers {
     cache.offer(key, obj) shouldEqual true
     cache.remove(key) shouldEqual obj
     cache.get(key) shouldEqual null
+  }
+
+  it should "cache types" in {
+    val cache = new RuntimeCache
+    val key   = UUID.randomUUID()
+    val obj   = "Number"
+
+    cache.putType(key, obj) shouldEqual null
+    cache.putType(key, obj) shouldEqual obj
+
+    cache.removeType(key)
+    cache.putType(key, obj) shouldEqual null
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -123,7 +123,7 @@ class RuntimeServerTest
 
       object Update {
 
-        def mainX(contextId: UUID, value: String = "6") =
+        def mainX(contextId: UUID) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -131,14 +131,13 @@ class RuntimeServerTest
                 Api.ExpressionValueUpdate(
                   Main.idMainX,
                   Some("Number"),
-                  Some(value),
                   None
                 )
               )
             )
           )
 
-        def mainY(contextId: UUID, value: String = "45") =
+        def mainY(contextId: UUID) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -146,14 +145,13 @@ class RuntimeServerTest
                 Api.ExpressionValueUpdate(
                   Main.idMainY,
                   Some("Number"),
-                  Some(value),
                   Some(Api.MethodPointer(pkg.mainFile, "Number", "foo"))
                 )
               )
             )
           )
 
-        def mainZ(contextId: UUID, value: String = "50") =
+        def mainZ(contextId: UUID) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -161,14 +159,13 @@ class RuntimeServerTest
                 Api.ExpressionValueUpdate(
                   Main.idMainZ,
                   Some("Number"),
-                  Some(value),
                   None
                 )
               )
             )
           )
 
-        def fooY(contextId: UUID, value: String = "9") =
+        def fooY(contextId: UUID) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -176,14 +173,13 @@ class RuntimeServerTest
                 Api.ExpressionValueUpdate(
                   Main.idFooY,
                   Some("Number"),
-                  Some(value),
                   None
                 )
               )
             )
           )
 
-        def fooZ(contextId: UUID, value: String = "45") =
+        def fooZ(contextId: UUID) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -191,7 +187,6 @@ class RuntimeServerTest
                 Api.ExpressionValueUpdate(
                   Main.idFooZ,
                   Some("Number"),
-                  Some(value),
                   None
                 )
               )
@@ -226,7 +221,7 @@ class RuntimeServerTest
 
       object Update {
 
-        def mainY(contextId: UUID, value: String = "15") =
+        def mainY(contextId: UUID) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -234,14 +229,13 @@ class RuntimeServerTest
                 Api.ExpressionValueUpdate(
                   idMainY,
                   Some("Number"),
-                  Some(value),
                   Some(Api.MethodPointer(pkg.mainFile, "Main", "foo"))
                 )
               )
             )
           )
 
-        def mainZ(contextId: UUID, value: String = "75") =
+        def mainZ(contextId: UUID) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -249,7 +243,6 @@ class RuntimeServerTest
                 Api.ExpressionValueUpdate(
                   idMainZ,
                   Some("Number"),
-                  Some(value),
                   Some(Api.MethodPointer(pkg.mainFile, "Main", "bar"))
                 )
               )
@@ -509,7 +502,7 @@ class RuntimeServerTest
         Api.ExpressionValuesComputed(
           contextId,
           Vector(
-            Api.ExpressionValueUpdate(idMain, Some("Number"), Some("84"), None)
+            Api.ExpressionValueUpdate(idMain, Some("Number"), None)
           )
         )
       ),
@@ -551,9 +544,7 @@ class RuntimeServerTest
       Api.Response(
         Api.ExpressionValuesComputed(
           contextId,
-          Vector(
-            Api.ExpressionValueUpdate(idMain, Some("Number"), Some("42"), None)
-          )
+          Vector(Api.ExpressionValueUpdate(idMain, Some("Number"), None))
         )
       )
     )
@@ -567,14 +558,7 @@ class RuntimeServerTest
       Api.Response(
         Api.ExpressionValuesComputed(
           contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              idMain,
-              Some("Number"),
-              Some("50"),
-              None
-            )
-          )
+          Vector(Api.ExpressionValueUpdate(idMain, Some("Number"), None))
         )
       )
 

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -692,14 +692,7 @@ class RuntimeServerTest
         )
       )
     )
-    context.receive shouldEqual Some(
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(Api.ExpressionValueUpdate(idMain, Some("Number"), None))
-        )
-      )
-    )
+    context.receive shouldEqual None
   }
 
   it should "send suggestion notifications when file executed" in {
@@ -1045,11 +1038,8 @@ class RuntimeServerTest
         )
       )
     )
-    context.receive(5) should contain theSameElementsAs Seq(
-      Api.Response(requestId, Api.RecomputeContextResponse(contextId)),
-      context.Main.Update.mainX(contextId),
-      context.Main.Update.mainY(contextId),
-      context.Main.Update.mainZ(contextId)
+    context.receive(2) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.RecomputeContextResponse(contextId))
     )
   }
 
@@ -1092,9 +1082,8 @@ class RuntimeServerTest
         )
       )
     )
-    context.receive(3) should contain theSameElementsAs Seq(
-      Api.Response(requestId, Api.RecomputeContextResponse(contextId)),
-      context.Main.Update.mainZ(contextId)
+    context.receive(1) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.RecomputeContextResponse(contextId))
     )
   }
 
@@ -1269,10 +1258,9 @@ class RuntimeServerTest
         )
       )
     )
-    val recomputeResponses2 = context.receive(4)
-    recomputeResponses2 should contain allOf (
-      Api.Response(requestId, Api.RecomputeContextResponse(contextId)),
-      context.Main.Update.mainX(contextId),
+    val recomputeResponses2 = context.receive(3)
+    recomputeResponses2 should contain(
+      Api.Response(requestId, Api.RecomputeContextResponse(contextId))
     )
     val Some(data2) = recomputeResponses2.collectFirst {
       case Api.Response(
@@ -1473,13 +1461,7 @@ class RuntimeServerTest
       )
     )
 
-    val editResult = context.receive(4)
-    editResult should contain allOf (
-      context.Main.Update.mainX(contextId),
-      context.Main.Update.mainY(contextId),
-      context.Main.Update.mainZ(contextId),
-    )
-    val Some(data1) = editResult.collectFirst {
+    val Some(data1) = context.receive(1).collectFirst {
       case Api.Response(
             None,
             Api.VisualisationUpdate(
@@ -1703,9 +1685,8 @@ class RuntimeServerTest
         )
       )
     )
-    context.receive(3) should contain theSameElementsAs Seq(
-      Api.Response(requestId, Api.RecomputeContextResponse(contextId)),
-      context.Main.Update.mainX(contextId)
+    context.receive(2) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.RecomputeContextResponse(contextId))
     )
   }
 
@@ -1745,8 +1726,7 @@ class RuntimeServerTest
     context.send(
       Api.Request(requestId, Api.RecomputeContextRequest(contextId, None))
     )
-
-    context.receive(2) should contain(
+    context.receive(2) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.RecomputeContextResponse(contextId))
     )
 
@@ -1760,11 +1740,8 @@ class RuntimeServerTest
         )
       )
     )
-    context.receive(4) should contain theSameElementsAs Seq(
-      Api.Response(requestId, Api.RecomputeContextResponse(contextId)),
-      context.Main.Update.mainX(contextId),
-      context.Main.Update.mainY(contextId),
-      context.Main.Update.mainZ(contextId)
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.RecomputeContextResponse(contextId))
     )
   }
 

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -507,9 +507,8 @@ class RuntimeServerTest
 
     // pop foo call
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
-    context.receive(3) should contain theSameElementsAs Seq(
-      Api.Response(requestId, Api.PopContextResponse(contextId)),
-      idMainUpdate
+    context.receive(2) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PopContextResponse(contextId))
     )
 
     // pop main
@@ -692,14 +691,7 @@ class RuntimeServerTest
         )
       )
     )
-    context.receive(2) should contain theSameElementsAs Seq(
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(Api.ExpressionValueUpdate(idMain, Some("Number"), None))
-        )
-      )
-    )
+    context.receive shouldEqual None
   }
 
   it should "send suggestion notifications when file executed" in {
@@ -846,9 +838,8 @@ class RuntimeServerTest
 
     // pop foo call
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
-    context.receive(3) should contain theSameElementsAs Seq(
-      Api.Response(requestId, Api.PopContextResponse(contextId)),
-      idMainUpdate
+    context.receive(2) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PopContextResponse(contextId))
     )
 
     // pop main

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/infrastructure/languageserver/ProjectRenameActionSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/infrastructure/languageserver/ProjectRenameActionSpec.scala
@@ -28,7 +28,7 @@ class ProjectRenameActionSpec
     with MockitoSugar
     with FlakySpec {
 
-  "A project rename action" should "delegate request to the Language Server" in new TestCtx {
+  "A project rename action" should "delegate request to the Language Server" taggedAs Flaky in new TestCtx {
     //given
     val probe = TestProbe()
     fakeServer.withBehaviour {


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #441 
close #442 

PR changes the Runtime to emit `ExpressionValueUpdate` only when there is a change in the return type or the underlying method pointer of the executed expression.

Changelog:

- update: cache return types and method call info of the executed expressions
- update: runtime emits value updates only when there is a change in the type, or the underlying method pointer
- refactor: remove the `shortValue` field from the Runtime expression value update notification

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
