### PR TITLE
Add Log Level Options to Project Manager

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -548,6 +548,7 @@ lazy val `project-manager` = (project in file("lib/scala/project-manager"))
         "com.typesafe.scala-logging" %% "scala-logging"       % scalaLoggingVersion,
         "dev.zio"                    %% "zio"                 % zioVersion,
         "dev.zio"                    %% "zio-interop-cats"    % zioInteropCatsVersion,
+        "commons-cli"                 % "commons-cli"         % commonsCliVersion,
         "commons-io"                  % "commons-io"          % commonsIoVersion,
         "com.beachape"               %% "enumeratum-circe"    % enumeratumCirceVersion,
         "com.typesafe.slick"         %% "slick-hikaricp"      % slickVersion             % Runtime,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
@@ -1,0 +1,56 @@
+package org.enso.projectmanager.boot
+
+import org.apache.commons.cli
+import org.enso.polyglot.LanguageInfo
+
+import scala.util.Try
+
+object Cli {
+
+  val JSON_OPTION    = "json"
+  val HELP_OPTION    = "help"
+  val VERBOSE_OPTION = "verbose"
+  val VERSION_OPTION = "version"
+
+  object option {
+
+    val help: cli.Option = cli.Option
+      .builder("h")
+      .longOpt(HELP_OPTION)
+      .desc("Displays this message.")
+      .build()
+
+    val verbose: cli.Option = cli.Option
+      .builder("v")
+      .longOpt(VERBOSE_OPTION)
+      .desc("Increase logs verbosity.")
+      .build()
+
+    val version: cli.Option = cli.Option.builder
+      .longOpt(VERSION_OPTION)
+      .desc("Checks the version of the Enso executable.")
+      .build()
+
+    val json: cli.Option = cli.Option.builder
+      .longOpt(JSON_OPTION)
+      .desc("Switches the --version option to JSON output.")
+      .build()
+  }
+
+  val options: cli.Options =
+    new cli.Options()
+      .addOption(option.help)
+      .addOption(option.verbose)
+      .addOption(option.version)
+      .addOption(option.json)
+
+  /** Parse the command line options. */
+  def parse(args: Array[String]): Option[cli.CommandLine] = {
+    Try(new cli.DefaultParser().parse(options, args)).toOption
+  }
+
+  /** Print the help message to the standard output. */
+  def printHelp(): Unit =
+    new cli.HelpFormatter().printHelp(LanguageInfo.ID, options)
+
+}

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
@@ -45,8 +45,9 @@ object Cli {
       .addOption(option.json)
 
   /** Parse the command line options. */
-  def parse(args: Array[String]): Option[cli.CommandLine] = {
-    Try(new cli.DefaultParser().parse(options, args)).toOption
+  def parse(args: Array[String]): Either[String, cli.CommandLine] = {
+    Try(new cli.DefaultParser().parse(options, args)).toEither.left
+      .map(_.getMessage)
   }
 
   /** Print the help message to the standard output. */

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
@@ -23,7 +23,7 @@ object Cli {
     val verbose: cli.Option = cli.Option
       .builder("v")
       .longOpt(VERBOSE_OPTION)
-      .desc("Increase logs verbosity.")
+      .desc("Increase logs verbosity. Can be added multiple times (-vv)")
       .build()
 
     val version: cli.Option = cli.Option.builder

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
@@ -4,7 +4,6 @@ import java.io.IOException
 import java.util.concurrent.ScheduledThreadPoolExecutor
 
 import akka.http.scaladsl.Http
-import ch.qos.logback.classic.{Level, LoggerContext}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.cli.CommandLine
 import org.enso.projectmanager.boot.Globals.{
@@ -14,8 +13,8 @@ import org.enso.projectmanager.boot.Globals.{
   SuccessExitCode
 }
 import org.enso.projectmanager.boot.configuration.ProjectManagerConfig
+import org.enso.projectmanager.util.Logging
 import org.enso.version.VersionDescription
-import org.slf4j.LoggerFactory
 import pureconfig.ConfigSource
 import pureconfig.generic.auto._
 import zio.ZIO.effectTotal
@@ -25,7 +24,6 @@ import zio.interop.catz.core._
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
-import scala.util.control.NonFatal
 
 /**
   * Project manager runner containing the main method.
@@ -136,17 +134,15 @@ object ProjectManager extends App with LazyLogging {
     ZIO
       .effectTotal {
         val level = verbosityLevel match {
-          case 0 => Level.INFO
-          case 1 => Level.DEBUG
-          case _ => Level.TRACE
+          case 0 => Logging.LogLevel.Info
+          case 1 => Logging.LogLevel.Debug
+          case _ => Logging.LogLevel.Trace
         }
-        try {
-          val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
-          ctx.getLogger("org.enso").setLevel(level)
-          logger.info(s"Set log level $level")
-        } catch {
-          case NonFatal(ex) =>
-            logger.error(s"Failed to set log level $verbosityLevel", ex)
+        Logging.setLogLevel(level) match {
+          case Some(level) =>
+            logger.info(s"Set log level $level")
+          case None =>
+            logger.error(s"Failed to set log level $level")
         }
       }
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
@@ -4,7 +4,9 @@ import java.io.IOException
 import java.util.concurrent.ScheduledThreadPoolExecutor
 
 import akka.http.scaladsl.Http
+import ch.qos.logback.classic.{Level, LoggerContext}
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.commons.cli.CommandLine
 import org.enso.projectmanager.boot.Globals.{
   ConfigFilename,
   ConfigNamespace,
@@ -12,17 +14,18 @@ import org.enso.projectmanager.boot.Globals.{
   SuccessExitCode
 }
 import org.enso.projectmanager.boot.configuration.ProjectManagerConfig
+import org.enso.version.VersionDescription
+import org.slf4j.LoggerFactory
 import pureconfig.ConfigSource
+import pureconfig.generic.auto._
 import zio.ZIO.effectTotal
 import zio._
 import zio.console._
 import zio.interop.catz.core._
-import org.enso.projectmanager.infrastructure.config.ConfigurationReaders.fileReader
-import org.enso.version.VersionDescription
-import pureconfig.generic.auto._
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
+import scala.util.control.NonFatal
 
 /**
   * Project manager runner containing the main method.
@@ -98,21 +101,54 @@ object ProjectManager extends App with LazyLogging {
         success = ZIO.succeed(_)
       )
 
+  override def run(args: List[String]): ZIO[ZEnv, Nothing, Int] = {
+    Cli.parse(args.toArray) match {
+      case Some(opts) =>
+        runOpts(opts)
+      case None =>
+        effectTotal(Cli.printHelp()) *>
+        ZIO.succeed(FailureExitCode)
+    }
+  }
+
   /**
     * The main function of the application, which will be passed the command-line
     * arguments to the program and has to return an `IO` with the errors fully handled.
     */
-  override def run(args: List[String]): ZIO[ZEnv, Nothing, Int] = {
-    if (args.contains("--version")) {
-      displayVersion(args.contains("--json"))
+  def runOpts(options: CommandLine): ZIO[ZEnv, Nothing, Int] = {
+    if (options.hasOption(Cli.HELP_OPTION)) {
+      ZIO.effectTotal(Cli.printHelp()) *>
+      ZIO.succeed(SuccessExitCode)
+    } else if (options.hasOption(Cli.VERSION_OPTION)) {
+      displayVersion(options.hasOption(Cli.JSON_OPTION))
     } else {
+      val verbosity = options.getOptions.count(_ == Cli.option.verbose)
       logger.info("Starting Project Manager...")
+      setupLogging(verbosity) *>
       mainProcess.fold(
         th => { th.printStackTrace(); FailureExitCode },
         _ => SuccessExitCode
       )
     }
   }
+
+  private def setupLogging(verbosityLevel: Int): UIO[Unit] =
+    ZIO
+      .effectTotal {
+        val level = verbosityLevel match {
+          case 0 => Level.INFO
+          case 1 => Level.DEBUG
+          case _ => Level.TRACE
+        }
+        try {
+          val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+          ctx.getLogger("org.enso").setLevel(level)
+          logger.info(s"Set log level $level")
+        } catch {
+          case NonFatal(ex) =>
+            logger.error(s"Failed to set log level $verbosityLevel", ex)
+        }
+      }
 
   private def displayVersion(useJson: Boolean): ZIO[Console, Nothing, Int] = {
     val versionDescription = VersionDescription.make(

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
@@ -139,10 +139,10 @@ object ProjectManager extends App with LazyLogging {
           case _ => Logging.LogLevel.Trace
         }
         Logging.setLogLevel(level) match {
-          case Some(level) =>
+          case Right(level) =>
             logger.info(s"Set log level $level")
-          case None =>
-            logger.error(s"Failed to set log level $level")
+          case Left(error) =>
+            logger.error(s"Failed to set log level $level", error)
         }
       }
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
@@ -101,9 +101,10 @@ object ProjectManager extends App with LazyLogging {
 
   override def run(args: List[String]): ZIO[ZEnv, Nothing, Int] = {
     Cli.parse(args.toArray) match {
-      case Some(opts) =>
+      case Right(opts) =>
         runOpts(opts)
-      case None =>
+      case Left(error) =>
+        putStrLn(error) *>
         effectTotal(Cli.printHelp()) *>
         ZIO.succeed(FailureExitCode)
     }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/util/Logging.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/util/Logging.scala
@@ -1,9 +1,8 @@
 package org.enso.projectmanager.util
 
+import cats.syntax.either._
 import ch.qos.logback.classic.{Level, LoggerContext}
 import org.slf4j.LoggerFactory
-
-import scala.util.Try
 
 object Logging {
 
@@ -48,20 +47,20 @@ object Logging {
     * @return the new log level
     */
   def setLogLevel(level: LogLevel): Either[Throwable, LogLevel] = {
-    Try {
+    Either.catchNonFatal {
       val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
       ctx.getLogger(ROOT_LOGGER).setLevel(LogLevel.toLogback(level))
       level
-    }.toEither
+    }
   }
 
   /** Get log level of the application root logger. */
   def getLogLevel: Either[Throwable, LogLevel] = {
-    Try {
+    Either.catchNonFatal {
       val ctx   = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
       val level = ctx.getLogger(ROOT_LOGGER).getLevel
       LogLevel.fromLogback(level)
-    }.toEither
+    }
   }
 
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/util/Logging.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/util/Logging.scala
@@ -1,0 +1,67 @@
+package org.enso.projectmanager.util
+
+import ch.qos.logback.classic.{Level, LoggerContext}
+import org.slf4j.LoggerFactory
+
+import scala.util.Try
+
+object Logging {
+
+  /** Application log level. */
+  sealed trait LogLevel
+  object LogLevel {
+
+    case object Error   extends LogLevel
+    case object Warning extends LogLevel
+    case object Info    extends LogLevel
+    case object Debug   extends LogLevel
+    case object Trace   extends LogLevel
+
+    /** Convert to logback log level. */
+    def toLogback(level: LogLevel): Level =
+      level match {
+        case Error   => Level.ERROR
+        case Warning => Level.WARN
+        case Info    => Level.INFO
+        case Debug   => Level.DEBUG
+        case Trace   => Level.TRACE
+      }
+
+    /** Convert from logback log level. */
+    def fromLogback(level: Level): LogLevel = {
+      level match {
+        case Level.`ERROR` => Error
+        case Level.`WARN`  => Warning
+        case Level.`INFO`  => Info
+        case Level.`DEBUG` => Debug
+        case Level.`TRACE` => Trace
+      }
+    }
+  }
+
+  private val ROOT_LOGGER = "org.enso"
+
+  /**
+    * Set log level for the application root logger.
+    *
+    * @param level the log level
+    * @return the new log level
+    */
+  def setLogLevel(level: LogLevel): Option[LogLevel] = {
+    Try {
+      val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+      ctx.getLogger(ROOT_LOGGER).setLevel(LogLevel.toLogback(level))
+      level
+    }.toOption
+  }
+
+  /** Get log level of the application root logger. */
+  def getLogLevel: Option[LogLevel] = {
+    Try {
+      val ctx   = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+      val level = ctx.getLogger(ROOT_LOGGER).getLevel
+      LogLevel.fromLogback(level)
+    }.toOption
+  }
+
+}

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/util/Logging.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/util/Logging.scala
@@ -47,21 +47,21 @@ object Logging {
     * @param level the log level
     * @return the new log level
     */
-  def setLogLevel(level: LogLevel): Option[LogLevel] = {
+  def setLogLevel(level: LogLevel): Either[Throwable, LogLevel] = {
     Try {
       val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
       ctx.getLogger(ROOT_LOGGER).setLevel(LogLevel.toLogback(level))
       level
-    }.toOption
+    }.toEither
   }
 
   /** Get log level of the application root logger. */
-  def getLogLevel: Option[LogLevel] = {
+  def getLogLevel: Either[Throwable, LogLevel] = {
     Try {
       val ctx   = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
       val level = ctx.getLogger(ROOT_LOGGER).getLevel
       LogLevel.fromLogback(level)
-    }.toOption
+    }.toEither
   }
 
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #945 

Set the project manager log level from the CLI options. Now the logs verbosity can be controlled by stacking `-v` verbosity options:
- `<no options>` - _info_
- `-v` - _debug_
- `-vv` - _trace_

Changelog:
- add CLI options parser to project manager
- update project manager to change the application log level based on CLI verbosity options

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
