### PR TITLE
Resolve `here` References when Building Suggestions

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
@@ -121,6 +121,7 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
     )
   }
 
+  /** Build a method suggestion. */
   private def buildMethod(
     externalId: Option[IR.ExternalId],
     module: String,
@@ -157,6 +158,7 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
     }
   }
 
+  /** Build a function suggestion */
   private def buildFunction(
     externalId: Option[IR.ExternalId],
     module: String,
@@ -190,6 +192,7 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
     }
   }
 
+  /** Build a local suggestion. */
   private def buildLocal(
     externalId: Option[IR.ExternalId],
     module: String,
@@ -210,6 +213,7 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
         Suggestion.Local(externalId, module, name, Any, buildScope(location))
     }
 
+  /** Build an atom suggestion. */
   private def buildAtom(
     module: String,
     name: String,
@@ -225,6 +229,11 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
       documentation = doc
     )
 
+  /** Build self type from the method definitions metadata.
+    *
+    * @param definition the method definitions metadata
+    * @return the self type
+    */
   private def buildSelfType(
     definition: MethodDefinitions.Metadata
   ): Option[String] = {
@@ -238,6 +247,11 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
     }
   }
 
+  /** Build type signature from the type expression.
+    *
+    * @param typeExpr the type signature expression
+    * @return the list of type arguments
+    */
   private def buildTypeSignature(typeExpr: IR.Expression): Vector[TypeArg] = {
     @scala.annotation.tailrec
     def go(typeExpr: IR.Expression, args: Vector[TypeArg]): Vector[TypeArg] =
@@ -254,6 +268,13 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
     go(typeExpr, Vector())
   }
 
+  /** Build arguments of a method.
+    *
+    * @param vargs the list of value arguments
+    * @param targs the list of type arguments
+    * @param selfType the self type of a method
+    * @return the list of arguments with a method return type
+    */
   private def buildMethodArguments(
     vargs: Seq[IR.DefinitionArgument],
     targs: Seq[TypeArg],
@@ -298,6 +319,12 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
     go(vargs, targs, Vector())
   }
 
+  /** Build arguments of a function.
+    *
+    * @param vargs the list of value arguments
+    * @param targs the list of type arguments
+    * @return the list of arguments with a function return type
+    */
   private def buildFunctionArguments(
     vargs: Seq[IR.DefinitionArgument],
     targs: Seq[TypeArg]
@@ -325,6 +352,12 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
     go(vargs, targs, Vector())
   }
 
+  /** Build suggestion argument from a typed definition.
+    *
+    * @param varg the value argument
+    * @param targ the type argument
+    * @return the suggestion argument
+    */
   private def buildTypedArgument(
     varg: IR.DefinitionArgument,
     targ: TypeArg
@@ -337,6 +370,11 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
       defaultValue = varg.defaultValue.flatMap(buildDefaultValue)
     )
 
+  /** Build suggestion argument from an untyped definition.
+    *
+    * @param arg the value argument
+    * @return the suggestion argument
+    */
   private def buildArgument(arg: IR.DefinitionArgument): Suggestion.Argument =
     Suggestion.Argument(
       name         = arg.name.name,
@@ -346,24 +384,22 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
       defaultValue = arg.defaultValue.flatMap(buildDefaultValue)
     )
 
-  def buildArgument(
-    varg: IR.DefinitionArgument,
-    targ: Option[TypeArg]
-  ): Suggestion.Argument =
-    Suggestion.Argument(
-      name         = varg.name.name,
-      reprType     = targ.fold(Any)(_.name),
-      isSuspended  = targ.fold(varg.suspended)(_.isSuspended),
-      hasDefault   = varg.defaultValue.isDefined,
-      defaultValue = varg.defaultValue.flatMap(buildDefaultValue)
-    )
-
+  /** Build return type from the type definition.
+    *
+    * @param typeDef the type definition
+    * @return the type name
+    */
   private def buildReturnType(typeDef: Option[TypeArg]): String =
     typeDef match {
       case Some(TypeArg(name, _)) => name
       case None                   => Any
     }
 
+  /** Build argument default value from the expression.
+    *
+    * @param expr the argument expression
+    * @return the argument default value
+    */
   private def buildDefaultValue(expr: IR): Option[String] =
     expr match {
       case IR.Literal.Number(value, _, _, _) => Some(value)
@@ -371,9 +407,15 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
       case _                                 => None
     }
 
+  /** Build scope from the location. */
   private def buildScope(location: Location): Suggestion.Scope =
     Suggestion.Scope(toPosition(location.start), toPosition(location.end))
 
+  /** Convert absolute position index to the relative position of a suggestion.
+    *
+    * @param index the absolute position in the source
+    * @return the relative position
+    */
   private def toPosition(index: Int): Suggestion.Position = {
     val pos = IndexedSource[A].toPosition(index, source)
     Suggestion.Position(pos.line, pos.character)

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/CompilerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/CompilerTest.scala
@@ -216,16 +216,18 @@ trait CompilerRunner {
   /**
     * Builds a module context with a mocked module for testing purposes.
     *
+    * @param moduleName the name of the test module.
     * @param freshNameSupply the fresh name supply to use in tests.
     * @param passConfiguration any additional pass configuration.
     * @return an instance of module context.
     */
   def buildModuleContext(
+    moduleName: QualifiedName                    = QualifiedName.simpleName("Test_Module"),
     freshNameSupply: Option[FreshNameSupply]     = None,
     passConfiguration: Option[PassConfiguration] = None
   ): ModuleContext = {
     ModuleContext(
-      module            = Module.empty(QualifiedName.simpleName("Test_Module")),
+      module            = Module.empty(moduleName),
       freshNameSupply   = freshNameSupply,
       passConfiguration = passConfiguration
     )

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
@@ -23,7 +23,7 @@ class SuggestionBuilderTest extends CompilerTest {
     "build method without explicit arguments" in {
       implicit val moduleContext: ModuleContext = freshModuleContext
 
-      val code   = """foo = 42""".stripMargin
+      val code   = """foo = 42"""
       val module = code.preprocessModule
 
       build(code, module) should contain theSameElementsAs Seq(
@@ -109,8 +109,7 @@ class SuggestionBuilderTest extends CompilerTest {
     "build method with default arguments" in {
       implicit val moduleContext: ModuleContext = freshModuleContext
 
-      val code =
-        """foo (a = 0) = a + 1""".stripMargin
+      val code   = """foo (a = 0) = a + 1"""
       val module = code.preprocessModule
 
       build(code, module) should contain theSameElementsAs Seq(
@@ -168,7 +167,7 @@ class SuggestionBuilderTest extends CompilerTest {
       implicit val moduleContext: ModuleContext = freshModuleContext
 
       val code =
-        """MyAtom.bar a b = a + b""".stripMargin
+        """MyAtom.bar a b = a + b"""
       val module = code.preprocessModule
 
       build(code, module) should contain theSameElementsAs Seq()
@@ -214,7 +213,7 @@ class SuggestionBuilderTest extends CompilerTest {
       implicit val moduleContext: ModuleContext = freshModuleContext
 
       val code =
-        """foo ~a = a + 1""".stripMargin
+        """foo ~a = a + 1"""
       val module = code.preprocessModule
 
       build(code, module) should contain theSameElementsAs Seq(

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
@@ -11,6 +11,7 @@ import org.enso.compiler.context.{
 import org.enso.compiler.core.IR
 import org.enso.compiler.pass.PassManager
 import org.enso.compiler.test.CompilerTest
+import org.enso.pkg.QualifiedName
 import org.enso.polyglot.Suggestion
 
 class SuggestionBuilderTest extends CompilerTest {
@@ -28,12 +29,12 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "foo",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None)
           ),
-          selfType      = "here",
+          selfType      = "Test",
           returnType    = "Any",
           documentation = None
         )
@@ -51,12 +52,12 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "foo",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None)
           ),
-          selfType      = "here",
+          selfType      = "Test",
           returnType    = "Any",
           documentation = Some(" The foo")
         )
@@ -77,27 +78,27 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "foo",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None),
             Suggestion.Argument("a", "Any", false, false, None),
             Suggestion.Argument("b", "Any", false, false, None)
           ),
-          selfType      = "here",
+          selfType      = "Test",
           returnType    = "Any",
           documentation = None
         ),
         Suggestion.Local(
           externalId = None,
-          "Test",
+          "Unnamed.Test",
           "x",
           "Number",
           Suggestion.Scope(Suggestion.Position(0, 9), Suggestion.Position(4, 9))
         ),
         Suggestion.Local(
           externalId = None,
-          "Test",
+          "Unnamed.Test",
           "y",
           "Any",
           Suggestion.Scope(Suggestion.Position(0, 9), Suggestion.Position(4, 9))
@@ -115,33 +116,87 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "foo",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None),
             Suggestion.Argument("a", "Any", false, true, Some("0"))
           ),
-          selfType      = "here",
+          selfType      = "Test",
           returnType    = "Any",
           documentation = None
         )
       )
     }
 
+    "build method with explicit self type" in {
+      implicit val moduleContext: ModuleContext = freshModuleContext
+
+      val code =
+        """type MyType
+          |
+          |MyType.bar a b = a + b
+          |""".stripMargin
+      val module = code.preprocessModule
+
+      build(code, module) should contain theSameElementsAs Seq(
+        Suggestion.Atom(
+          externalId    = None,
+          module        = "Unnamed.Test",
+          name          = "MyType",
+          arguments     = Seq(),
+          returnType    = "MyType",
+          documentation = None
+        ),
+        Suggestion.Method(
+          externalId = None,
+          module     = "Unnamed.Test",
+          name       = "bar",
+          arguments = Seq(
+            Suggestion.Argument("this", "Any", false, false, None),
+            Suggestion.Argument("a", "Any", false, false, None),
+            Suggestion.Argument("b", "Any", false, false, None)
+          ),
+          selfType      = "MyType",
+          returnType    = "Any",
+          documentation = None
+        )
+      )
+    }
+
+    "not build method with undefined self type" in {
+      implicit val moduleContext: ModuleContext = freshModuleContext
+
+      val code =
+        """MyAtom.bar a b = a + b""".stripMargin
+      val module = code.preprocessModule
+
+      build(code, module) should contain theSameElementsAs Seq()
+    }
+
     "build method with associated type signature" in {
       implicit val moduleContext: ModuleContext = freshModuleContext
 
       val code =
-        """
+        """type MyAtom
+          |
           |MyAtom.bar : Number -> Number -> Number
           |MyAtom.bar a b = a + b
           |""".stripMargin
       val module = code.preprocessModule
 
       build(code, module) should contain theSameElementsAs Seq(
+        Suggestion.Atom(
+          externalId    = None,
+          module        = "Unnamed.Test",
+          name          = "MyAtom",
+          arguments     = Seq(),
+          returnType    = "MyAtom",
+          documentation = None
+        ),
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "bar",
           arguments = Seq(
             Suggestion.Argument("this", "MyAtom", false, false, None),
@@ -165,13 +220,13 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "foo",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None),
             Suggestion.Argument("a", "Any", true, false, None)
           ),
-          selfType      = "here",
+          selfType      = "Test",
           returnType    = "Any",
           documentation = None
         )
@@ -190,18 +245,18 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "main",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None)
           ),
-          selfType      = "here",
+          selfType      = "Test",
           returnType    = "Any",
           documentation = None
         ),
         Suggestion.Function(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "foo",
           arguments = Seq(
             Suggestion.Argument("a", "Any", false, false, None)
@@ -228,18 +283,18 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "main",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None)
           ),
-          selfType      = "here",
+          selfType      = "Test",
           returnType    = "Any",
           documentation = None
         ),
         Suggestion.Function(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "foo",
           arguments = Seq(
             Suggestion.Argument("a", "Number", false, false, None)
@@ -262,7 +317,7 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Atom(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "MyType",
           arguments = Seq(
             Suggestion.Argument("a", "Any", false, false, None),
@@ -285,7 +340,7 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Atom(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "MyType",
           arguments = Seq(
             Suggestion.Argument("a", "Any", false, false, None),
@@ -309,7 +364,7 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Atom(
           externalId    = None,
-          module        = "Test",
+          module        = "Unnamed.Test",
           name          = "Nothing",
           arguments     = Seq(),
           returnType    = "Nothing",
@@ -317,7 +372,7 @@ class SuggestionBuilderTest extends CompilerTest {
         ),
         Suggestion.Atom(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "Just",
           arguments = Seq(
             Suggestion.Argument("a", "Any", false, false, None)
@@ -343,7 +398,7 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Atom(
           externalId    = None,
-          module        = "Test",
+          module        = "Unnamed.Test",
           name          = "Nothing",
           arguments     = Seq(),
           returnType    = "Nothing",
@@ -351,7 +406,7 @@ class SuggestionBuilderTest extends CompilerTest {
         ),
         Suggestion.Atom(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "Just",
           arguments = Seq(
             Suggestion.Argument("a", "Any", false, false, None)
@@ -377,7 +432,7 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Atom(
           externalId    = None,
-          module        = "Test",
+          module        = "Unnamed.Test",
           name          = "Nothing",
           arguments     = Seq(),
           returnType    = "Nothing",
@@ -385,7 +440,7 @@ class SuggestionBuilderTest extends CompilerTest {
         ),
         Suggestion.Atom(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "Just",
           arguments = Seq(
             Suggestion.Argument("a", "Any", false, false, None)
@@ -395,7 +450,7 @@ class SuggestionBuilderTest extends CompilerTest {
         ),
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "map",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None),
@@ -407,7 +462,7 @@ class SuggestionBuilderTest extends CompilerTest {
         ),
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "map",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None),
@@ -433,7 +488,7 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Atom(
           externalId    = None,
-          module        = "Test",
+          module        = "Unnamed.Test",
           name          = "MyAtom",
           arguments     = Seq(),
           returnType    = "MyAtom",
@@ -441,7 +496,7 @@ class SuggestionBuilderTest extends CompilerTest {
         ),
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "is_atom",
           arguments = Seq(
             Suggestion.Argument("this", "MyAtom", false, false, None)
@@ -464,7 +519,7 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Atom(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "MyType",
           arguments = Seq(
             Suggestion.Argument("a", "Any", false, false, None),
@@ -475,12 +530,12 @@ class SuggestionBuilderTest extends CompilerTest {
         ),
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "main",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None)
           ),
-          selfType      = "here",
+          selfType      = "Test",
           returnType    = "Any",
           documentation = None
         )
@@ -503,12 +558,12 @@ class SuggestionBuilderTest extends CompilerTest {
         Suggestion.Method(
           externalId =
             Some(UUID.fromString("4083ce56-a5e5-4ecd-bf45-37ddf0b58456")),
-          module = "Test",
+          module = "Unnamed.Test",
           name   = "main",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None)
           ),
-          selfType      = "here",
+          selfType      = "Test",
           returnType    = "Any",
           documentation = None
         )
@@ -532,19 +587,19 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "main",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None)
           ),
-          selfType      = "here",
+          selfType      = "Test",
           returnType    = "Any",
           documentation = None
         ),
         Suggestion.Function(
           externalId =
             Some(UUID.fromString("f533d910-63f8-44cd-9204-a1e2d46bb7c3")),
-          module = "Test",
+          module = "Unnamed.Test",
           name   = "id",
           arguments = Seq(
             Suggestion.Argument("x", "Any", false, false, None)
@@ -575,19 +630,19 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) should contain theSameElementsAs Seq(
         Suggestion.Method(
           externalId = None,
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "main",
           arguments = Seq(
             Suggestion.Argument("this", "Any", false, false, None)
           ),
-          selfType      = "here",
+          selfType      = "Test",
           returnType    = "Any",
           documentation = None
         ),
         Suggestion.Local(
           externalId =
             Some(UUID.fromString("0270bcdf-26b8-4b99-8745-85b3600c7359")),
-          module     = "Test",
+          module     = "Unnamed.Test",
           name       = "foo",
           returnType = "Any",
           scope = Suggestion.Scope(
@@ -600,11 +655,14 @@ class SuggestionBuilderTest extends CompilerTest {
 
   }
 
-  private val Module = "Test"
+  private val Module = QualifiedName(List("Unnamed"), "Test")
 
   private def build(source: String, ir: IR.Module): Vector[Suggestion] =
-    SuggestionBuilder(source).build(Module, ir)
+    SuggestionBuilder(source).build(Module.toString, ir)
 
   private def freshModuleContext: ModuleContext =
-    buildModuleContext(freshNameSupply = Some(new FreshNameSupply))
+    buildModuleContext(
+      moduleName      = QualifiedName.simpleName(Module.item),
+      freshNameSupply = Some(new FreshNameSupply)
+    )
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -454,7 +454,7 @@ class RuntimeServerTest
                   Suggestion.Argument("a", "Any", false, false, None),
                   Suggestion.Argument("b", "Any", false, false, None)
                 ),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -465,7 +465,7 @@ class RuntimeServerTest
                 moduleName,
                 "main",
                 List(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -555,7 +555,7 @@ class RuntimeServerTest
                   Suggestion.Argument("a", "Any", false, false, None),
                   Suggestion.Argument("b", "Any", false, false, None)
                 ),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -566,7 +566,7 @@ class RuntimeServerTest
                 moduleName,
                 "main",
                 List(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -652,7 +652,7 @@ class RuntimeServerTest
                 moduleName,
                 "main",
                 Seq(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -663,7 +663,7 @@ class RuntimeServerTest
                 moduleName,
                 "bar",
                 Seq(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -751,7 +751,7 @@ class RuntimeServerTest
                 moduleName,
                 "main",
                 Seq(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -762,7 +762,7 @@ class RuntimeServerTest
                 moduleName,
                 "bar",
                 Seq(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -854,7 +854,7 @@ class RuntimeServerTest
                   Suggestion.Argument("a", "Any", false, false, None),
                   Suggestion.Argument("b", "Any", false, false, None)
                 ),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -865,7 +865,7 @@ class RuntimeServerTest
                 moduleName,
                 "main",
                 List(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -934,7 +934,7 @@ class RuntimeServerTest
                 moduleName,
                 "main",
                 Seq(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -1122,7 +1122,7 @@ class RuntimeServerTest
                 moduleName,
                 "main",
                 Seq(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -1254,7 +1254,7 @@ class RuntimeServerTest
                 moduleName,
                 "main",
                 Seq(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -1603,7 +1603,7 @@ class RuntimeServerTest
                 moduleName,
                 "main",
                 Seq(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -1894,7 +1894,7 @@ class RuntimeServerTest
                 "Test.Foo",
                 "main",
                 Seq(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Foo",
                 "Any",
                 None
               )
@@ -1991,7 +1991,7 @@ class RuntimeServerTest
                 "Test.Foo",
                 "main",
                 Seq(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Foo",
                 "Any",
                 None
               )
@@ -2076,7 +2076,7 @@ class RuntimeServerTest
                 "Test.Main",
                 "main",
                 List(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )
@@ -2248,7 +2248,7 @@ class RuntimeServerTest
                 "Test.Foo",
                 "main",
                 Seq(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Foo",
                 "Any",
                 None
               )
@@ -2922,7 +2922,7 @@ class RuntimeServerTest
                 moduleName,
                 "main",
                 List(Suggestion.Argument("this", "Any", false, false, None)),
-                "here",
+                "Main",
                 "Any",
                 None
               )


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1091 

Resolve `here` method references when building suggestions.

- update `SuggestionBuilder` to resolve method self type reference using the `MethodDefinitions` compiler pass
- update tests

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
