### PR TITLE
Bump the Node LTS Patch Version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
     branches: ["*"]
 
 env:
-  nodeVersion: 12.18.3
+  nodeVersion: 12.18.4
 
 jobs:
   check:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
     branches: ["*"]
 
 env:
-  nodeVersion: 12.18.0
+  nodeVersion: 12.18.3
 
 jobs:
   check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
         shell: bash
         run: |
           cd std-bits
-          mvn package
+          mvn --no-transfer-progress package
 
       # The way artifacts are uploaded currently does not preserve the
       # executable bits for Unix. However putting artifacts into a ZIP would

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,13 @@ jobs:
             ~/.cache
           key: ${{ runner.os }}-sbt-${{ hashFiles('**build.sbt') }}
           restore-keys: ${{ runner.os }}-sbt-
+      - name: Cache Local Maven Repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
       # Build Artifacts
       - name: Enable Release Mode

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   wasmpackVersion: 0.8.1
-  nodeVersion: 12.18.0
+  nodeVersion: 12.18.3
   rustToolchain: nightly-2019-11-04
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   wasmpackVersion: 0.8.1
-  nodeVersion: 12.18.3
+  nodeVersion: 12.18.4
   rustToolchain: nightly-2019-11-04
 
 jobs:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -99,6 +99,13 @@ jobs:
             ~/.cache
           key: ${{ runner.os }}-sbt-${{ hashFiles('**build.sbt') }}
           restore-keys: ${{ runner.os }}-sbt-
+      - name: Cache Local Maven Repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
       # Build
       - name: Bootstrap Enso project
@@ -233,6 +240,13 @@ jobs:
             ~/.cache
           key: ${{ runner.os }}-sbt-${{ hashFiles('**build.sbt') }}
           restore-keys: ${{ runner.os }}-sbt-
+      - name: Cache Local Maven Repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
       # Build Artifacts
       - name: Bootstrap the Project

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -127,7 +127,7 @@ jobs:
         shell: bash
         run: |
           cd std-bits
-          mvn package
+          mvn --no-transfer-progress package
       - name: Build the Launcher
         run: |
           sleep 1
@@ -343,7 +343,7 @@ jobs:
         shell: bash
         run: |
           cd std-bits
-          mvn package
+          mvn --no-transfer-progress package
 
       # The way artifacts are uploaded currently does not preserve the
       # executable bits for Unix. However putting artifacts into a ZIP would

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -116,6 +116,11 @@ jobs:
         run: |
           echo '::set-env name=CI_TEST_TIMEFACTOR::2'
           echo '::set-env name=CI_TEST_FLAKY_ENABLE::true'
+      - name: Prebuild Base Java Extensions
+        shell: bash
+        run: |
+          cd std-bits
+          mvn package
       - name: Build the Launcher
         run: |
           sleep 1

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -204,7 +204,7 @@ rustup component add clippy
 You will also need `node` in order to run the `wasm` tests. We only support the
 latest LTS version of [NodeJS](https://nodejs.org/en/download) and NPM. We
 recommend using [`nvm`](https://github.com/nvm-sh/nvm) to manage node versions.
-The current LTS is `v12.18.3`.
+The current LTS is `v12.18.4`.
 
 ### Getting Set Up (JVM)
 

--- a/engine/launcher/src/test/scala/org/enso/launcher/NativeTest.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/NativeTest.scala
@@ -22,7 +22,7 @@ import scala.jdk.StreamConverters._
   */
 trait NativeTest extends AnyWordSpec with Matchers with TimeLimitedTests {
 
-  override val timeLimit: Span               = 30 seconds
+  override val timeLimit: Span               = 60.seconds
   override val defaultTestSignaler: Signaler = _.interrupt()
 
   /**
@@ -242,7 +242,7 @@ trait NativeTest extends AnyWordSpec with Matchers with TimeLimitedTests {
       */
     def waitForMessageOnErrorStream(
       message: String,
-      timeoutSeconds: Long = 10
+      timeoutSeconds: Long
     ): Unit = {
       val semaphore = new Semaphore(0)
       def handler(line: String, streamType: StreamType): Unit = {

--- a/engine/launcher/src/test/scala/org/enso/launcher/locking/TestSynchronizer.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/locking/TestSynchronizer.scala
@@ -78,7 +78,7 @@ class TestSynchronizer {
   /**
     * Timeout used by [[waitFor]].
     */
-  val timeOutSeconds: Long = 10
+  val timeOutSeconds: Long = 20
 
   /**
     * Reports that the event has happened now.

--- a/engine/launcher/src/test/scala/org/enso/launcher/upgrade/UpgradeSpec.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/upgrade/UpgradeSpec.scala
@@ -331,7 +331,8 @@ class UpgradeSpec
       )
       try {
         firstSuspended.waitForMessageOnErrorStream(
-          "INTERNAL-TEST-ACQUIRING-LOCK"
+          "INTERNAL-TEST-ACQUIRING-LOCK",
+          timeoutSeconds = 30
         )
 
         val secondFailed = run(Seq("upgrade", "0.0.0"))


### PR DESCRIPTION
### Pull Request Description
Bump the patch version of the node LTS from `.0` to `.3`.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
