### PR TITLE
Disable TCP Offloading on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
           path: repo
       - name: Enable Developer Command Prompt (Windows)
         uses: ilammy/msvc-dev-cmd@v1.3.0
+      - name: Disable TCP/UDP Offloading (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          sudo sysctl -w net.link.generic.system.hwcksum_tx=0
+          sudo sysctl -w net.link.generic.system.hwcksum_rx=0
       - name: Disable TCP/UDP Offloading (Linux)
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -41,6 +41,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Enable Developer Command Prompt (Windows)
         uses: ilammy/msvc-dev-cmd@v1.3.0
+      - name: Disable TCP/UDP Offloading (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          sudo sysctl -w net.link.generic.system.hwcksum_tx=0
+          sudo sysctl -w net.link.generic.system.hwcksum_rx=0
       - name: Disable TCP/UDP Offloading (Linux)
         if: runner.os == 'Linux'
         shell: bash
@@ -164,6 +170,12 @@ jobs:
         if: github.event_name != 'pull_request'
       - name: Enable Developer Command Prompt (Windows)
         uses: ilammy/msvc-dev-cmd@v1.3.0
+      - name: Disable TCP/UDP Offloading (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          sudo sysctl -w net.link.generic.system.hwcksum_tx=0
+          sudo sysctl -w net.link.generic.system.hwcksum_rx=0
       - name: Disable TCP/UDP Offloading (Linux)
         if: runner.os == 'Linux'
         shell: bash


### PR DESCRIPTION
### Pull Request Description
As proposed [here](https://github.com/actions/virtual-environments/issues/1187), I'm disabling offloading on macOS. It's already disabled on Linux and Windows runners.

### Important Notes
This should hopefully increase the stability of localhost-based tests.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
