### PR TITLE
Send Method Call Updates After Popping the Frame

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
@@ -222,6 +222,7 @@ public class IdExecutionInstrument extends TruffleInstrument {
     private final Consumer<ExpressionValue> onComputedCallback;
     private final Consumer<ExpressionValue> onCachedCallback;
     private final RuntimeCache cache;
+    private final MethodCallsCache callsCache;
     private final UUID nextExecutionItem;
     private final Map<UUID, FunctionCallInfo> calls = new HashMap<>();
 
@@ -238,12 +239,14 @@ public class IdExecutionInstrument extends TruffleInstrument {
     public IdExecutionEventListener(
         CallTarget entryCallTarget,
         RuntimeCache cache,
+        MethodCallsCache methodCallsCache,
         UUID nextExecutionItem,
         Consumer<ExpressionCall> functionCallCallback,
         Consumer<ExpressionValue> onComputedCallback,
         Consumer<ExpressionValue> onCachedCallback) {
       this.entryCallTarget = entryCallTarget;
       this.cache = cache;
+      this.callsCache = methodCallsCache;
       this.nextExecutionItem = nextExecutionItem;
       this.functionCallCallback = functionCallCallback;
       this.onComputedCallback = onComputedCallback;
@@ -314,6 +317,7 @@ public class IdExecutionInstrument extends TruffleInstrument {
         if (cachedResult != null) {
           throw context.createUnwind(cachedResult);
         }
+        callsCache.setExecuted(nodeId);
       } else if (node instanceof ExpressionNode) {
         UUID nodeId = ((ExpressionNode) node).getId();
         String resultType = Types.getName(result);
@@ -379,6 +383,7 @@ public class IdExecutionInstrument extends TruffleInstrument {
       int funSourceStart,
       int funSourceLength,
       RuntimeCache cache,
+      MethodCallsCache methodCallsCache,
       UUID nextExecutionItem,
       Consumer<ExpressionValue> onComputedCallback,
       Consumer<IdExecutionInstrument.ExpressionValue> onCachedCallback,
@@ -397,6 +402,7 @@ public class IdExecutionInstrument extends TruffleInstrument {
                 new IdExecutionEventListener(
                     entryCallTarget,
                     cache,
+                    methodCallsCache,
                     nextExecutionItem,
                     functionCallCallback,
                     onComputedCallback,

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
@@ -231,6 +231,7 @@ public class IdExecutionInstrument extends TruffleInstrument {
      *
      * @param entryCallTarget the call target being observed.
      * @param cache the precomputed expression values.
+     * @param methodCallsCache the storage tracking the executed method calls.
      * @param nextExecutionItem the next item scheduled for execution.
      * @param functionCallCallback the consumer of function call events.
      * @param onComputedCallback the consumer of the computed value events.
@@ -372,6 +373,7 @@ public class IdExecutionInstrument extends TruffleInstrument {
    * @param funSourceStart the source start of the observed range of ids.
    * @param funSourceLength the length of the observed source range.
    * @param cache the precomputed expression values.
+   * @param methodCallsCache the storage tracking the executed method calls.
    * @param nextExecutionItem the next item scheduled for execution.
    * @param onComputedCallback the consumer of the computed value events.
    * @param onCachedCallback the consumer of the cached value events.

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/MethodCallsCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/MethodCallsCache.java
@@ -1,0 +1,25 @@
+package org.enso.interpreter.instrument;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * A storage for computed method calls. Method calls cache is not preserved between the program
+ * invocations.
+ */
+public class MethodCallsCache {
+
+  private final Set<UUID> callsExecuted = new HashSet<>();
+
+  public void setExecuted(UUID call) {
+    callsExecuted.add(call);
+  }
+
+  public Set<UUID> getNotExecuted(Collection<UUID> calls) {
+    HashSet<UUID> cached = new HashSet<>(calls);
+    cached.removeAll(callsExecuted);
+    return cached;
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/MethodCallsCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/MethodCallsCache.java
@@ -6,17 +6,26 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * A storage for computed method calls. Method calls cache is not preserved between the program
- * invocations.
+ * A storage for executed methods.
+ *
+ * <p>Tracks the encountered method calls during the invocation of the stack frame. Method calls
+ * cache is not preserved between the program invocations.
  */
-public class MethodCallsCache {
+public final class MethodCallsCache {
 
   private final Set<UUID> callsExecuted = new HashSet<>();
 
+  /** Save the executed method call. */
   public void setExecuted(UUID call) {
     callsExecuted.add(call);
   }
 
+  /**
+   * Get the subset of method calls that were not executed.
+   *
+   * @param calls the collection of all calls.
+   * @return the set of calls that were not executed.
+   */
   public Set<UUID> getNotExecuted(Collection<UUID> calls) {
     HashSet<UUID> cached = new HashSet<>(calls);
     cached.removeAll(callsExecuted);

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
@@ -4,7 +4,7 @@ import java.lang.ref.SoftReference;
 import java.util.*;
 
 /** A storage for computed values. */
-public class RuntimeCache {
+public final class RuntimeCache {
 
   private final Map<UUID, SoftReference<Object>> cache = new HashMap<>();
   private final Map<UUID, String> types = new HashMap<>();

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/RuntimeCache.java
@@ -1,10 +1,7 @@
 package org.enso.interpreter.instrument;
 
 import java.lang.ref.SoftReference;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 /** A storage for computed values. */
 public class RuntimeCache {
@@ -81,6 +78,11 @@ public class RuntimeCache {
   /** @return the cached function call associated with the expression. */
   public IdExecutionInstrument.FunctionCallInfo getCall(UUID key) {
     return calls.get(key);
+  }
+
+  /** @return the cached method calls. */
+  public Set<UUID> getCalls() {
+    return calls.keySet();
   }
 
   /** Clear the cached calls. */

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -84,6 +84,7 @@ public class ExecutionService {
    *
    * @param call the call metadata.
    * @param cache the precomputed expression values.
+   * @param methodCallsCache the storage tracking the executed method calls.
    * @param nextExecutionItem the next item scheduled for execution.
    * @param onComputedCallback the consumer of the computed value events.
    * @param onCachedCallback the consumer of the cached value events.
@@ -126,6 +127,7 @@ public class ExecutionService {
    * @param consName the name of the constructor the method is defined on.
    * @param methodName the method name.
    * @param cache the precomputed expression values.
+   * @param methodCallsCache the storage tracking the executed method calls.
    * @param nextExecutionItem the next item scheduled for execution.
    * @param onComputedCallback the consumer of the computed value events.
    * @param onCachedCallback the consumer of the cached value events.

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -7,6 +7,7 @@ import com.oracle.truffle.api.interop.*;
 import com.oracle.truffle.api.source.SourceSection;
 import org.enso.compiler.context.Changeset;
 import org.enso.interpreter.instrument.IdExecutionInstrument;
+import org.enso.interpreter.instrument.MethodCallsCache;
 import org.enso.interpreter.instrument.RuntimeCache;
 import org.enso.interpreter.node.callable.FunctionCallInstrumentationNode;
 import org.enso.interpreter.runtime.Context;
@@ -91,6 +92,7 @@ public class ExecutionService {
   public void execute(
       FunctionCallInstrumentationNode.FunctionCall call,
       RuntimeCache cache,
+      MethodCallsCache methodCallsCache,
       UUID nextExecutionItem,
       Consumer<IdExecutionInstrument.ExpressionValue> onComputedCallback,
       Consumer<IdExecutionInstrument.ExpressionValue> onCachedCallback,
@@ -107,6 +109,7 @@ public class ExecutionService {
             src.getCharIndex(),
             src.getCharLength(),
             cache,
+            methodCallsCache,
             nextExecutionItem,
             onComputedCallback,
             onCachedCallback,
@@ -133,6 +136,7 @@ public class ExecutionService {
       String consName,
       String methodName,
       RuntimeCache cache,
+      MethodCallsCache methodCallsCache,
       UUID nextExecutionItem,
       Consumer<IdExecutionInstrument.ExpressionValue> onComputedCallback,
       Consumer<IdExecutionInstrument.ExpressionValue> onCachedCallback,
@@ -148,6 +152,7 @@ public class ExecutionService {
     execute(
         callMay.get(),
         cache,
+        methodCallsCache,
         nextExecutionItem,
         onComputedCallback,
         onCachedCallback,

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
@@ -18,8 +18,8 @@ class EditFileCmd(request: Api.EditFileNotification) extends Command(None) {
     *
     * @param ctx contains suppliers of services to perform a request
     */
-  override def execute(
-    implicit ctx: RuntimeContext,
+  override def execute(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {
     for {
@@ -31,15 +31,15 @@ class EditFileCmd(request: Api.EditFileNotification) extends Command(None) {
     } yield ()
   }
 
-  private def executeJobs(
-    implicit ctx: RuntimeContext
+  private def executeJobs(implicit
+    ctx: RuntimeContext
   ): Iterable[ExecuteJob] = {
     ctx.contextManager.getAll
       .filter(kv => kv._2.nonEmpty)
       .mapValues(_.toList)
       .map {
         case (contextId, stack) =>
-          new ExecuteJob(contextId, stack, Seq())
+          new ExecuteJob(contextId, stack, Seq(), sendMethodCallUpdates = false)
       }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/PopContextCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/PopContextCmd.scala
@@ -18,9 +18,9 @@ class PopContextCmd(
   request: Api.PopContextRequest
 ) extends Command(maybeRequestId) {
 
-  /** @inheritdoc **/
-  override def execute(
-    implicit ctx: RuntimeContext,
+  /** @inheritdoc * */
+  override def execute(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =
     if (doesContextExist) {
@@ -29,8 +29,8 @@ class PopContextCmd(
       replyWithContextNotExistError()
     }
 
-  private def replyWithContextNotExistError()(
-    implicit ctx: RuntimeContext,
+  private def replyWithContextNotExistError()(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {
     Future {
@@ -38,8 +38,8 @@ class PopContextCmd(
     }
   }
 
-  private def popItemFromStack()(
-    implicit ctx: RuntimeContext,
+  private def popItemFromStack()(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =
     Future {
@@ -56,13 +56,19 @@ class PopContextCmd(
     ctx.contextManager.contains(request.contextId)
   }
 
-  private def scheduleExecutionIfNeeded()(
-    implicit ctx: RuntimeContext,
+  private def scheduleExecutionIfNeeded()(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {
     val stack = ctx.contextManager.getStack(request.contextId)
     if (stack.nonEmpty) {
-      val executable = Executable(request.contextId, stack, Seq())
+      val executable =
+        Executable(
+          request.contextId,
+          stack,
+          Seq(),
+          sendMethodCallUpdates = true
+        )
       for {
         _ <- ctx.jobProcessor.run(new EnsureCompiledStackJob(executable.stack))
         _ <- ctx.jobProcessor.run(new ExecuteJob(executable))

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/PopContextCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/PopContextCmd.scala
@@ -18,7 +18,7 @@ class PopContextCmd(
   request: Api.PopContextRequest
 ) extends Command(maybeRequestId) {
 
-  /** @inheritdoc * */
+  /** @inheritdoc */
   override def execute(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
@@ -18,7 +18,7 @@ class PushContextCmd(
   request: Api.PushContextRequest
 ) extends Command(maybeRequestId) {
 
-  /** @inheritdoc * */
+  /** @inheritdoc */
   override def execute(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
@@ -18,9 +18,9 @@ class PushContextCmd(
   request: Api.PushContextRequest
 ) extends Command(maybeRequestId) {
 
-  /** @inheritdoc **/
-  override def execute(
-    implicit ctx: RuntimeContext,
+  /** @inheritdoc * */
+  override def execute(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =
     if (doesContextExist) {
@@ -33,8 +33,8 @@ class PushContextCmd(
     ctx.contextManager.contains(request.contextId)
   }
 
-  private def replyWithContextNotExistError()(
-    implicit ctx: RuntimeContext,
+  private def replyWithContextNotExistError()(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {
     Future {
@@ -42,8 +42,8 @@ class PushContextCmd(
     }
   }
 
-  private def pushItemOntoStack()(
-    implicit ctx: RuntimeContext,
+  private def pushItemOntoStack()(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Boolean] =
     Future {
@@ -69,13 +69,18 @@ class PushContextCmd(
       pushed
     }
 
-  private def scheduleExecutionIfNeeded(pushed: Boolean)(
-    implicit ctx: RuntimeContext,
+  private def scheduleExecutionIfNeeded(pushed: Boolean)(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {
     if (pushed) {
-      val stack      = ctx.contextManager.getStack(request.contextId)
-      val executable = Executable(request.contextId, stack, Seq())
+      val stack = ctx.contextManager.getStack(request.contextId)
+      val executable = Executable(
+        request.contextId,
+        stack,
+        Seq(),
+        sendMethodCallUpdates = false
+      )
       for {
         _ <- ctx.jobProcessor.run(new EnsureCompiledStackJob(executable.stack))
         _ <- ctx.jobProcessor.run(new ExecuteJob(executable))

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
@@ -19,9 +19,9 @@ class RecomputeContextCmd(
   request: Api.RecomputeContextRequest
 ) extends Command(maybeRequestId) {
 
-  /** @inheritdoc **/
-  override def execute(
-    implicit ctx: RuntimeContext,
+  /** @inheritdoc * */
+  override def execute(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =
     if (doesContextExist) {
@@ -30,8 +30,8 @@ class RecomputeContextCmd(
       replyWithContextNotExistError()
     }
 
-  private def invalidateCache()(
-    implicit ctx: RuntimeContext,
+  private def invalidateCache()(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Boolean] = {
     Future {
@@ -55,21 +55,26 @@ class RecomputeContextCmd(
     ctx.contextManager.contains(request.contextId)
   }
 
-  private def replyWithContextNotExistError()(
-    implicit ctx: RuntimeContext,
+  private def replyWithContextNotExistError()(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =
     Future {
       reply(Api.ContextNotExistError(request.contextId))
     }
 
-  private def scheduleExecutionIfNeeded(isStackNonEmpty: Boolean)(
-    implicit ctx: RuntimeContext,
+  private def scheduleExecutionIfNeeded(isStackNonEmpty: Boolean)(implicit
+    ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {
     if (isStackNonEmpty) {
-      val stack      = ctx.contextManager.getStack(request.contextId)
-      val executable = Executable(request.contextId, stack, Seq())
+      val stack = ctx.contextManager.getStack(request.contextId)
+      val executable = Executable(
+        request.contextId,
+        stack,
+        Seq(),
+        sendMethodCallUpdates = false
+      )
       for {
         _ <- ctx.jobProcessor.run(new EnsureCompiledStackJob(executable.stack))
         _ <- ctx.jobProcessor.run(new ExecuteJob(executable))

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
@@ -19,7 +19,7 @@ class RecomputeContextCmd(
   request: Api.RecomputeContextRequest
 ) extends Command(maybeRequestId) {
 
-  /** @inheritdoc * */
+  /** @inheritdoc */
   override def execute(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/Executable.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/Executable.scala
@@ -11,9 +11,12 @@ import scala.collection.mutable
   * @param contextId an identifier of a context to execute
   * @param stack a call stack that must be executed
   * @param updatedVisualisations a list of updated visualisations
+  * @param sendMethodCallUpdates a flag to send the method calls of the
+  * executed frame as a value updates
   */
 case class Executable(
   contextId: Api.ContextId,
   stack: mutable.Stack[InstrumentFrame],
-  updatedVisualisations: Seq[Api.ExpressionId]
+  updatedVisualisations: Seq[Api.ExpressionId],
+  sendMethodCallUpdates: Boolean
 )

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/Executable.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/Executable.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable
   * @param contextId an identifier of a context to execute
   * @param stack a call stack that must be executed
   * @param updatedVisualisations a list of updated visualisations
-  * @param sendMethodCallUpdates a flag to send the method calls of the
+  * @param sendMethodCallUpdates a flag to send all the method calls of the
   * executed frame as a value updates
   */
 case class Executable(

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
@@ -12,7 +12,7 @@ import org.enso.polyglot.runtime.Runtime.Api
   * @param contextId an identifier of a context to execute
   * @param stack a call stack to execute
   * @param updatedVisualisations a list of updated visualisations
-  * @param sendMethodCallUpdates a flag to send the method calls of the
+  * @param sendMethodCallUpdates a flag to send all the method calls of the
   * executed frame as a value updates
   */
 class ExecuteJob(

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
@@ -31,7 +31,7 @@ class ExecuteJob(
       exe.sendMethodCallUpdates
     )
 
-  /** @inheritdoc * */
+  /** @inheritdoc */
   override def run(implicit ctx: RuntimeContext): Unit = {
     ctx.locking.acquireContextLock(contextId)
     ctx.locking.acquireReadCompilationLock()

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
@@ -12,24 +12,38 @@ import org.enso.polyglot.runtime.Runtime.Api
   * @param contextId an identifier of a context to execute
   * @param stack a call stack to execute
   * @param updatedVisualisations a list of updated visualisations
+  * @param sendMethodCallUpdates a flag to send the method calls of the
+  * executed frame as a value updates
   */
 class ExecuteJob(
   contextId: UUID,
   stack: List[InstrumentFrame],
-  updatedVisualisations: Seq[UUID]
+  updatedVisualisations: Seq[UUID],
+  sendMethodCallUpdates: Boolean
 ) extends Job[Unit](List(contextId), true, true)
     with ProgramExecutionSupport {
 
   def this(exe: Executable) =
-    this(exe.contextId, exe.stack.toList, exe.updatedVisualisations)
+    this(
+      exe.contextId,
+      exe.stack.toList,
+      exe.updatedVisualisations,
+      exe.sendMethodCallUpdates
+    )
 
-  /** @inheritdoc **/
+  /** @inheritdoc * */
   override def run(implicit ctx: RuntimeContext): Unit = {
     ctx.locking.acquireContextLock(contextId)
     ctx.locking.acquireReadCompilationLock()
     ctx.executionService.getContext.getThreadManager.enter()
     try {
-      val errorOrOk = runProgram(contextId, stack, updatedVisualisations)
+      val errorOrOk =
+        runProgram(
+          contextId,
+          stack,
+          updatedVisualisations,
+          sendMethodCallUpdates
+        )
       errorOrOk match {
         case Left(e) =>
           ctx.endpoint.sendToClient(

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -122,7 +122,7 @@ trait ProgramExecutionSupport {
     * @param contextId an identifier of an execution context
     * @param stack a call stack
     * @param updatedVisualisations a list of updated visualisations
-    * @param sendMethodCallUpdates a flag to send the method calls of the
+    * @param sendMethodCallUpdates a flag to send all the method calls of the
     * executed frame as a value updates
     * @param ctx a runtime context
     * @return either an error message or Unit signaling completion of a program

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -36,6 +36,7 @@ trait ProgramExecutionSupport {
     *
     * @param executionFrame an execution frame
     * @param callStack a call stack
+    * @param cachedMethodCallsCallback a listener for cached method calls
     * @param onComputedCallback a listener of computed values
     * @param onCachedCallback a listener of cached values
     */
@@ -85,23 +86,19 @@ trait ProgramExecutionSupport {
 
     callStack match {
       case Nil =>
-        //import scala.jdk.CollectionConverters._
-//        println("CACHED_CALLS")
-//        executionFrame.cache.getCalls.forEach { callId =>
-//          println(s"$callId -> ${executionFrame.cache.getCall(callId)}")
-//        }
         methodCallsCache
           .getNotExecuted(executionFrame.cache.getCalls)
           .forEach { expressionId =>
-            val value = new ExpressionValue(
-              expressionId,
-              null,
-              executionFrame.cache.getType(expressionId),
-              null,
-              executionFrame.cache.getCall(expressionId),
-              null
+            cachedMethodCallsCallback.accept(
+              new ExpressionValue(
+                expressionId,
+                null,
+                executionFrame.cache.getType(expressionId),
+                null,
+                executionFrame.cache.getCall(expressionId),
+                null
+              )
             )
-            cachedMethodCallsCallback.accept(value)
           }
       case item :: tail =>
         enterables.get(item.expressionId) match {

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualisationJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualisationJob.scala
@@ -38,7 +38,7 @@ class UpsertVisualisationJob(
       false
     ) {
 
-  /** @inheritdoc * */
+  /** @inheritdoc */
   override def run(implicit ctx: RuntimeContext): Option[Executable] = {
     ctx.locking.acquireContextLock(config.executionContextId)
     ctx.locking.acquireWriteCompilationLock()

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualisationJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualisationJob.scala
@@ -38,7 +38,7 @@ class UpsertVisualisationJob(
       false
     ) {
 
-  /** @inheritdoc **/
+  /** @inheritdoc * */
   override def run(implicit ctx: RuntimeContext): Option[Executable] = {
     ctx.locking.acquireContextLock(config.executionContextId)
     ctx.locking.acquireWriteCompilationLock()
@@ -59,8 +59,12 @@ class UpsertVisualisationJob(
           updateVisualisation(callable)
           ctx.endpoint.sendToClient(Api.Response(requestId, response))
           val stack = ctx.contextManager.getStack(config.executionContextId)
-          val exe =
-            Executable(config.executionContextId, stack, Seq(expressionId))
+          val exe = Executable(
+            config.executionContextId,
+            stack,
+            Seq(expressionId),
+            sendMethodCallUpdates = false
+          )
           Some(exe)
       }
     } finally {
@@ -95,8 +99,8 @@ class UpsertVisualisationJob(
     )
   }
 
-  private def replyWithModuleNotFoundError()(
-    implicit ctx: RuntimeContext
+  private def replyWithModuleNotFoundError()(implicit
+    ctx: RuntimeContext
   ): Unit = {
     ctx.endpoint.sendToClient(
       Api.Response(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -349,8 +349,20 @@ class RuntimeServerTest
 
     // pop foo call
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
-    context.receive(2) should contain theSameElementsAs Seq(
-      Api.Response(requestId, Api.PopContextResponse(contextId))
+    context.receive(3) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PopContextResponse(contextId)),
+      Api.Response(
+        Api.ExpressionValuesComputed(
+          contextId,
+          Vector(
+            Api.ExpressionValueUpdate(
+              context.Main.idMainY,
+              None,
+              Some(Api.MethodPointer("Test.Main", "Number", "foo"))
+            )
+          )
+        )
+      )
     )
 
     // pop main
@@ -633,8 +645,20 @@ class RuntimeServerTest
 
     // pop foo call
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
-    context.receive(2) should contain theSameElementsAs Seq(
-      Api.Response(requestId, Api.PopContextResponse(contextId))
+    context.receive(3) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PopContextResponse(contextId)),
+      Api.Response(
+        Api.ExpressionValuesComputed(
+          contextId,
+          Vector(
+            Api.ExpressionValueUpdate(
+              context.Main.idMainY,
+              None,
+              Some(Api.MethodPointer("Test.Main", "Number", "foo"))
+            )
+          )
+        )
+      )
     )
 
     // pop main
@@ -1278,8 +1302,20 @@ class RuntimeServerTest
 
     // pop foo call
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
-    context.receive(2) should contain theSameElementsAs Seq(
-      Api.Response(requestId, Api.PopContextResponse(contextId))
+    context.receive(3) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PopContextResponse(contextId)),
+      Api.Response(
+        Api.ExpressionValuesComputed(
+          contextId,
+          Vector(
+            Api.ExpressionValueUpdate(
+              context.Main.idMainY,
+              None,
+              Some(Api.MethodPointer("Test.Main", "Number", "foo"))
+            )
+          )
+        )
+      )
     )
 
     // pop main


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1029 

The difficulty with sending all the method pointer updates is that some values can be cached, and we don't want to re-execute them. And some values can be invalidated, executed, and send to the user as a value update, and we don't want to re-send them.

PR introduces the `MetodCallsCache` created per frame execution, meaning that it is not persisted in between the runs. The cache tracks which calls have been fired during the program execution (and sent as a notification to the user). When the program finishes, we compute the set of calls that have not been executed and send them to the user as well.

- add: `MethodCallsCache` temporary storage tracking the executed method calls
- add: `sendMethodCallUpdates` flag enabling sending all the method calls of the frame as a value updates

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
