### PR TITLE
Polyglot Import Renaming

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
@@ -97,10 +97,11 @@ object AstToIr {
         val imports = presentBlocks.collect {
           case AST.Import.any(list) => translateImport(list)
           case AST.JavaImport.any(imp) =>
-            val pkg = imp.path.init.map(_.name)
-            val cls = imp.path.last.name
+            val pkg    = imp.path.init.map(_.name)
+            val cls    = imp.path.last.name
+            val rename = imp.rename.map(_.name)
             Module.Scope.Import.Polyglot(
-              Module.Scope.Import.Polyglot.Java(pkg.mkString("."), cls),
+              Module.Scope.Import.Polyglot.Java(pkg.mkString("."), cls, rename),
               getIdentifiedLocation(imp)
             )
         }

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
@@ -101,7 +101,8 @@ object AstToIr {
             val cls    = imp.path.last.name
             val rename = imp.rename.map(_.name)
             Module.Scope.Import.Polyglot(
-              Module.Scope.Import.Polyglot.Java(pkg.mkString("."), cls, rename),
+              Module.Scope.Import.Polyglot.Java(pkg.mkString("."), cls),
+              rename,
               getIdentifiedLocation(imp)
             )
         }

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -157,11 +157,10 @@ class IrToTruffle(
 
     // Register the imports in scope
     imports.foreach {
-      case Import.Polyglot(Import.Polyglot.Java(pkg, cls), _, _, _) =>
-        val fullName = s"$pkg.$cls"
+      case Import.Polyglot(i: Import.Polyglot.Java, _, _, _) =>
         this.moduleScope.registerPolyglotSymbol(
-          cls,
-          context.getEnvironment.lookupHostSymbol(fullName)
+          i.getVisibleName,
+          context.getEnvironment.lookupHostSymbol(i.getJavaName)
         )
       case i: Import.Module =>
         this.moduleScope.addImport(

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -157,9 +157,9 @@ class IrToTruffle(
 
     // Register the imports in scope
     imports.foreach {
-      case Import.Polyglot(i: Import.Polyglot.Java, _, _, _) =>
+      case poly @ Import.Polyglot(i: Import.Polyglot.Java, _, _, _, _) =>
         this.moduleScope.registerPolyglotSymbol(
-          i.getVisibleName,
+          poly.getVisibleName,
           context.getEnvironment.lookupHostSymbol(i.getJavaName)
         )
       case i: Import.Module =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -727,12 +727,29 @@ object IR {
             *                    class
             * @param className the class name
             */
-          case class Java(packageName: String, className: String)
-              extends Entity {
+          case class Java(
+            packageName: String,
+            className: String,
+            rename: Option[String]
+          ) extends Entity {
             val langName = "java"
 
+            /** Returns the name this object is visible as from Enso code.
+              *
+              * @return the visible name of this object
+              */
+            def getVisibleName: String = rename.getOrElse(className)
+
+            /** Returns the fully qualified Java name of this object.
+              *
+              * @return the Java-side name of the imported entity
+              */
+            def getJavaName: String = s"$packageName.$className"
+
             override def showCode(indent: Int): String =
-              s"$packageName.$className"
+              s"$packageName.$className" + rename
+                .map(n => s"as $n")
+                .getOrElse("")
           }
         }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -726,6 +726,8 @@ object IR {
             * @param packageName the name of the package containing the imported
             *                    class
             * @param className the class name
+            * @param rename the name this object should be visible under in the
+            *               importing scope
             */
           case class Java(
             packageName: String,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
@@ -2,7 +2,6 @@ package org.enso.compiler.pass.analyse
 
 import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
-import org.enso.compiler.core.IR.Module.Scope.Import.Polyglot
 import org.enso.compiler.core.ir.MetadataStorage.ToPair
 import org.enso.compiler.data.BindingsMap
 import org.enso.compiler.pass.IRPass
@@ -51,10 +50,7 @@ case object BindingAnalysis extends IRPass {
     }
     val importedPolyglot = ir.imports.collect {
       case poly: IR.Module.Scope.Import.Polyglot =>
-        val sym = poly.entity match {
-          case java: Polyglot.Java => java.getVisibleName
-        }
-        BindingsMap.PolyglotSymbol(sym)
+        BindingsMap.PolyglotSymbol(poly.getVisibleName)
     }
     val moduleMethods = ir.bindings
       .collect {

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
@@ -52,7 +52,7 @@ case object BindingAnalysis extends IRPass {
     val importedPolyglot = ir.imports.collect {
       case poly: IR.Module.Scope.Import.Polyglot =>
         val sym = poly.entity match {
-          case Polyglot.Java(_, className) => className
+          case java: Polyglot.Java => java.getVisibleName
         }
         BindingsMap.PolyglotSymbol(sym)
     }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/BindingAnalysisTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/BindingAnalysisTest.scala
@@ -51,6 +51,7 @@ class BindingAnalysisTest extends CompilerTest {
     val ir =
       """
         |polyglot java import foo.bar.baz.MyClass
+        |polyglot java import foo.bar.baz.OtherClass as Renamed_Class
         |
         |type Foo a b c
         |type Bar
@@ -66,7 +67,7 @@ class BindingAnalysisTest extends CompilerTest {
       ir.getMetadata(BindingAnalysis) shouldEqual Some(
         BindingsMap(
           List(Cons("Foo", 3), Cons("Bar", 0), Cons("Baz", 2)),
-          List(PolyglotSymbol("MyClass")),
+          List(PolyglotSymbol("MyClass"), PolyglotSymbol("Renamed_Class")),
           List(ModuleMethod("foo")),
           ctx.module
         )

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -353,8 +353,11 @@ object Shape extends ShapeImplicit {
     isAll: Boolean,
     onlyNames: Option[List1[AST.Ident]],
     hidingNames: Option[List1[AST.Ident]]
-  )                                                      extends SpacelessAST[T]
-  final case class JavaImport[T](path: List1[AST.Ident]) extends SpacelessAST[T]
+  ) extends SpacelessAST[T]
+  final case class JavaImport[T](
+    path: List1[AST.Ident],
+    rename: Option[AST.Ident.Cons]
+  ) extends SpacelessAST[T]
   final case class Mixfix[T](name: List1[AST.Ident], args: List1[T])
       extends SpacelessAST[T]
   final case class Group[T](body: Option[T])          extends SpacelessAST[T]
@@ -2422,7 +2425,8 @@ object AST {
   type JavaImport = ASTOf[Shape.JavaImport]
 
   object JavaImport {
-    def apply(path: List1[Ident]): JavaImport = Shape.JavaImport[AST](path)
+    def apply(path: List1[Ident], rename: Option[Ident.Cons]): JavaImport =
+      Shape.JavaImport[AST](path, rename)
     def unapply(t: AST): Option[List1[Ident]] =
       Unapply[JavaImport].run(t => t.path)(t)
     val any = UnapplyByType[JavaImport]

--- a/test/Test/src/Java_Interop/Spec.enso
+++ b/test/Test/src/Java_Interop/Spec.enso
@@ -6,6 +6,7 @@ polyglot java import java.lang.Integer
 polyglot java import java.lang.Float
 polyglot java import java.lang.String
 polyglot java import java.util.ArrayList
+polyglot java import java.lang.StringBuilder as Java_String_Builder
 
 spec = describe "Java FFI" <|
     it "should call methods imported from Java" <|
@@ -22,4 +23,9 @@ spec = describe "Java FFI" <|
         (Integer.sum [1, 2] + 3) . should_equal 6
     it "should auto-convert strings across the polyglot boundary" <|
         (String.format ["%s bar %s", "baz", "quux"] + " foo").should_equal "baz bar quux foo"
-
+    it "should support Java import renaming" <|
+        builder = Java_String_Builder.new [].to_array
+        builder.append ["foo"]
+        builder.append ["bar"]
+        str = builder.toString []
+        str.should_equal "foobar"


### PR DESCRIPTION
### Pull Request Description
Introduces the ability to rename a Polyglot Java import.

Closes #1178.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
