### PR TITLE
Information about visualization directory in package structure

### DIFF
--- a/docs/distribution/packaging.md
+++ b/docs/distribution/packaging.md
@@ -19,6 +19,7 @@ future directions and enhancements to it.
   - [The `src` Directory](#the-src-directory)
   - [The `polyglot` Directory](#the-polyglot-directory)
   - [The `package.yaml` File](#the-packageyaml-file)
+  - [The `visualization` Directory](#the-visualization-directory)
 - [Build Reproducibility](#build-reproducibility)
 
 <!-- /MarkdownTOC -->
@@ -35,11 +36,13 @@ My_Package
 │   │   └── jar.jar
 │   └── js
 │       └── library.js
-└── src
-    ├── Main.enso
-    └── Sub_Module
-        ├── Helper.enso
-        └── Util.enso
+├── src
+│   ├── Main.enso
+│   └── Sub_Module
+│       ├── Helper.enso
+│       └── Util.enso
+└── visualization (optional)
+    └── 
 ```
 
 ### The `src` Directory
@@ -161,12 +164,14 @@ version: <semver string of the required library version>
 
 ### The `visualization` Directory
 
-As Enso is a visual language, a package may contain a specification of how 
-data can be displayed in various tools, for example [Enso IDE](https://github.com/enso-org/ide). 
-The Enso package structure may optionally contain a `visualization` directory
-which may contain visualization definitions.
+As Enso is a visual language, a package may contain a specification of how data
+can be displayed in various tools, for example
+[Enso IDE](https://github.com/enso-org/ide). The Enso package structure may
+optionally contain a `visualization` directory which may contain visualization
+definitions.
 
-For more information on how visualization definitions should work with the Enso IDE, see
+For more information on how visualization definitions should work with the Enso
+IDE, see
 [this example](https://dev.enso.org/docs/ide/product/visualizations.html#custom-visualization-example).
 
 ## Build Reproducibility

--- a/docs/distribution/packaging.md
+++ b/docs/distribution/packaging.md
@@ -159,6 +159,17 @@ version: <semver string of the required library version>
 >
 > - Extend the library version field to handle version bounds.
 
+### The `visualization` Directory
+
+As Enso is a visual language, the package may contain specification how 
+data can be displayed in various tools, e.g. 
+[Enso IDE](https://github.com/enso-org/ide). Conventionally, all those files
+should be put in the `visualization` directory, and from there all tools should
+read them.
+
+See also [this example](https://dev.enso.org/docs/ide/product/visualizations.html#custom-visualization-example) 
+of visualization file working with Enso IDE.   
+
 ## Build Reproducibility
 
 It is crucial for any good development environment to provide reproducible

--- a/docs/distribution/packaging.md
+++ b/docs/distribution/packaging.md
@@ -166,8 +166,8 @@ data can be displayed in various tools, for example [Enso IDE](https://github.co
 The Enso package structure may optionally contain a `visualization` directory
 which may contain visualization definitions.
 
-See also [this example](https://dev.enso.org/docs/ide/product/visualizations.html#custom-visualization-example) 
-of visualization file working with Enso IDE.   
+For more information on how visualization definitions should work with the Enso IDE, see
+[this example](https://dev.enso.org/docs/ide/product/visualizations.html#custom-visualization-example).
 
 ## Build Reproducibility
 

--- a/docs/distribution/packaging.md
+++ b/docs/distribution/packaging.md
@@ -161,11 +161,10 @@ version: <semver string of the required library version>
 
 ### The `visualization` Directory
 
-As Enso is a visual language, the package may contain specification how 
-data can be displayed in various tools, e.g. 
-[Enso IDE](https://github.com/enso-org/ide). Conventionally, all those files
-should be put in the `visualization` directory, and from there all tools should
-read them.
+As Enso is a visual language, a package may contain a specification of how 
+data can be displayed in various tools, for example [Enso IDE](https://github.com/enso-org/ide). 
+The Enso package structure may optionally contain a `visualization` directory
+which may contain visualization definitions.
 
 See also [this example](https://dev.enso.org/docs/ide/product/visualizations.html#custom-visualization-example) 
 of visualization file working with Enso IDE.   

--- a/docs/infrastructure/rust.md
+++ b/docs/infrastructure/rust.md
@@ -37,6 +37,6 @@ crate-type = ["cdylib"]
 Invoking `cargo build` will then output the library into `target/rust/debug`
 with the extension `.so` on Linux, `.dll` on Windows and `.dylib` on macOS.
 
-Then, to be able to load the library by `System.loadLibrary("lib_name")`,
-the Java application should be started with the option
+Then, to be able to load the library by `System.loadLibrary("lib_name")`, the
+Java application should be started with the option
 `-Djava.library.path=path/to/lib_folder`.


### PR DESCRIPTION
### Pull Request Description

Let's imagine the following situation: some Enso developers crafted it's own package and now thinks "I would put here some visualizations for my shiny types my library introduces. Where I should place them?". They look into package structure description in docs, but there is no such information.

This add a short note in the package structure description about _convention_ of embedding visualizations in Enso packages.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.