### PR TITLE
Update Runtime Notifications API

### DIFF
--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -28,6 +28,8 @@ transport formats, please look [here](./protocol-architecture).
   - [`SuggestionEntryArgument`](#suggestionentryargument)
   - [`SuggestionEntry`](#suggestionentry)
   - [`SuggestionEntryType`](#suggestionentrytype)
+  - [`SuggestionId`](#suggestionid)
+  - [`SuggestionsDatabaseEntry`](#suggestionsdatabaseentry)
   - [`SuggestionsDatabaseUpdate`](#suggestionsdatabaseupdate)
   - [`File`](#file)
   - [`DirectoryTree`](#directorytree)
@@ -203,8 +205,13 @@ Points to a method definition.
 
 ```typescript
 interface MethodPointer {
-  file: Path;
+  /** The fully qualified module name. */
+  module: String;
+
+  /** The type on which the method is defined. */
   definedOnType: String;
+
+  /** The method name. */
   name: String;
 }
 ```
@@ -216,8 +223,11 @@ interface ExpressionValueUpdate {
   /** The id of updated expression */
   expressionId: ExpressionId;
 
-  /** The updated suggestion id */
-  suggestionId: number;
+  /** The updated type of the expression */
+  type?: String;
+
+  /** The updated pointer to the method call */
+  methodPointer?: SuggestionId;
 }
 ```
 
@@ -335,6 +345,16 @@ The suggestion entry type that is used as a filter in search requests.
 type SuggestionEntryType = Atom | Method | Function | Local;
 ```
 
+### `SuggestionId`
+
+The suggestion entry id of the suggestions database.
+
+#### Format
+
+```typescript
+type SuggestionId = number;
+```
+
 ### `SuggestionsDatabaseEntry`
 
 #### Format
@@ -344,7 +364,7 @@ The entry in the suggestions database.
 ```typescript
 interface SuggestionsDatabaseEntry {
   // suggestion entry id
-  id: number;
+  id: SuggestionId;
   // suggestion entry
   suggestion: SuggestionEntry;
 }
@@ -362,19 +382,19 @@ type SuggestionsDatabaseUpdate = Add | Remove | Modify;
 
 interface Add {
   // suggestion entry id
-  id: number;
+  id: SuggestionId;
   // suggestion entry
   suggestion: SuggestionEntry;
 }
 
 interface Remove {
   // suggestion entry id
-  id: number;
+  id: SuggestionId;
 }
 
 interface Modify {
   // suggestion entry id
-  id: number;
+  id: SuggestionId;
   // new return type
   returnType: String;
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExpressionValueUpdate.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExpressionValueUpdate.scala
@@ -6,6 +6,11 @@ import org.enso.languageserver.runtime.ExecutionApi.ExpressionId
   * An update containing information about expression.
   *
   * @param expressionId the id of updated expression
-  * @param suggestionId the updated suggestion id
+  * @param `type` the updated type of expression
+  * @param methodPointer the suggestion id of the updated method pointer
   */
-case class ExpressionValueUpdate(expressionId: ExpressionId, suggestionId: Long)
+case class ExpressionValueUpdate(
+  expressionId: ExpressionId,
+  `type`: Option[String],
+  methodPointer: Option[Long]
+)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/MethodPointer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/MethodPointer.scala
@@ -1,12 +1,10 @@
 package org.enso.languageserver.runtime
 
-import org.enso.languageserver.filemanager.Path
-
 /**
   * An object pointing to a method definition.
   *
-  * @param file path to the method file
+  * @param module the module of the method file
   * @param definedOnType method type
   * @param name method name
   */
-case class MethodPointer(file: Path, definedOnType: String, name: String)
+case class MethodPointer(module: String, definedOnType: String, name: String)

--- a/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
@@ -74,8 +74,14 @@ class ContextEventsListenerSpec
           Vector(
             Api.ExpressionValueUpdate(
               Suggestions.method.externalId.get,
-              None,
-              None
+              Some(Suggestions.method.returnType),
+              Some(
+                Api.MethodPointer(
+                  Suggestions.method.module,
+                  Suggestions.method.selfType,
+                  Suggestions.method.name
+                )
+              )
             )
           )
         )
@@ -88,7 +94,8 @@ class ContextEventsListenerSpec
               Vector(
                 ExpressionValueUpdate(
                   Suggestions.method.externalId.get,
-                  suggestionIds(1).get
+                  Some(Suggestions.method.returnType),
+                  Some(suggestionIds(1).get)
                 )
               )
             )
@@ -98,7 +105,7 @@ class ContextEventsListenerSpec
 
     "send expression updates grouped" taggedAs Retry in withDb(0.seconds) {
       (clientId, contextId, repo, router, listener) =>
-        val (_, suggestionIds) = Await.result(
+        Await.result(
           repo.insertAll(
             Seq(
               Suggestions.atom,
@@ -142,11 +149,13 @@ class ContextEventsListenerSpec
               Vector(
                 ExpressionValueUpdate(
                   Suggestions.method.externalId.get,
-                  suggestionIds(1).get
+                  None,
+                  None
                 ),
                 ExpressionValueUpdate(
                   Suggestions.local.externalId.get,
-                  suggestionIds(3).get
+                  None,
+                  None
                 )
               )
             )

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -198,7 +198,11 @@ object Runtime {
     /**
       * A representation of a pointer to a method definition.
       */
-    case class MethodPointer(file: File, definedOnType: String, name: String)
+    case class MethodPointer(
+      module: String,
+      definedOnType: String,
+      name: String
+    )
 
     /**
       * A representation of an executable position in code.

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -119,7 +119,7 @@ public class ExecutionService {
    * Executes a method described by its name, constructor it's defined on and the module it's
    * defined in.
    *
-   * @param modulePath the path to the module where the method is defined.
+   * @param moduleName the module where the method is defined.
    * @param consName the name of the constructor the method is defined on.
    * @param methodName the method name.
    * @param cache the precomputed expression values.
@@ -129,7 +129,7 @@ public class ExecutionService {
    * @param funCallCallback the consumer for function call events.
    */
   public void execute(
-      File modulePath,
+      String moduleName,
       String consName,
       String methodName,
       RuntimeCache cache,
@@ -140,7 +140,7 @@ public class ExecutionService {
       throws UnsupportedMessageException, ArityException, UnsupportedTypeException {
     Optional<FunctionCallInstrumentationNode.FunctionCall> callMay =
         context
-            .getModuleForFile(modulePath)
+            .findModule(moduleName)
             .flatMap(module -> prepareFunctionCall(module, consName, methodName));
     if (!callMay.isPresent()) {
       return;

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -21,7 +21,7 @@ import scala.jdk.OptionConverters._
   *
   * @param files a files to compile
   */
-class EnsureCompiledJob(protected val files: List[File])
+class EnsureCompiledJob(protected val files: Iterable[File])
     extends Job[Unit](List.empty, true, false) {
 
   /**

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -144,7 +144,7 @@ class RuntimeServerTest
                 Api.ExpressionValueUpdate(
                   Main.idMainY,
                   Some("Number"),
-                  Some(Api.MethodPointer(pkg.mainFile, "Number", "foo"))
+                  Some(Api.MethodPointer("Test.Main", "Number", "foo"))
                 )
               )
             )
@@ -228,7 +228,7 @@ class RuntimeServerTest
                 Api.ExpressionValueUpdate(
                   idMainY,
                   Some("Number"),
-                  Some(Api.MethodPointer(pkg.mainFile, "Main", "foo"))
+                  Some(Api.MethodPointer("Test.Main", "Main", "foo"))
                 )
               )
             )
@@ -242,7 +242,7 @@ class RuntimeServerTest
                 Api.ExpressionValueUpdate(
                   idMainZ,
                   Some("Number"),
-                  Some(Api.MethodPointer(pkg.mainFile, "Main", "bar"))
+                  Some(Api.MethodPointer("Test.Main", "Main", "bar"))
                 )
               )
             )
@@ -284,7 +284,7 @@ class RuntimeServerTest
   }
 
   "RuntimeServer" should "push and pop functions on the stack" in {
-    val mainFile  = context.writeMain(context.Main.code)
+    context.writeMain(context.Main.code)
     val contextId = UUID.randomUUID()
     val requestId = UUID.randomUUID()
 
@@ -306,7 +306,7 @@ class RuntimeServerTest
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )
@@ -333,7 +333,7 @@ class RuntimeServerTest
 
     // push method pointer on top of the non-empty stack
     val invalidExplicitCall = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )
@@ -402,7 +402,7 @@ class RuntimeServerTest
         Api.PushContextRequest(
           contextId,
           Api.StackItem.ExplicitCall(
-            Api.MethodPointer(mainFile, "Main", "main"),
+            Api.MethodPointer(moduleName, "Main", "main"),
             None,
             Vector()
           )
@@ -521,7 +521,7 @@ class RuntimeServerTest
         Api.PushContextRequest(
           contextId,
           Api.StackItem.ExplicitCall(
-            Api.MethodPointer(mainFile, "Main", "main"),
+            Api.MethodPointer(moduleName, "Main", "main"),
             None,
             Vector()
           )
@@ -689,7 +689,7 @@ class RuntimeServerTest
         Api.PushContextRequest(
           contextId,
           Api.StackItem.ExplicitCall(
-            Api.MethodPointer(mainFile, "Main", "main"),
+            Api.MethodPointer(moduleName, "Main", "main"),
             None,
             Vector()
           )
@@ -818,7 +818,7 @@ class RuntimeServerTest
             Api.ExpressionValueUpdate(
               idMainA,
               Some("Number"),
-              Some(Api.MethodPointer(mainFile, "Number", "x"))
+              Some(Api.MethodPointer(moduleName, "Number", "x"))
             )
           )
         )
@@ -865,7 +865,7 @@ class RuntimeServerTest
             Api.ExpressionValueUpdate(
               idMainA,
               Some("Number"),
-              Some(Api.MethodPointer(mainFile, "Main", "pie"))
+              Some(Api.MethodPointer(moduleName, "Main", "pie"))
             )
           )
         )
@@ -895,7 +895,7 @@ class RuntimeServerTest
             Api.ExpressionValueUpdate(
               idMainA,
               Some("Number"),
-              Some(Api.MethodPointer(mainFile, "Main", "uwu"))
+              Some(Api.MethodPointer(moduleName, "Main", "uwu"))
             )
           )
         )
@@ -925,7 +925,7 @@ class RuntimeServerTest
             Api.ExpressionValueUpdate(
               idMainA,
               Some("Text"),
-              Some(Api.MethodPointer(mainFile, "Main", "hie"))
+              Some(Api.MethodPointer(moduleName, "Main", "hie"))
             )
           )
         )
@@ -992,7 +992,7 @@ class RuntimeServerTest
           contextId,
           Api.StackItem
             .ExplicitCall(
-              Api.MethodPointer(fooFile, "Foo", "main"),
+              Api.MethodPointer("Test.Foo", "Foo", "main"),
               None,
               Vector()
             )
@@ -1080,7 +1080,7 @@ class RuntimeServerTest
           contextId,
           Api.StackItem
             .ExplicitCall(
-              Api.MethodPointer(fooFile, "Foo", "main"),
+              Api.MethodPointer("Test.Foo", "Foo", "main"),
               None,
               Vector()
             )
@@ -1168,7 +1168,7 @@ class RuntimeServerTest
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )
@@ -1329,7 +1329,7 @@ class RuntimeServerTest
           contextId,
           Api.StackItem
             .ExplicitCall(
-              Api.MethodPointer(fooFile, "Foo", "main"),
+              Api.MethodPointer("Test.Foo", "Foo", "main"),
               None,
               Vector()
             )
@@ -1405,7 +1405,7 @@ class RuntimeServerTest
   }
 
   it should "recompute expressions without invalidation" in {
-    val mainFile  = context.writeMain(context.Main.code)
+    context.writeMain(context.Main.code)
     val contextId = UUID.randomUUID()
     val requestId = UUID.randomUUID()
 
@@ -1417,7 +1417,7 @@ class RuntimeServerTest
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )
@@ -1441,7 +1441,7 @@ class RuntimeServerTest
   }
 
   it should "recompute expressions invalidating all" in {
-    val mainFile  = context.writeMain(context.Main.code)
+    context.writeMain(context.Main.code)
     val contextId = UUID.randomUUID()
     val requestId = UUID.randomUUID()
 
@@ -1453,7 +1453,7 @@ class RuntimeServerTest
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )
@@ -1483,7 +1483,7 @@ class RuntimeServerTest
   }
 
   it should "recompute expressions invalidating some" in {
-    val mainFile  = context.writeMain(context.Main.code)
+    context.writeMain(context.Main.code)
     val contextId = UUID.randomUUID()
     val requestId = UUID.randomUUID()
 
@@ -1495,7 +1495,7 @@ class RuntimeServerTest
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )
@@ -1527,7 +1527,7 @@ class RuntimeServerTest
   }
 
   it should "return error when computing erroneous code" in {
-    val mainFile  = context.writeMain(context.MainWithError.code)
+    context.writeMain(context.MainWithError.code)
     val contextId = UUID.randomUUID()
     val requestId = UUID.randomUUID()
 
@@ -1539,7 +1539,7 @@ class RuntimeServerTest
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )
@@ -1562,7 +1562,7 @@ class RuntimeServerTest
   }
 
   it should "skip side effects when evaluating cached expression" in {
-    val file      = context.writeMain(context.Main2.code)
+    context.writeMain(context.Main2.code)
     val contextId = UUID.randomUUID()
     val requestId = UUID.randomUUID()
 
@@ -1574,7 +1574,7 @@ class RuntimeServerTest
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(file, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )
@@ -1601,7 +1601,7 @@ class RuntimeServerTest
   }
 
   it should "emit visualisation update when expression is evaluated" in {
-    val mainFile = context.writeMain(context.Main.code)
+    context.writeMain(context.Main.code)
     val visualisationFile =
       context.writeInSrcDir("Visualisation", context.Visualisation.code)
 
@@ -1627,7 +1627,7 @@ class RuntimeServerTest
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )
@@ -1752,7 +1752,7 @@ class RuntimeServerTest
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer(moduleName, "Main", "main"),
       None,
       Vector()
     )
@@ -1918,7 +1918,7 @@ class RuntimeServerTest
   }
 
   it should "be able to modify visualisations" in {
-    val mainFile = context.writeMain(context.Main.code)
+    context.writeMain(context.Main.code)
     val visualisationFile =
       context.writeInSrcDir("Visualisation", context.Visualisation.code)
 
@@ -1944,7 +1944,7 @@ class RuntimeServerTest
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )
@@ -2031,7 +2031,7 @@ class RuntimeServerTest
   }
 
   it should "not emit visualisation updates when visualisation is detached" in {
-    val mainFile = context.writeMain(context.Main.code)
+    context.writeMain(context.Main.code)
     val visualisationFile =
       context.writeInSrcDir("Visualisation", context.Visualisation.code)
 
@@ -2075,7 +2075,7 @@ class RuntimeServerTest
     )
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )
@@ -2130,7 +2130,7 @@ class RuntimeServerTest
   }
 
   it should "rename a project" in {
-    val mainFile  = context.writeMain(context.Main.code)
+    context.writeMain(context.Main.code)
     val contextId = UUID.randomUUID()
     val requestId = UUID.randomUUID()
 
@@ -2142,7 +2142,7 @@ class RuntimeServerTest
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
-      Api.MethodPointer(mainFile, "Main", "main"),
+      Api.MethodPointer("Test.Main", "Main", "main"),
       None,
       Vector()
     )

--- a/lib/scala/searcher/src/bench/java/org/enso/searcher/sql/SuggestionsRepoBenchmark.java
+++ b/lib/scala/searcher/src/bench/java/org/enso/searcher/sql/SuggestionsRepoBenchmark.java
@@ -32,7 +32,6 @@ public class SuggestionsRepoBenchmark {
   final Path dbfile = Path.of(System.getProperty("java.io.tmpdir"), "bench-suggestions.db");
   final Seq<Suggestion.Kind> kinds = SuggestionRandom.nextKinds();
   final Seq<scala.Tuple2<UUID, String>> updateInput = SuggestionRandom.nextUpdateAllInput();
-  final Seq<UUID> getAllByExternalIdsInput = SuggestionRandom.nextGetAllByExternalIdsInput();
   final Seq<scala.Tuple3<String, String, String>> getAllMethodsInput =
       SuggestionRandom.nextGetAllMethodsInput();
 
@@ -103,11 +102,6 @@ public class SuggestionsRepoBenchmark {
             scala.Some.apply(kinds),
             none()),
         TIMEOUT);
-  }
-
-  @Benchmark
-  public Object getAllByExternalIds() throws TimeoutException, InterruptedException {
-    return Await.result(repo.getAllByExternalIds(getAllByExternalIdsInput), TIMEOUT);
   }
 
   @Benchmark

--- a/lib/scala/searcher/src/bench/java/org/enso/searcher/sql/SuggestionsRepoBenchmark.java
+++ b/lib/scala/searcher/src/bench/java/org/enso/searcher/sql/SuggestionsRepoBenchmark.java
@@ -32,7 +32,9 @@ public class SuggestionsRepoBenchmark {
   final Path dbfile = Path.of(System.getProperty("java.io.tmpdir"), "bench-suggestions.db");
   final Seq<Suggestion.Kind> kinds = SuggestionRandom.nextKinds();
   final Seq<scala.Tuple2<UUID, String>> updateInput = SuggestionRandom.nextUpdateAllInput();
-  final Seq<UUID> getAllByExternalIdsInput = SuggestionRandom.nextGetByExternalIdsInput();
+  final Seq<UUID> getAllByExternalIdsInput = SuggestionRandom.nextGetAllByExternalIdsInput();
+  final Seq<scala.Tuple3<String, String, String>> getAllMethodsInput =
+      SuggestionRandom.nextGetAllMethodsInput();
 
   SqlSuggestionsRepo repo;
 
@@ -104,8 +106,13 @@ public class SuggestionsRepoBenchmark {
   }
 
   @Benchmark
-  public Object searchByExternalIds() throws TimeoutException, InterruptedException {
+  public Object getAllByExternalIds() throws TimeoutException, InterruptedException {
     return Await.result(repo.getAllByExternalIds(getAllByExternalIdsInput), TIMEOUT);
+  }
+
+  @Benchmark
+  public Object getAllMethods() throws TimeoutException, InterruptedException {
+    return Await.result(repo.getAllMethods(getAllMethodsInput), TIMEOUT);
   }
 
   @Benchmark

--- a/lib/scala/searcher/src/bench/scala/org/enso/searcher/sql/SuggestionRandom.scala
+++ b/lib/scala/searcher/src/bench/scala/org/enso/searcher/sql/SuggestionRandom.scala
@@ -11,8 +11,14 @@ object SuggestionRandom {
   def nextUpdateAllInput(): Seq[(UUID, String)] =
     Seq(UUID.randomUUID() -> nextString())
 
-  def nextGetByExternalIdsInput(): Seq[UUID] =
+  def nextGetAllByExternalIdsInput(): Seq[UUID] =
     Seq(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())
+
+  def nextGetAllMethodsInput(): Seq[(String, String, String)] =
+    Seq(
+      (nextString(), nextString(), nextString()),
+      (nextString(), nextString(), nextString())
+    )
 
   def nextKinds(): Seq[Suggestion.Kind] =
     Set.fill(1)(nextKind()).toSeq

--- a/lib/scala/searcher/src/bench/scala/org/enso/searcher/sql/SuggestionRandom.scala
+++ b/lib/scala/searcher/src/bench/scala/org/enso/searcher/sql/SuggestionRandom.scala
@@ -11,9 +11,6 @@ object SuggestionRandom {
   def nextUpdateAllInput(): Seq[(UUID, String)] =
     Seq(UUID.randomUUID() -> nextString())
 
-  def nextGetAllByExternalIdsInput(): Seq[UUID] =
-    Seq(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())
-
   def nextGetAllMethodsInput(): Seq[(String, String, String)] =
     Seq(
       (nextString(), nextString(), nextString()),

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/SuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/SuggestionsRepo.scala
@@ -21,6 +21,13 @@ trait SuggestionsRepo[F[_]] {
     */
   def getAllByExternalIds(ids: Seq[Suggestion.ExternalId]): F[Seq[Option[Long]]]
 
+  /** Get suggestions by the method call info.
+    *
+    * @param calls the list of triples: module, self type and method name
+    * @return the list of found suggestion ids
+    */
+  def getAllMethods(calls: Seq[(String, String, String)]): F[Seq[Option[Long]]]
+
   /** Search suggestion by various parameters.
     *
     * @param module the module name search parameter

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/SuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/SuggestionsRepo.scala
@@ -14,13 +14,6 @@ trait SuggestionsRepo[F[_]] {
     */
   def getAll: F[(Long, Seq[SuggestionEntry])]
 
-  /** Get suggestions by external ids.
-    *
-    * @param ids the list of external ids
-    * @return the list of found suggestion ids
-    */
-  def getAllByExternalIds(ids: Seq[Suggestion.ExternalId]): F[Seq[Option[Long]]]
-
   /** Get suggestions by the method call info.
     *
     * @param calls the list of triples: module, self type and method name

--- a/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
+++ b/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
@@ -63,42 +63,6 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
       )
     }
 
-    "get suggestions by external ids" taggedAs Retry in withRepo { repo =>
-      val action = for {
-        (_, ids) <- repo.insertAll(
-          Seq(
-            suggestion.atom,
-            suggestion.method,
-            suggestion.function,
-            suggestion.local
-          )
-        )
-        results <- repo.getAllByExternalIds(
-          Seq(suggestion.method.externalId.get, suggestion.local.externalId.get)
-        )
-      } yield (ids, results)
-
-      val (ids, results) = Await.result(action, Timeout)
-      results should contain theSameElementsInOrderAs Seq(ids(1), ids(3))
-    }
-
-    "get suggestions by empty external ids" taggedAs Retry in withRepo { repo =>
-      val action = for {
-        _ <- repo.insertAll(
-          Seq(
-            suggestion.atom,
-            suggestion.method,
-            suggestion.function,
-            suggestion.local
-          )
-        )
-        results <- repo.getAllByExternalIds(Seq())
-      } yield results
-
-      val results = Await.result(action, Timeout)
-      results.isEmpty shouldEqual true
-    }
-
     "get suggestions by method call info" taggedAs Retry in withRepo { repo =>
       val action = for {
         (_, ids) <- repo.insertAll(


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1009 

PR reverts the API to the previous state (back with the type and method pointer info), changing the `methodPointer` field to contain the `SuggestionId` as it was requested in the issue description.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

Language Server API has changed.

```typescript
type SuggestionId = number;

interface ExpressionValueUpdate {
  /** The id of updated expression */
  expressionId: ExpressionId;

  /** The updated type of the expression */
  type?: String;

  /** The updated pointer to the method call */
  methodPointer?: SuggestionId;
}

interface MethodPointer {
  /** The fully qualified module name. */
  module: String;
  
  /** The type on which the method is defined. */
  definedOnType: String;
  
  /** The method name. */
  name: String;
}
```

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
