### PR TITLE
Catch Polyglot Exceptions

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/CatchPanicNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/CatchPanicNode.java
@@ -1,9 +1,14 @@
 package org.enso.interpreter.node.expression.builtin.error;
 
+import com.oracle.truffle.api.TruffleException;
+import com.oracle.truffle.api.dsl.CachedContext;
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.argument.Thunk;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.RuntimeError;
@@ -13,14 +18,32 @@ import org.enso.interpreter.runtime.state.Stateful;
     type = "Panic",
     name = "catch",
     description = "Executes an action and converts any Panic thrown by it into an Error")
-public class CatchPanicNode extends Node {
+public abstract class CatchPanicNode extends Node {
   private @Child ThunkExecutorNode thunkExecutorNode = ThunkExecutorNode.build();
 
-  Stateful execute(@MonadicState Object state, Object _this, Thunk action) {
+  static CatchPanicNode build() {
+    return CatchPanicNodeGen.create();
+  }
+
+  abstract Stateful execute(@MonadicState Object state, Object _this, Thunk action);
+
+  @Specialization
+  Stateful doExecute(
+      @MonadicState Object state,
+      Object _this,
+      Thunk action,
+      @CachedContext(Language.class) Context ctx) {
     try {
       return thunkExecutorNode.executeThunk(action, state, false);
     } catch (PanicException e) {
       return new Stateful(state, new RuntimeError(e.getExceptionObject()));
+    } catch (Throwable e) {
+      if (ctx.getEnvironment().isHostException(e)) {
+        Object cause = ((TruffleException) e).getExceptionObject();
+        return new Stateful(
+            state, new RuntimeError(ctx.getBuiltins().error().makePolyglotError(cause)));
+      }
+      throw e;
     }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
@@ -14,6 +14,7 @@ public class Error {
   private final AtomConstructor inexhaustivePatternMatchError;
   private final AtomConstructor uninitializedState;
   private final AtomConstructor noSuchMethodError;
+  private final AtomConstructor polyglotError;
 
   /**
    * Creates and registers the relevant constructors.
@@ -43,12 +44,17 @@ public class Error {
             .initializeFields(
                 new ArgumentDefinition(0, "target", ArgumentDefinition.ExecutionMode.EXECUTE),
                 new ArgumentDefinition(1, "method_name", ArgumentDefinition.ExecutionMode.EXECUTE));
+    polyglotError =
+        new AtomConstructor("Polyglot_Error", scope)
+            .initializeFields(
+                new ArgumentDefinition(0, "cause", ArgumentDefinition.ExecutionMode.EXECUTE));
 
     scope.registerConstructor(syntaxError);
     scope.registerConstructor(compileError);
     scope.registerConstructor(inexhaustivePatternMatchError);
     scope.registerConstructor(uninitializedState);
     scope.registerConstructor(noSuchMethodError);
+    scope.registerConstructor(polyglotError);
   }
 
   /** @return the builtin {@code Syntax_Error} atom constructor. */
@@ -80,5 +86,9 @@ public class Error {
    */
   public Atom makeNoSuchMethodError(Object target, String name) {
     return noSuchMethodError.newInstance(target, Text.create(name));
+  }
+
+  public Atom makePolyglotError(Throwable cause) {
+    return polyglotError.newInstance(cause);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
@@ -88,7 +88,13 @@ public class Error {
     return noSuchMethodError.newInstance(target, Text.create(name));
   }
 
-  public Atom makePolyglotError(Throwable cause) {
+  /**
+   * Creates an instance of the runtime representation of a {@code Polyglot_Error}.
+   *
+   * @param cause the cause of the error.
+   * @return a runtime representation of the polyglot error.
+   */
+  public Atom makePolyglotError(Object cause) {
     return polyglotError.newInstance(cause);
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ErrorsTest.scala
@@ -140,8 +140,7 @@ class ErrorsTest extends InterpreterTest {
           |polyglot java import java.lang.Long
           |
           |main =
-          |    args = Array.new 1
-          |    args.set_at 0 "oops"
+          |    args = Array.new_1 "oops"
           |    caught = Panic.recover (Long.parseLong args)
           |    IO.println caught
           |    unwrap = caught.catch <| case _ of

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ErrorsTest.scala
@@ -144,9 +144,16 @@ class ErrorsTest extends InterpreterTest {
           |    args.set_at 0 "oops"
           |    caught = Panic.recover (Long.parseLong args)
           |    IO.println caught
+          |    unwrap = caught.catch <| case _ of
+          |        Polyglot_Error err -> err
+          |        _ -> "fail"
+          |    IO.println unwrap
           |""".stripMargin
       eval(code)
-      consumeOut shouldEqual List("""(Error: (Polyglot_Error java.lang.NumberFormatException: For input string: "oops"))""")
+      consumeOut shouldEqual List(
+        """(Error: (Polyglot_Error java.lang.NumberFormatException: For input string: "oops"))""",
+        """java.lang.NumberFormatException: For input string: "oops""""
+      )
     }
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ErrorsTest.scala
@@ -140,18 +140,20 @@ class ErrorsTest extends InterpreterTest {
           |polyglot java import java.lang.Long
           |
           |main =
-          |    args = Array.new_1 "oops"
-          |    caught = Panic.recover (Long.parseLong args)
+          |    caught = Panic.recover (Long.parseLong (Array.new_1 "oops"))
           |    IO.println caught
-          |    unwrap = caught.catch <| case _ of
+          |    cause = caught.catch <| case _ of
           |        Polyglot_Error err -> err
           |        _ -> "fail"
-          |    IO.println unwrap
+          |    IO.println cause
+          |    message = cause.getMessage (Array.new 0)
+          |    IO.println message
           |""".stripMargin
       eval(code)
       consumeOut shouldEqual List(
         """(Error: (Polyglot_Error java.lang.NumberFormatException: For input string: "oops"))""",
-        """java.lang.NumberFormatException: For input string: "oops""""
+        """java.lang.NumberFormatException: For input string: "oops"""",
+        """For input string: "oops""""
       )
     }
   }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ErrorsTest.scala
@@ -133,5 +133,20 @@ class ErrorsTest extends InterpreterTest {
       val code = "main = 10.catch (x -> x + 1)"
       eval(code) shouldEqual 10
     }
+
+    "catch polyglot errors" in {
+      val code =
+        """from Builtins import all
+          |polyglot java import java.lang.Long
+          |
+          |main =
+          |    args = Array.new 1
+          |    args.set_at 0 "oops"
+          |    caught = Panic.recover (Long.parseLong args)
+          |    IO.println caught
+          |""".stripMargin
+      eval(code)
+      consumeOut shouldEqual List("""(Error: (Polyglot_Error java.lang.NumberFormatException: For input string: "oops"))""")
+    }
   }
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1168 

`Panic.recover` catches host exceptions wrapping them in `Polyglot_Error` atom constructor.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
