### PR TITLE
Fix bugs in TCO and test library

### DIFF
--- a/distribution/std-lib/Base/src/Test.enso
+++ b/distribution/std-lib/Base/src/Test.enso
@@ -104,7 +104,10 @@ Text.it ~behavior pending=False =
     State.put Spec new_spec
 
 run_spec ~behavior =
-    maybeExc = case Panic.recover behavior of
+    recovery = Panic.recover <|
+        behavior
+        Unit
+    maybeExc = case recovery of
         _ -> Success
     result = maybeExc.catch ex->
         case ex of

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
@@ -154,7 +154,7 @@ case object TailCall extends IRPass {
       case binding @ IR.Expression.Binding(_, expression, _, _, _) =>
         binding
           .copy(
-            expression = analyseExpression(expression, isInTailPosition)
+            expression = analyseExpression(expression, isInTailPosition = false)
           )
           .updateMetadata(this -->> TailPosition.fromBool(isInTailPosition))
       case err: IR.Diagnostic =>

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallTest.scala
@@ -127,6 +127,20 @@ class TailCallTest extends CompilerTest {
 
       ir.getMetadata(TailCall) shouldEqual Some(TailPosition.NotTail)
     }
+
+    "mark the value of a tail assignment as non-tail" in {
+      implicit val ctx: InlineContext = mkTailContext
+      val binding =
+        """
+          |foo = a b
+          |""".stripMargin.preprocessExpression.get.analyse
+          .asInstanceOf[IR.Expression.Binding]
+      binding.getMetadata(TailCall) shouldEqual Some(TailPosition.Tail)
+      binding.expression.getMetadata(TailCall) shouldEqual Some(
+        TailPosition.NotTail
+      )
+
+    }
   }
 
   "Tail call analysis on functions" should {


### PR DESCRIPTION
### Pull Request Description
Two bug fixes:
1. the test framework would fail upon returning a dataflow error. It shouldn't do that.
2. The rhs of a tail-position assignment would be marked tail, which changed the return values of functions.

### Important Notes


### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
