### PR TITLE
Remove Duplicate Suggestion Entry Id in Doc

### DIFF
--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -169,10 +169,6 @@ An identifier used for execution contexts.
 type ContextId = UUID;
 ```
 
-```typescript
-type SuggestionEntryId = number;
-```
-
 ### `StackItem`
 
 A representation of an executable position in code, used by the execution APIs.
@@ -2757,7 +2753,7 @@ Sent from client to the server to receive the autocomplete suggestion.
 
 ```typescript
 {
-  results: [SuggestionEntryId];
+  results: [SuggestionId];
   currentVersion: number;
 }
 ```


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Remove duplicate `SuggestionEntryId` type alias from the Language Server docs.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
