### PR TITLE
Make Locking Thread-Safe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -493,25 +493,25 @@ lazy val `lexer-bench` =
     .dependsOn(flexer.jvm)
     .settings(
       javaOptions ++= Seq(
-          "-Xms4096m",
-          "-Xmx4096m",
-          "-XX:+FlightRecorder",
+        "-Xms4096m",
+        "-Xmx4096m",
+        "-XX:+FlightRecorder"
       ),
       mainClass in Benchmark := Some("org.openjdk.jmh.Main"),
       bench := Def.task {
-          (run in Benchmark).toTask("").value
-        },
+        (run in Benchmark).toTask("").value
+      },
       benchOnly := Def.inputTaskDyn {
-          import complete.Parsers.spaceDelimited
-          val name = spaceDelimited("<name>").parsed match {
-            case List(name) => name
-            case _ =>
-              throw new IllegalArgumentException("Expected one argument.")
-          }
-          Def.task {
-            (testOnly in Benchmark).toTask(" -- -z " + name).value
-          }
-        }.evaluated,
+        import complete.Parsers.spaceDelimited
+        val name = spaceDelimited("<name>").parsed match {
+          case List(name) => name
+          case _ =>
+            throw new IllegalArgumentException("Expected one argument.")
+        }
+        Def.task {
+          (testOnly in Benchmark).toTask(" -- -z " + name).value
+        }
+      }.evaluated,
       parallelExecution in Benchmark := false
     )
 
@@ -1217,6 +1217,7 @@ lazy val `runtime-version-manager-test` = project
   .settings(parallelExecution in Test := false)
   .dependsOn(`runtime-version-manager`)
   .dependsOn(`logging-service`)
+  .dependsOn(testkit)
 
 val `std-lib-root`          = file("distribution/std-lib/")
 val `std-lib-polyglot-root` = `std-lib-root` / "Base" / "polyglot" / "java"

--- a/build.sbt
+++ b/build.sbt
@@ -1215,9 +1215,21 @@ lazy val `runtime-version-manager-test` = project
     )
   )
   .settings(parallelExecution in Test := false)
+  .settings(
+    (Test / test) := (Test / test)
+      .dependsOn(`locking-test-helper` / assembly)
+      .value
+  )
   .dependsOn(`runtime-version-manager`)
   .dependsOn(`logging-service`)
   .dependsOn(testkit)
+
+lazy val `locking-test-helper` = project
+  .in(file("lib/scala/locking-test-helper"))
+  .settings(
+    test in assembly := {},
+    assemblyOutputPath in assembly := file("locking-test-helper.jar")
+  )
 
 val `std-lib-root`          = file("distribution/std-lib/")
 val `std-lib-polyglot-root` = `std-lib-root` / "Base" / "polyglot" / "java"

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/SuggestionsHandlerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/SuggestionsHandlerTest.scala
@@ -4,9 +4,12 @@ import java.util.UUID
 import io.circe.literal._
 import org.enso.languageserver.refactoring.ProjectNameChangedEvent
 import org.enso.languageserver.websocket.json.{SearchJsonMessages => json}
-import org.enso.testkit.FlakySpec
+import org.enso.testkit.{FlakySpec, RetrySpec}
 
-class SuggestionsHandlerTest extends BaseServerTest with FlakySpec {
+class SuggestionsHandlerTest
+    extends BaseServerTest
+    with FlakySpec
+    with RetrySpec {
 
   "SuggestionsHandler" must {
 
@@ -17,7 +20,7 @@ class SuggestionsHandlerTest extends BaseServerTest with FlakySpec {
       client.expectNoMessage()
     }
 
-    "get initial suggestions database version" in {
+    "get initial suggestions database version" taggedAs Retry in {
       val client = getInitialisedWsClient()
       system.eventStream.publish(ProjectNameChangedEvent("Test", "Test"))
 

--- a/engine/launcher/src/main/scala/org/enso/launcher/DefaultComponentManager.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/DefaultComponentManager.scala
@@ -21,7 +21,7 @@ object DefaultComponentManager {
       ),
       distributionManager,
       temporaryDirectoryManager,
-      DefaultResourceManager,
+      defaultResourceManager,
       EnsoRepository.defaultEngineReleaseProvider,
       GraalCEReleaseProvider
     )

--- a/engine/launcher/src/main/scala/org/enso/launcher/cli/LauncherApplication.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/cli/LauncherApplication.scala
@@ -574,7 +574,7 @@ object LauncherApplication {
     */
   private def initializeApp(): Unit = {
     // Note [Main Lock Initialization]
-    DefaultResourceManager.initializeMainLock()
+    defaultResourceManager.initializeMainLock()
   }
 
   val commands: NonEmptyList[Command[Config => Int]] = NonEmptyList

--- a/engine/launcher/src/main/scala/org/enso/launcher/cli/Main.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/cli/Main.scala
@@ -56,7 +56,7 @@ object Main {
     */
   def exit(exitCode: Int): Nothing = {
     LauncherLogging.tearDown()
-    DefaultManagers.DefaultResourceManager.releaseMainLock()
+    DefaultManagers.defaultResourceManager.releaseMainLock()
     sys.exit(exitCode)
   }
 }

--- a/engine/launcher/src/main/scala/org/enso/launcher/distribution/DefaultManagers.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/distribution/DefaultManagers.scala
@@ -1,7 +1,5 @@
 package org.enso.launcher.distribution
 
-import java.nio.file.Path
-
 import org.enso.runtimeversionmanager.distribution.{
   PortableDistributionManager,
   TemporaryDirectoryManager
@@ -18,14 +16,12 @@ object DefaultManagers {
   /** Default [[FileLockManager]] storing lock files in a directory defined by
     * the distribution manager.
     */
-  object DefaultFileLockManager extends FileLockManager {
+  val defaultFileLockManager = new FileLockManager(
+    distributionManager.paths.locks
+  )
 
-    /** @inheritdoc */
-    override def locksRoot: Path = distributionManager.paths.locks
-  }
-
-  /** Default [[ResourceManager]] using the [[DefaultFileLockManager]]. */
-  object DefaultResourceManager extends ResourceManager(DefaultFileLockManager)
+  /** Default [[ResourceManager]] using the [[defaultFileLockManager]]. */
+  object DefaultResourceManager extends ResourceManager(defaultFileLockManager)
 
   /** Default [[TemporaryDirectoryManager]]. */
   val temporaryDirectoryManager =

--- a/engine/launcher/src/main/scala/org/enso/launcher/distribution/DefaultManagers.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/distribution/DefaultManagers.scala
@@ -4,26 +4,32 @@ import org.enso.runtimeversionmanager.distribution.{
   PortableDistributionManager,
   TemporaryDirectoryManager
 }
-import org.enso.runtimeversionmanager.locking.{FileLockManager, ResourceManager}
+import org.enso.runtimeversionmanager.locking.{
+  ResourceManager,
+  ThreadSafeFileLockManager
+}
 
 /** Gathers default managers used in the launcher. */
 object DefaultManagers {
 
-  /** Default distribution manager that is capable of detecting portable mode.
-    */
+  /** Default distribution manager that is capable of detecting portable mode. */
   val distributionManager = new PortableDistributionManager(LauncherEnvironment)
 
-  /** Default [[FileLockManager]] storing lock files in a directory defined by
+  /** Default [[LockManager]] storing lock files in a directory defined by
     * the distribution manager.
+    *
+    * It is lazily initialized, because initializing it triggers path detection
+    * and this cannot happen within static initialization, because with Native
+    * Image, static initialization is done at build-time, so the paths would be
+    * set at build time and not actual runtime, leading to very wrong results.
     */
-  val defaultFileLockManager = new FileLockManager(
-    distributionManager.paths.locks
-  )
+  lazy val defaultFileLockManager =
+    new ThreadSafeFileLockManager(distributionManager.paths.locks)
 
   /** Default [[ResourceManager]] using the [[defaultFileLockManager]]. */
-  object DefaultResourceManager extends ResourceManager(defaultFileLockManager)
+  lazy val defaultResourceManager = new ResourceManager(defaultFileLockManager)
 
   /** Default [[TemporaryDirectoryManager]]. */
-  val temporaryDirectoryManager =
-    new TemporaryDirectoryManager(distributionManager, DefaultResourceManager)
+  lazy val temporaryDirectoryManager =
+    new TemporaryDirectoryManager(distributionManager, defaultResourceManager)
 }

--- a/engine/launcher/src/main/scala/org/enso/launcher/installation/DistributionInstaller.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/installation/DistributionInstaller.scala
@@ -415,7 +415,7 @@ object DistributionInstaller {
   ): DistributionInstaller =
     new DistributionInstaller(
       DefaultManagers.distributionManager,
-      DefaultManagers.DefaultResourceManager,
+      DefaultManagers.defaultResourceManager,
       globalCLIOptions.autoConfirm,
       removeOldLauncher  = removeOldLauncher,
       bundleActionOption = bundleActionOption

--- a/engine/launcher/src/main/scala/org/enso/launcher/installation/DistributionUninstaller.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/installation/DistributionUninstaller.scala
@@ -349,7 +349,7 @@ object DistributionUninstaller {
   def default(globalCLIOptions: GlobalCLIOptions): DistributionUninstaller =
     new DistributionUninstaller(
       DefaultManagers.distributionManager,
-      DefaultManagers.DefaultResourceManager,
+      DefaultManagers.defaultResourceManager,
       globalCLIOptions
     )
 }

--- a/engine/launcher/src/main/scala/org/enso/launcher/releases/EnsoRepository.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/releases/EnsoRepository.scala
@@ -104,7 +104,7 @@ object EnsoRepository {
     FakeReleaseProvider(
       fakeRepositoryRoot,
       lockManagerForAssets =
-        if (shouldWaitForAssets) Some(DefaultManagers.DefaultFileLockManager)
+        if (shouldWaitForAssets) Some(DefaultManagers.defaultFileLockManager)
         else None
     )
 }

--- a/engine/launcher/src/main/scala/org/enso/launcher/upgrade/LauncherUpgrader.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/upgrade/LauncherUpgrader.scala
@@ -378,7 +378,7 @@ object LauncherUpgrader {
       globalCLIOptions,
       DefaultManagers.distributionManager,
       EnsoRepository.defaultLauncherReleaseProvider,
-      DefaultManagers.DefaultResourceManager,
+      DefaultManagers.defaultResourceManager,
       originalExecutablePath
     )
 

--- a/engine/launcher/src/test/scala/org/enso/launcher/NativeTest.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/NativeTest.scala
@@ -1,11 +1,9 @@
 package org.enso.launcher
 
-import java.io.{BufferedReader, IOException, InputStream, InputStreamReader}
-import java.lang.{ProcessBuilder => JProcessBuilder}
 import java.nio.file.{Files, Path}
-import java.util.concurrent.{Semaphore, TimeUnit}
 
 import org.enso.runtimeversionmanager.OS
+import org.enso.runtimeversionmanager.test.NativeTestHelper
 import org.scalatest.concurrent.{Signaler, TimeLimitedTests}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.{MatchResult, Matcher}
@@ -13,26 +11,17 @@ import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.collection.Factory
-import scala.concurrent.TimeoutException
-import scala.jdk.CollectionConverters._
-import scala.jdk.StreamConverters._
-
 /** Contains helper methods for creating tests that need to run the native
   * launcher binary.
   */
-trait NativeTest extends AnyWordSpec with Matchers with TimeLimitedTests {
+trait NativeTest
+    extends AnyWordSpec
+    with Matchers
+    with TimeLimitedTests
+    with NativeTestHelper {
 
   override val timeLimit: Span               = 60.seconds
   override val defaultTestSignaler: Signaler = _.interrupt()
-
-  /** A result of running the native launcher binary.
-    *
-    * @param exitCode the returned exit code
-    * @param stdout contents of the standard output stream
-    * @param stderr contents of the standard error stream
-    */
-  case class RunResult(exitCode: Int, stdout: String, stderr: String)
 
   object RunSuccessMatcher extends Matcher[RunResult] {
     override def apply(left: RunResult): MatchResult =
@@ -72,7 +61,7 @@ trait NativeTest extends AnyWordSpec with Matchers with TimeLimitedTests {
       )
     }
 
-    run(
+    runCommand(
       Seq(baseLauncherLocation.toAbsolutePath.toString) ++ args,
       extraEnv.toSeq
     )
@@ -97,7 +86,10 @@ trait NativeTest extends AnyWordSpec with Matchers with TimeLimitedTests {
       )
     }
 
-    run(Seq(pathToLauncher.toAbsolutePath.toString) ++ args, extraEnv.toSeq)
+    runCommand(
+      Seq(pathToLauncher.toAbsolutePath.toString) ++ args,
+      extraEnv.toSeq
+    )
   }
 
   /** Returns the expected location of the launcher binary compiled by the
@@ -137,223 +129,11 @@ trait NativeTest extends AnyWordSpec with Matchers with TimeLimitedTests {
     pathOverride: String
   ): RunResult = {
     val pathName = if (isWindows) "Path" else "PATH" // Note [Windows Path]
-    run(
+    runCommand(
       Seq(baseLauncherLocation.toAbsolutePath.toString) ++ args,
       Seq(pathName -> pathOverride)
     )
   }
-
-  /** Starts the provided `command`.
-    *
-    * `extraEnv` may be provided to extend the environment. Care must be taken
-    * on Windows where environment variables are (mostly) case-insensitive.
-    *
-    * If `waitForDescendants` is set, tries to wait for descendants of the
-    * launched process to finish too. Especially important on Windows where
-    * child processes may run after the launcher parent has been terminated.
-    */
-  def start(
-    command: Seq[String],
-    extraEnv: Seq[(String, String)]
-  ): WrappedProcess = {
-    val builder = new JProcessBuilder(command: _*)
-    val newKeys = extraEnv.map(_._1.toLowerCase)
-    if (newKeys.distinct.size < newKeys.size) {
-      throw new IllegalArgumentException(
-        "The extra environment keys have to be unique"
-      )
-    }
-
-    lazy val existingKeys =
-      builder.environment().keySet().asScala
-    for ((key, value) <- extraEnv) {
-      if (OS.isWindows) {
-        def shadows(key1: String, key2: String): Boolean =
-          key1.toLowerCase == key2.toLowerCase && key1 != key2
-
-        existingKeys.find(shadows(_, key)) match {
-          case Some(oldKey) =>
-            throw new IllegalArgumentException(
-              s"The environment key `$key` may be shadowed by `$oldKey` " +
-              s"already existing in the environment. Please use `$oldKey`."
-            )
-          case None =>
-        }
-      }
-      builder.environment().put(key, value)
-    }
-
-    try {
-      val process = builder.start()
-      new WrappedProcess(command, process)
-    } catch {
-      case e: Exception =>
-        throw new RuntimeException("Cannot run the Native Image binary", e)
-    }
-  }
-
-  class WrappedProcess(command: Seq[String], process: Process) {
-
-    private val outQueue =
-      new java.util.concurrent.LinkedTransferQueue[String]()
-    private val errQueue =
-      new java.util.concurrent.LinkedTransferQueue[String]()
-
-    sealed trait StreamType
-    case object StdErr extends StreamType
-    case object StdOut extends StreamType
-    @volatile private var ioHandlers: Seq[(String, StreamType) => Unit] = Seq()
-
-    def watchStream(
-      stream: InputStream,
-      streamType: StreamType
-    ): Unit = {
-      val reader       = new BufferedReader(new InputStreamReader(stream))
-      var line: String = null
-      val queue = streamType match {
-        case StdErr => errQueue
-        case StdOut => outQueue
-      }
-      try {
-        while ({ line = reader.readLine(); line != null }) {
-          queue.add(line)
-          ioHandlers.foreach(f => f(line, streamType))
-        }
-      } catch {
-        case _: InterruptedException =>
-        case _: IOException =>
-          ioHandlers.foreach(f => f("<Unexpected EOF>", streamType))
-      }
-    }
-
-    private val outThread = new Thread(() =>
-      watchStream(process.getInputStream, StdOut)
-    )
-    private val errThread = new Thread(() =>
-      watchStream(process.getErrorStream, StdErr)
-    )
-    outThread.start()
-    errThread.start()
-
-    /** Waits for a message on the stderr to appear.
-      */
-    def waitForMessageOnErrorStream(
-      message: String,
-      timeoutSeconds: Long
-    ): Unit = {
-      val semaphore = new Semaphore(0)
-      def handler(line: String, streamType: StreamType): Unit = {
-        if (streamType == StdErr && line.contains(message)) {
-          semaphore.release()
-        }
-      }
-
-      this.synchronized {
-        ioHandlers ++= Seq(handler _)
-      }
-
-      errQueue.asScala.toSeq.foreach(handler(_, StdErr))
-
-      val acquired = semaphore.tryAcquire(timeoutSeconds, TimeUnit.SECONDS)
-      if (!acquired) {
-        throw new TimeoutException(s"Waiting for `$message` timed out.")
-      }
-    }
-
-    /** Starts printing the stdout and stderr of the started process to the
-      * stdout with prefixes to indicate that these messages come from another
-      * process.
-      *
-      * It also prints lines that were printed before invoking this method.
-      * Thus, it is possible that a line may be printed twice (once as
-      * 'before-printIO' and once normally).
-      */
-    def printIO(): Unit = {
-      def handler(line: String, streamType: StreamType): Unit = {
-        val prefix = streamType match {
-          case StdErr => "stderr> "
-          case StdOut => "stdout> "
-        }
-        println(prefix + line)
-      }
-      this.synchronized {
-        ioHandlers ++= Seq(handler _)
-      }
-      outQueue.asScala.toSeq.foreach(line =>
-        println(s"stdout-before-printIO> $line")
-      )
-      errQueue.asScala.toSeq.foreach(line =>
-        println(s"stderr-before-printIO> $line")
-      )
-    }
-
-    /** Tries to kill the process immediately.
-      */
-    def kill(): Unit = {
-      process.destroyForcibly()
-    }
-
-    /** Waits for the process to finish and returns its [[RunResult]].
-      *
-      * If `waitForDescendants` is set, tries to wait for descendants of the
-      * launched process to finish too. Especially important on Windows where
-      * child processes may run after the launcher parent has been terminated.
-      *
-      * It will timeout after `timeoutSeconds` and try to kill the process (or
-      * its descendants), although it may not always be able to.
-      */
-    def join(
-      waitForDescendants: Boolean = true,
-      timeoutSeconds: Long        = 15
-    ): RunResult = {
-      var descendants: Seq[ProcessHandle] = Seq()
-      try {
-        val exitCode =
-          if (process.waitFor(timeoutSeconds, TimeUnit.SECONDS))
-            process.exitValue()
-          else throw new TimeoutException("Process timed out")
-        if (waitForDescendants) {
-          descendants =
-            process.descendants().toScala(Factory.arrayFactory).toSeq
-          descendants.foreach(_.onExit().get(timeoutSeconds, TimeUnit.SECONDS))
-        }
-        errThread.join(1000)
-        outThread.join(1000)
-        if (errThread.isAlive) {
-          errThread.interrupt()
-        }
-        if (outThread.isAlive) {
-          outThread.interrupt()
-        }
-        val stdout = outQueue.asScala.toSeq.mkString("\n")
-        val stderr = errQueue.asScala.toSeq.mkString("\n")
-        RunResult(exitCode, stdout, stderr)
-      } catch {
-        case e @ (_: InterruptedException | _: TimeoutException) =>
-          if (process.isAlive) {
-            println(s"Killing the timed-out process: ${command.mkString(" ")}")
-            process.destroyForcibly()
-          }
-          for (processHandle <- descendants) {
-            if (processHandle.isAlive) {
-              processHandle.destroyForcibly()
-            }
-          }
-          throw e
-      }
-    }
-  }
-
-  /** Runs the provided `command`.
-    *
-    * `extraEnv` may be provided to extend the environment. Care must be taken
-    * on Windows where environment variables are (mostly) case-insensitive.
-    */
-  private def run(
-    command: Seq[String],
-    extraEnv: Seq[(String, String)],
-    waitForDescendants: Boolean = true
-  ): RunResult = start(command, extraEnv).join(waitForDescendants)
 }
 
 /* Note [Windows Path]

--- a/engine/launcher/src/test/scala/org/enso/launcher/upgrade/UpgradeSpec.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/upgrade/UpgradeSpec.scala
@@ -9,6 +9,7 @@ import org.enso.runtimeversionmanager.FileSystem.PathSyntax
 import org.enso.launcher._
 import org.enso.runtimeversionmanager.locking.{FileLockManager, LockType}
 import org.enso.runtimeversionmanager.test.WithTemporaryDirectory
+import org.enso.testkit.RetrySpec
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.{BeforeAndAfterAll, OptionValues}
 
@@ -18,7 +19,8 @@ class UpgradeSpec
     extends NativeTest
     with WithTemporaryDirectory
     with BeforeAndAfterAll
-    with OptionValues {
+    with OptionValues
+    with RetrySpec {
 
   /** Location of the fake releases root.
     */
@@ -216,7 +218,7 @@ class UpgradeSpec
         .trim shouldEqual "Test license"
     }
 
-    "perform a multi-step upgrade if necessary" in {
+    "perform a multi-step upgrade if necessary" taggedAs Retry in {
       // 0.0.3 can only be upgraded from 0.0.2 which can only be upgraded from
       // 0.0.1, so the upgrade path should be following:
       // 0.0.0 -> 0.0.1 -> 0.0.2 -> 0.0.3
@@ -298,7 +300,7 @@ class UpgradeSpec
       result.stdout should include(message)
     }
 
-    "fail if another upgrade is running in parallel" in {
+    "fail if another upgrade is running in parallel" taggedAs Retry in {
       prepareDistribution(
         portable        = true,
         launcherVersion = Some(SemVer(0, 0, 1))

--- a/engine/launcher/src/test/scala/org/enso/launcher/upgrade/UpgradeSpec.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/upgrade/UpgradeSpec.scala
@@ -304,9 +304,8 @@ class UpgradeSpec
         launcherVersion = Some(SemVer(0, 0, 1))
       )
 
-      val syncLocker = new FileLockManager {
-        override def locksRoot: Path = getTestDirectory / "enso" / "lock"
-      }
+      val syncLocker = new FileLockManager(getTestDirectory / "enso" / "lock")
+
       val launcherManifestAssetName = "launcher-manifest.yaml"
       // The fake release tries to acquire a shared lock on each accessed file,
       // so acquiring this exclusive lock will stall access to that file until

--- a/lib/scala/locking-test-helper/src/main/scala/org/enso/runtimeversionmanager/test/Main.scala
+++ b/lib/scala/locking-test-helper/src/main/scala/org/enso/runtimeversionmanager/test/Main.scala
@@ -6,6 +6,15 @@ import java.nio.file.{Path, StandardOpenOption}
 import scala.io.StdIn
 
 object Main {
+
+  /** Entry-point for the helper application used by
+    * `runtime-version-manager-test` to test inter-process locking.
+    *
+    * It expects exactly one argument - path to the file that should be locked.
+    * It acquires a lock for this file and reports that the lock has been
+    * acquired to stderr. Afterwards, it waits for a new line in stdin and once
+    * it appears, it releases the lock and exits.
+    */
   def main(args: Array[String]): Unit = {
     args match {
       case Array(pathString) =>

--- a/lib/scala/locking-test-helper/src/main/scala/org/enso/runtimeversionmanager/test/Main.scala
+++ b/lib/scala/locking-test-helper/src/main/scala/org/enso/runtimeversionmanager/test/Main.scala
@@ -1,0 +1,36 @@
+package org.enso.runtimeversionmanager.test
+
+import java.nio.channels.FileChannel
+import java.nio.file.{Path, StandardOpenOption}
+
+import scala.io.StdIn
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    args match {
+      case Array(pathString) =>
+        try {
+          val lockfilePath = Path.of(pathString)
+          val channel = FileChannel.open(
+            lockfilePath,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.READ,
+            StandardOpenOption.WRITE
+          )
+          val shared = true
+          val lock   = channel.lock(0L, Long.MaxValue, shared)
+          System.err.println("Lock acquired")
+          StdIn.readLine()
+          lock.release()
+          System.exit(0)
+        } catch {
+          case throwable: Throwable =>
+            throwable.printStackTrace()
+            System.exit(1)
+        }
+      case _ =>
+        System.err.println("Invalid argument count")
+        System.exit(1)
+    }
+  }
+}

--- a/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/NativeTestHelper.scala
+++ b/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/NativeTestHelper.scala
@@ -17,6 +17,11 @@ import scala.concurrent.TimeoutException
 import scala.jdk.CollectionConverters._
 import scala.jdk.StreamConverters._
 
+/** A mix-in providing helper functions for running native commands in tests.
+  *
+  * It provides multiple ways to start a command, inspect its exit code and
+  * interact with its streams.
+  */
 trait NativeTestHelper {
 
   /** A result of running the native launcher binary.

--- a/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/NativeTestHelper.scala
+++ b/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/NativeTestHelper.scala
@@ -1,0 +1,256 @@
+package org.enso.runtimeversionmanager.test
+
+import java.io.{
+  BufferedReader,
+  IOException,
+  InputStream,
+  InputStreamReader,
+  PrintWriter
+}
+import java.util.concurrent.{Semaphore, TimeUnit}
+import java.lang.{ProcessBuilder => JProcessBuilder}
+
+import org.enso.runtimeversionmanager.OS
+
+import scala.collection.Factory
+import scala.concurrent.TimeoutException
+import scala.jdk.CollectionConverters._
+import scala.jdk.StreamConverters._
+
+trait NativeTestHelper {
+
+  /** A result of running the native launcher binary.
+    *
+    * @param exitCode the returned exit code
+    * @param stdout contents of the standard output stream
+    * @param stderr contents of the standard error stream
+    */
+  case class RunResult(exitCode: Int, stdout: String, stderr: String)
+
+  /** Starts the provided `command`.
+    *
+    * `extraEnv` may be provided to extend the environment. Care must be taken
+    * on Windows where environment variables are (mostly) case-insensitive.
+    *
+    * If `waitForDescendants` is set, tries to wait for descendants of the
+    * launched process to finish too. Especially important on Windows where
+    * child processes may run after the launcher parent has been terminated.
+    */
+  def start(
+    command: Seq[String],
+    extraEnv: Seq[(String, String)]
+  ): WrappedProcess = {
+    val builder = new JProcessBuilder(command: _*)
+    val newKeys = extraEnv.map(_._1.toLowerCase)
+    if (newKeys.distinct.size < newKeys.size) {
+      throw new IllegalArgumentException(
+        "The extra environment keys have to be unique"
+      )
+    }
+
+    lazy val existingKeys =
+      builder.environment().keySet().asScala
+    for ((key, value) <- extraEnv) {
+      if (OS.isWindows) {
+        def shadows(key1: String, key2: String): Boolean =
+          key1.toLowerCase == key2.toLowerCase && key1 != key2
+
+        existingKeys.find(shadows(_, key)) match {
+          case Some(oldKey) =>
+            throw new IllegalArgumentException(
+              s"The environment key `$key` may be shadowed by `$oldKey` " +
+              s"already existing in the environment. Please use `$oldKey`."
+            )
+          case None =>
+        }
+      }
+      builder.environment().put(key, value)
+    }
+
+    try {
+      val process = builder.start()
+      new WrappedProcess(command, process)
+    } catch {
+      case e: Exception =>
+        throw new RuntimeException("Cannot run the Native Image binary", e)
+    }
+  }
+
+  /** Represents a started and possibly running process. */
+  class WrappedProcess(command: Seq[String], process: Process) {
+
+    private val outQueue =
+      new java.util.concurrent.LinkedTransferQueue[String]()
+    private val errQueue =
+      new java.util.concurrent.LinkedTransferQueue[String]()
+
+    sealed trait StreamType
+    case object StdErr extends StreamType
+    case object StdOut extends StreamType
+    @volatile private var ioHandlers: Seq[(String, StreamType) => Unit] = Seq()
+
+    private def watchStream(
+      stream: InputStream,
+      streamType: StreamType
+    ): Unit = {
+      val reader       = new BufferedReader(new InputStreamReader(stream))
+      var line: String = null
+      val queue = streamType match {
+        case StdErr => errQueue
+        case StdOut => outQueue
+      }
+      try {
+        while ({ line = reader.readLine(); line != null }) {
+          queue.add(line)
+          ioHandlers.foreach(f => f(line, streamType))
+        }
+      } catch {
+        case _: InterruptedException =>
+        case _: IOException =>
+          ioHandlers.foreach(f => f("<Unexpected EOF>", streamType))
+      }
+    }
+
+    private val outThread = new Thread(() =>
+      watchStream(process.getInputStream, StdOut)
+    )
+    private val errThread = new Thread(() =>
+      watchStream(process.getErrorStream, StdErr)
+    )
+    outThread.start()
+    errThread.start()
+
+    /** Waits for a message on the stderr to appear. */
+    def waitForMessageOnErrorStream(
+      message: String,
+      timeoutSeconds: Long
+    ): Unit = {
+      val semaphore = new Semaphore(0)
+      def handler(line: String, streamType: StreamType): Unit = {
+        if (streamType == StdErr && line.contains(message)) {
+          semaphore.release()
+        }
+      }
+
+      this.synchronized {
+        ioHandlers ++= Seq(handler _)
+      }
+
+      errQueue.asScala.toSeq.foreach(handler(_, StdErr))
+
+      val acquired = semaphore.tryAcquire(timeoutSeconds, TimeUnit.SECONDS)
+      if (!acquired) {
+        throw new TimeoutException(s"Waiting for `$message` timed out.")
+      }
+    }
+
+    private lazy val inputWriter = new PrintWriter(process.getOutputStream)
+
+    /** Prints a message to the standard input stream of the process.
+      *
+      * Does not append any newlines, so if a newline is expected, it has to be
+      * contained within the `message`.
+      */
+    def sendToInputStream(message: String): Unit = {
+      inputWriter.print(message)
+      inputWriter.flush()
+    }
+
+    /** Starts printing the stdout and stderr of the started process to the
+      * stdout with prefixes to indicate that these messages come from another
+      * process.
+      *
+      * It also prints lines that were printed before invoking this method.
+      * Thus, it is possible that a line may be printed twice (once as
+      * 'before-printIO' and once normally).
+      */
+    def printIO(): Unit = {
+      def handler(line: String, streamType: StreamType): Unit = {
+        val prefix = streamType match {
+          case StdErr => "stderr> "
+          case StdOut => "stdout> "
+        }
+        println(prefix + line)
+      }
+      this.synchronized {
+        ioHandlers ++= Seq(handler _)
+      }
+      outQueue.asScala.toSeq.foreach(line =>
+        println(s"stdout-before-printIO> $line")
+      )
+      errQueue.asScala.toSeq.foreach(line =>
+        println(s"stderr-before-printIO> $line")
+      )
+    }
+
+    /** Checks if the process is still running. */
+    def isAlive: Boolean = process.isAlive
+
+    /** Tries to kill the process immediately. */
+    def kill(): Unit = {
+      process.destroyForcibly()
+    }
+
+    /** Waits for the process to finish and returns its [[RunResult]].
+      *
+      * If `waitForDescendants` is set, tries to wait for descendants of the
+      * launched process to finish too. Especially important on Windows where
+      * child processes may run after the launcher parent has been terminated.
+      *
+      * It will timeout after `timeoutSeconds` and try to kill the process (or
+      * its descendants), although it may not always be able to.
+      */
+    def join(
+      waitForDescendants: Boolean = true,
+      timeoutSeconds: Long        = 15
+    ): RunResult = {
+      var descendants: Seq[ProcessHandle] = Seq()
+      try {
+        val exitCode =
+          if (process.waitFor(timeoutSeconds, TimeUnit.SECONDS))
+            process.exitValue()
+          else throw new TimeoutException("Process timed out")
+        if (waitForDescendants) {
+          descendants =
+            process.descendants().toScala(Factory.arrayFactory).toSeq
+          descendants.foreach(_.onExit().get(timeoutSeconds, TimeUnit.SECONDS))
+        }
+        errThread.join(1000)
+        outThread.join(1000)
+        if (errThread.isAlive) {
+          errThread.interrupt()
+        }
+        if (outThread.isAlive) {
+          outThread.interrupt()
+        }
+        val stdout = outQueue.asScala.toSeq.mkString("\n")
+        val stderr = errQueue.asScala.toSeq.mkString("\n")
+        RunResult(exitCode, stdout, stderr)
+      } catch {
+        case e @ (_: InterruptedException | _: TimeoutException) =>
+          if (process.isAlive) {
+            println(s"Killing the timed-out process: ${command.mkString(" ")}")
+            process.destroyForcibly()
+          }
+          for (processHandle <- descendants) {
+            if (processHandle.isAlive) {
+              processHandle.destroyForcibly()
+            }
+          }
+          throw e
+      }
+    }
+  }
+
+  /** Runs the provided `command`.
+    *
+    * `extraEnv` may be provided to extend the environment. Care must be taken
+    * on Windows where environment variables are (mostly) case-insensitive.
+    */
+  def runCommand(
+    command: Seq[String],
+    extraEnv: Seq[(String, String)],
+    waitForDescendants: Boolean = true
+  ): RunResult = start(command, extraEnv).join(waitForDescendants)
+
+}

--- a/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/TestSynchronizer.scala
+++ b/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/TestSynchronizer.scala
@@ -74,8 +74,7 @@ class TestSynchronizer {
     getSemaphore(event).release()
   }
 
-  /** Timeout used by [[waitFor]].
-    */
+  /** Timeout of variouse blocking operations. */
   val timeOutSeconds: Long = 20
 
   /** Reports that the event has happened now.

--- a/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/TestSynchronizer.scala
+++ b/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/TestSynchronizer.scala
@@ -48,7 +48,10 @@ class TestSynchronizer {
     val acquired =
       getSemaphore(event).tryAcquire(timeOutSeconds, TimeUnit.SECONDS)
     if (!acquired) {
-      throw new RuntimeException(s"$threadName waitFor($event) has timed out.")
+      throw new TestFailedException(
+        s"$threadName waitFor($event) has timed out.",
+        1
+      )
     }
     if (enableDebugOutput) {
       System.err.println(s"$threadName has been woken up by $event.")

--- a/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManagerSpec.scala
+++ b/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManagerSpec.scala
@@ -10,7 +10,7 @@ import org.enso.runtimeversionmanager.test.{
 
 class RuntimeVersionManagerSpec extends RuntimeVersionManagerTest {
 
-  "ComponentManager" should {
+  "RuntimeVersionManager" should {
     "find the latest engine version in semver ordering " +
     "(skipping broken releases)" in {
       val componentsManager = makeRuntimeVersionManager()

--- a/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ConcurrencyTest.scala
+++ b/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ConcurrencyTest.scala
@@ -64,9 +64,7 @@ class ConcurrencyTest
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    testLocalLockManager = Some(
-      new ThreadSafeFileLockManager(getTestDirectory.resolve("test-locks"))
-    )
+    testLocalLockManager = Some(new TestLocalLockManager)
   }
 
   /** A separate [[LockManager]] for each test case. */

--- a/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ConcurrencyTest.scala
+++ b/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ConcurrencyTest.scala
@@ -40,7 +40,7 @@ class ConcurrencyTest
     with DropLogs
     with TimeLimitedTests {
 
-  val timeLimit: Span = 30.seconds
+  val timeLimit: Span = 120.seconds
 
   case class WrapEngineRelease(
     originalRelease: EngineRelease,
@@ -58,6 +58,10 @@ class ConcurrencyTest
       callback(packageFileName)
       originalRelease.downloadPackage(destination)
     }
+  }
+
+  class SlowTestSynchronizer extends TestSynchronizer {
+    override val timeOutSeconds: Long = 90
   }
 
   var testLocalLockManager: Option[LockManager] = None
@@ -172,7 +176,7 @@ class ConcurrencyTest
         * startup, but only if it is safe to do so (so other processes are not
         * using it).
         */
-      val sync = new TestSynchronizer
+      val sync = new SlowTestSynchronizer
 
       val engine1 = SemVer(0, 0, 1)
       val engine2 = engine1.withPreRelease("pre")
@@ -238,7 +242,7 @@ class ConcurrencyTest
         * downloading the package. The second thread then tries to use it, but
         * it should wait until the installation is finished.
         */
-      val sync = new TestSynchronizer
+      val sync = new SlowTestSynchronizer
 
       val engineVersion = SemVer(0, 0, 1)
 
@@ -296,7 +300,7 @@ class ConcurrencyTest
         * another thread starts uninstalling it. The second thread has to wait
         * with uninstalling until the first one finishes using it.
         */
-      val sync = new TestSynchronizer
+      val sync = new SlowTestSynchronizer
 
       val engineVersion = SemVer(0, 0, 1)
 
@@ -355,7 +359,7 @@ class ConcurrencyTest
         * the two threads finish and after that the third one is able to acquire
         * the exclusive lock.
         */
-      val sync = new TestSynchronizer
+      val sync = new SlowTestSynchronizer
       sync.startThread("t1") {
         val resourceManager = makeNewResourceManager()
         resourceManager.initializeMainLock()

--- a/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ConcurrencyTest.scala
+++ b/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ConcurrencyTest.scala
@@ -64,7 +64,9 @@ class ConcurrencyTest
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    testLocalLockManager = Some(new TestLocalLockManager)
+    testLocalLockManager = Some(
+      new ThreadSafeFileLockManager(getTestDirectory.resolve("test-locks"))
+    )
   }
 
   /** A separate [[LockManager]] for each test case. */

--- a/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ThreadSafeFileLockManagerTest.scala
+++ b/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ThreadSafeFileLockManagerTest.scala
@@ -190,8 +190,8 @@ class ThreadSafeFileLockManagerTest
     }
 
     "handle distinct resources independently" in {
-      val r1 = lockManager.acquireLock("resource1", LockType.Shared)
-      val r2 = lockManager.acquireLock("resource2", LockType.Shared)
+      val r1 = lockManager.acquireLock("resource1", LockType.Exclusive)
+      val r2 = lockManager.acquireLock("resource2", LockType.Exclusive)
       r1.release()
       r2.release()
     }

--- a/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ThreadSafeFileLockManagerTest.scala
+++ b/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ThreadSafeFileLockManagerTest.scala
@@ -1,5 +1,7 @@
 package org.enso.runtimeversionmanager.locking
 
+import java.nio.file.Path
+
 import org.enso.runtimeversionmanager.test.{
   NativeTestHelper,
   TestSynchronizer,
@@ -22,10 +24,42 @@ class ThreadSafeFileLockManagerTest
 
   val timeLimit: Span = 30.seconds
 
-  private var testLocalLockManager: Option[ThreadSafeFileLockManager] = None
+  class TestableThreadSafeFileLockManager(locksRoot: Path)
+      extends ThreadSafeFileLockManager(locksRoot) {
+
+    /** A helper function that can be called by the test suite to release all file locks.
+      *
+      * It is only safe to call this function if it can be guaranteed that no
+      * locks created with this manager are still in scope.
+      *
+      * Normally all file locks are released automatically when the JVM exits,
+      * but as tests run within a single JVM,this is not the case and any
+      * dangling locks will cause problems when cleaning the temporary
+      * directory.
+      */
+    def releaseAllLocks(): Unit = {
+      localLocks.foreach { case (_, lock) =>
+        lock.fileLock.foreach(_.release())
+        lock.fileLock = None
+      }
+      localLocks.clear()
+    }
+  }
+
+  private var testLocalLockManager: Option[TestableThreadSafeFileLockManager] =
+    None
+
   override def beforeEach(): Unit = {
     super.beforeEach()
-    testLocalLockManager = Some(new ThreadSafeFileLockManager(getTestDirectory))
+    testLocalLockManager = Some(
+      new TestableThreadSafeFileLockManager(getTestDirectory)
+    )
+  }
+
+  override def afterEach(): Unit = {
+    testLocalLockManager.foreach(_.releaseAllLocks())
+    testLocalLockManager = None
+    super.afterEach()
   }
 
   def lockManager: ThreadSafeFileLockManager = testLocalLockManager.getOrElse(

--- a/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ThreadSafeFileLockManagerTest.scala
+++ b/lib/scala/runtime-version-manager-test/src/test/scala/org/enso/runtimeversionmanager/locking/ThreadSafeFileLockManagerTest.scala
@@ -1,0 +1,227 @@
+package org.enso.runtimeversionmanager.locking
+
+import java.lang.ProcessBuilder.Redirect
+import java.util.concurrent.TimeUnit
+
+import org.enso.runtimeversionmanager.test.{
+  TestSynchronizer,
+  WithTemporaryDirectory
+}
+import org.enso.testkit.OsSpec
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+import org.scalatest.wordspec.AnyWordSpec
+
+class ThreadSafeFileLockManagerTest
+    extends AnyWordSpec
+    with Matchers
+    with WithTemporaryDirectory
+    with TimeLimitedTests
+    with OptionValues
+    with OsSpec {
+
+  val timeLimit: Span = 30.seconds
+
+  private var testLocalLockManager: Option[ThreadSafeFileLockManager] = None
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    testLocalLockManager = Some(new ThreadSafeFileLockManager(getTestDirectory))
+  }
+
+  def lockManager: ThreadSafeFileLockManager = testLocalLockManager.getOrElse(
+    throw new IllegalStateException("Test not initialized")
+  )
+
+  "ThreadSafeFileLockManager" should {
+    "allow multiple concurrent shared locks" in {
+      val name = "resource1"
+      val r1   = lockManager.acquireLock(name, LockType.Shared)
+      val r2   = lockManager.acquireLock(name, LockType.Shared)
+      r1.release()
+      r2.release()
+    }
+
+    "allow no other locks if an exclusive lock is held" in {
+      val sync     = new TestSynchronizer
+      val name     = "resource1"
+      val mainLock = lockManager.acquireLock(name, LockType.Exclusive)
+      sync.report("acquired main")
+
+      sync.startThread("exclusive") {
+        lockManager.tryAcquireLock(name, LockType.Exclusive) shouldEqual None
+        sync.signal("exclusive-waited")
+        val lock = lockManager.acquireLock(name, LockType.Exclusive)
+        sync.report("acquired")
+        lock.release()
+      }
+
+      sync.startThread("shared") {
+        lockManager.tryAcquireLock(name, LockType.Shared) shouldEqual None
+        sync.signal("shared-waited")
+        val lock = lockManager.acquireLock(name, LockType.Shared)
+        sync.report("acquired")
+        lock.release()
+      }
+
+      sync.waitFor("exclusive-waited")
+      sync.waitFor("shared-waited")
+
+      sync.report("releasing main")
+      mainLock.release()
+
+      sync.join(5)
+      sync.summarizeReports() shouldEqual Seq(
+        "acquired main",
+        "releasing main",
+        "acquired",
+        "acquired"
+      )
+    }
+
+    "allow exclusive lock only when no shared locks are held" in {
+      val sync    = new TestSynchronizer
+      val name    = "resource1"
+      val shared1 = lockManager.acquireLock(name, LockType.Shared)
+
+      sync.startThread("exclusive") {
+        lockManager.tryAcquireLock(name, LockType.Exclusive) shouldEqual None
+        sync.signal("waited")
+        val lock = lockManager.acquireLock(name, LockType.Exclusive)
+        sync.report("acquired")
+        lock.release()
+      }
+
+      sync.waitFor("waited")
+
+      val shared2 = lockManager.acquireLock(name, LockType.Shared)
+      lockManager.acquireLock(name, LockType.Shared).release()
+      sync.report("releasing-some")
+      shared1.release()
+
+      sync.report("releasing-last-one")
+
+      shared2.release()
+
+      sync.join(5)
+      sync.summarizeReports() shouldEqual Seq(
+        "releasing-some",
+        "releasing-last-one",
+        "acquired"
+      )
+
+    }
+
+    "immediately resolve failed shared tryAcquire" in {
+      val name = "resource1"
+      lockManager.tryAcquireLock(name, LockType.Exclusive).value
+      lockManager.tryAcquireLock(name, LockType.Shared) shouldEqual None
+    }
+
+    "immediately resolve failed exclusive tryAcquire" in {
+      val name = "resource1"
+      lockManager.tryAcquireLock(name, LockType.Exclusive).value
+      lockManager.tryAcquireLock(name, LockType.Exclusive) shouldEqual None
+    }
+
+    /** TODO [RW] document
+      */
+    "immediately fail try* if waiting for another process" taggedAs OsLinux in {
+      val sync = new TestSynchronizer
+
+      val name = "resource1"
+      val lockFilePath = FileLockManager
+        .lockPath(getTestDirectory, name)
+        .toAbsolutePath
+        .normalize
+      println(lockFilePath)
+      val otherProcess = {
+        // FIXME [RW] flock does not have to work as it has a different
+        //  underlying mechanism from Java's FileLock which uses fcntl
+        val pb = new ProcessBuilder(
+          "flock",
+          "--shared",
+          "--nonblock",
+          lockFilePath.toString,
+          "-c",
+          "cat"
+        )
+        pb.redirectInput(Redirect.PIPE)
+        println(pb.command())
+        pb.start()
+      }
+
+      try {
+        Thread.sleep(200) // we need to ensure that flock has started already
+
+        otherProcess.getOutputStream.close()
+        println(otherProcess.waitFor())
+
+        sync.startThread("exclusive-waiting") {
+          assert(
+            otherProcess.isAlive,
+            "Other process should have acquired lock successfully and be waiting"
+          )
+          println("tryin to acquire")
+          withClue(
+            "The exclusive lock should not be acquired immediately as the " +
+            "other process is holding a shared lock."
+          ) {
+            lockManager.tryAcquireLock(
+              name,
+              LockType.Exclusive
+            ) shouldEqual None
+          }
+          println("well we treid")
+          sync.signal("waited")
+          val lock = lockManager.acquireLock(name, LockType.Exclusive)
+          sync.report("exclusive-acquired")
+          lock.release()
+        }
+
+        sync.waitFor("waited")
+        Thread.sleep(200) // ensure that our thread has started waiting
+
+        /** This would normally succeed, but the [[lockManager]] is busy waiting
+          * for the exclusive lock, so it should fail.
+          *
+          * If it succeeds, that means that the sleep above was too short and that
+          * the exclusive lock did not start waiting yet. Or alternatively, that
+          * it was already acquired and released but that is later checked by
+          * ensuring correct order of event reports.
+          */
+        lockManager.tryAcquireLock(name, LockType.Shared) shouldEqual None
+
+        sync.report("try-acquire-was-busy")
+
+        otherProcess.getOutputStream
+          .close() // by closing the stream, we ensure that the `cat` finishes
+
+        assert(
+          otherProcess.waitFor(2, TimeUnit.SECONDS),
+          "The flock process should terminate quickly"
+        )
+        withClue("The flock process should succeed") {
+          otherProcess.waitFor() shouldEqual 0
+        }
+
+        sync.join()
+        sync.summarizeReports() shouldEqual Seq(
+          "try-acquire-was-busy",
+          "exclusive-acquired"
+        )
+      } finally {
+        otherProcess.destroy()
+      }
+    }
+
+    "handle distinct resources independently" in {
+      val r1 = lockManager.acquireLock("resource1", LockType.Shared)
+      val r2 = lockManager.acquireLock("resource2", LockType.Shared)
+      r1.release()
+      r2.release()
+    }
+  }
+}

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/locking/FileLockManager.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/locking/FileLockManager.scala
@@ -59,10 +59,11 @@ class FileLockManager(locksRoot: Path) extends LockManager {
     }
 
   private def lockPath(resourceName: String): Path =
-    locksRoot.resolve(resourceName + ".lock")
+    FileLockManager.lockPath(locksRoot, resourceName)
 
   private def openChannel(resourceName: String): FileChannel = {
-    val path   = lockPath(resourceName)
+    val path = lockPath(resourceName)
+    println(s"channel ${path.toAbsolutePath.normalize()}")
     val parent = path.getParent
     if (!Files.exists(parent)) {
       try Files.createDirectories(parent)
@@ -112,4 +113,9 @@ class FileLockManager(locksRoot: Path) extends LockManager {
       channel.close()
     }
   }
+}
+
+object FileLockManager {
+  def lockPath(locksRoot: Path, resourceName: String): Path =
+    locksRoot.resolve(resourceName + ".lock")
 }

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/locking/FileLockManager.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/locking/FileLockManager.scala
@@ -20,15 +20,12 @@ import scala.util.control.NonFatal
   * currently support (Linux, macOS, Windows), do support shared locks, so this
   * should not be an issue for us. However, if a shared lock request returns an
   * exclusive lock, a warning is issued, just in case.
+  *
+  * @param locksRoot the directory in which lockfiles should be kept
   */
-abstract class FileLockManager extends LockManager {
+class FileLockManager(locksRoot: Path) extends LockManager {
 
-  /** Specifies the directory in which lockfiles should be created.
-    */
-  def locksRoot: Path
-
-  /** @inheritdoc
-    */
+  /** @inheritdoc */
   override def acquireLock(resourceName: String, lockType: LockType): Lock = {
     val channel = openChannel(resourceName)
     try {
@@ -40,8 +37,7 @@ abstract class FileLockManager extends LockManager {
     }
   }
 
-  /** @inheritdoc
-    */
+  /** @inheritdoc */
   override def tryAcquireLock(
     resourceName: String,
     lockType: LockType

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/locking/FileLockManager.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/locking/FileLockManager.scala
@@ -62,8 +62,7 @@ class FileLockManager(locksRoot: Path) extends LockManager {
     FileLockManager.lockPath(locksRoot, resourceName)
 
   private def openChannel(resourceName: String): FileChannel = {
-    val path = lockPath(resourceName)
-    println(s"channel ${path.toAbsolutePath.normalize()}")
+    val path   = lockPath(resourceName)
     val parent = path.getParent
     if (!Files.exists(parent)) {
       try Files.createDirectories(parent)

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/locking/ThreadSafeFileLockManager.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/locking/ThreadSafeFileLockManager.scala
@@ -1,0 +1,255 @@
+package org.enso.runtimeversionmanager.locking
+
+import java.nio.file.Path
+
+/** A class that allows to manage locks which synchronize access both between
+  * different processes and threads of the current process.
+  *
+  * It does not have as strong fairness guarantees as [[FileLockManager]], for
+  * example, when other processes are holding a shared lock on a resource and
+  * the current process tries to acquire an exclusive lock, other threads of the
+  * current process will not be able to acquire even shared locks until this
+  * other threads acquires and then releases its writer lock (they will wait for
+  * it).
+  *
+  * This weak-fairness issue should not be problematic as it only happens when
+  * the same process tries to acquire an exclusive and shared lock for the same
+  * resource. This can happen in two kinds of situations:
+  * - a short update (updating the config)
+  * - a long running operation (install/uninstall a component).
+  * In the first case, both reads and writes are short, so scheduling them is
+  * not an issue because the wait time will be marginal anyway. In the second
+  * case, opening a project while another thread is trying to uninstall the
+  * engine (and actively waiting for other processes), will wait until that
+  * completes and fail or try to install it again. But that is only the case if
+  * a single process both requests the uninstall of an engine and opening a
+  * project with the same engine, which from the user's perspective is extremely
+  * unlikely (why uninstall an engine and at the same time try to open a project
+  * using it).
+  *
+  * @param locksRoot the directory in which lockfiles should be kept
+  */
+class ThreadSafeFileLockManager(locksRoot: Path) extends LockManager {
+  private val fileLockManager = new FileLockManager(locksRoot)
+  private val localLocks =
+    collection.concurrent.TrieMap.empty[String, ThreadSafeLock]
+
+  /** A thread-safe wrapper for a file lock - ensures that the process holds at
+    * most one file lock for the file, but it can be shared by multiple threads
+    * which are properly synchronized.
+    *
+    * The structure maintains the following invariants:
+    * - either writers or readers can be nonzero, but never both at the same
+    *   time
+    * - there can be at most 1 writer
+    * - the fileLock is Some iff writers + readers > 0
+    * - waiting means that one of the threads is waiting to acquire the proper
+    *   file lock
+    * - any `try` operations should fail if waiting is set to true
+    * - busy == true implies readers + writers == 0
+    *   - because the writer lock is only tried to be acquired if
+    *     readers + writers == 0
+    *   - and the reader filelock is only tried to be acquired if readers == 0
+    *    (and writers == 0), as if readers > 0, the filelock is already held
+    *   - conversely, readers + writers > 0 implies busy == false
+    * - any thread entering the monitor should exit or start waiting immediately
+    *   if it encounters busy == true
+    *
+    * The purpose of the busy bit is to avoid long blocking the monitor while
+    * waiting to acquire the actual file lock, as to guarantee
+    * [[tryAcquireLock]] returning without blocking.
+    */
+  private class ThreadSafeLock(name: String) { self =>
+    var busy: Boolean          = false
+    var writers: Int           = 0
+    var readers: Int           = 0
+    var fileLock: Option[Lock] = None
+
+    /** Decrements the reader count and releases the lock if it was the last
+      * reader.
+      *
+      * Should be called at most once by each reader.
+      */
+    def releaseReader(): Unit = this.synchronized {
+      assert(readers > 0)
+      assert(!busy)
+      readers -= 1
+      if (readers == 0) {
+        fileLock.get.release()
+        fileLock = None
+      }
+
+      this.notifyAll()
+    }
+
+    /** Decrements the writer count and releases the exclusive lock.
+      *
+      * Should be called at most once by each writer.
+      */
+    def releaseWriter(): Unit = this.synchronized {
+      assert(writers == 1)
+      assert(!busy)
+      writers -= 1
+      fileLock.get.release()
+      fileLock = None
+
+      this.notifyAll()
+    }
+
+    /** Tries to acquire the exclusive lock, succeeding immediately if no one
+      * else is using the resource.
+      */
+    def tryAcquireWriter(): Option[Lock] = this.synchronized {
+      if (!busy && readers == 0 && writers == 0) {
+        fileLock = fileLockManager.tryAcquireLock(name, LockType.Exclusive)
+        if (fileLock.isDefined) {
+          writers += 1
+          Some(new WriterReleaser)
+        } else None
+      } else None
+    }
+
+    /** Tries to acquire the shared lock, succeeding immediately if no one
+      * else is using the resource.
+      */
+    def tryAcquireReader(): Option[Lock] = this.synchronized {
+      if (!busy && writers == 0) {
+        val noOtherReaders = readers == 0
+        if (noOtherReaders) {
+          fileLock = fileLockManager.tryAcquireLock(name, LockType.Shared)
+        }
+
+        if (fileLock.isDefined) {
+          readers += 1
+          Some(new ReaderReleaser)
+        } else None
+
+      } else None
+    }
+
+    /** Acquires an exclusive lock.
+      *
+      * First waits until no other threads are busy or holding any locks. It
+      * sets the busy bit and releases the monitor (so that tryAcquire will be
+      * able to enter it and fail immediately seeing the busy bit, instead of
+      * waiting). After acquiring the file lock (which may take some time as
+      * other processes may also be holding it), the busy bit is cleared and
+      * writer count updated.
+      */
+    def acquireWriter(): Lock = {
+      this.synchronized {
+        while (busy || (readers + writers) > 0) {
+          this.wait()
+        }
+        assert(!busy)
+        assert(readers + writers == 0)
+        busy = true
+      }
+
+      val lock = fileLockManager.acquireLock(name, LockType.Exclusive)
+      this.synchronized {
+        assert(busy)
+        assert(readers + writers == 0)
+        busy = false
+        writers += 1
+        fileLock = Some(lock)
+        new WriterReleaser
+      }
+    }
+
+    /** Acquires a shared lock.
+      *
+      * First waits until no other threads are busy or holding writer locks. If
+      * any other threads already hold a reader lock, it means that the file
+      * lock is already held, so we can just increase the counter and return
+      * immediately. Otherwise, we set the busy bit and release the monitor,
+      * similarly as in [[acquireWriter]]. Once the actual file lock is
+      * acquired, we update the reader count and clear the busy bit.
+      */
+    def acquireReader(): Lock = {
+      this.synchronized {
+        while (busy || writers > 0) {
+          this.wait()
+        }
+        assert(!busy)
+        assert(writers == 0)
+
+        if (readers > 0) {
+          readers += 1
+          return new ReaderReleaser
+        } else {
+          busy = true
+        }
+      }
+
+      val lock = fileLockManager.acquireLock(name, LockType.Shared)
+      this.synchronized {
+        assert(busy)
+        assert(readers + writers == 0)
+        busy = false
+        readers += 1
+        fileLock = Some(lock)
+        new ReaderReleaser
+      }
+    }
+
+    private class WriterReleaser extends ReleaseOnceLockWrapper {
+      override protected def doRelease(): Unit = self.releaseWriter()
+    }
+
+    private class ReaderReleaser extends ReleaseOnceLockWrapper {
+      override protected def doRelease(): Unit = self.releaseReader()
+    }
+  }
+
+  /** A simple wrapper that ensures that the lock is released at most once.
+    *
+    * This is to ensure the invariants of [[ThreadSafeLock]].
+    */
+  abstract private class ReleaseOnceLockWrapper extends Lock {
+
+    /** Perform the actual release. */
+    protected def doRelease(): Unit
+
+    private var released: Boolean = false
+
+    /** @inheritdoc */
+    override def release(): Unit = this.synchronized {
+      if (!released) {
+        doRelease()
+        released = true
+      }
+    }
+  }
+
+  /** Returns a unique lock used for synchronizing the resource with the given
+    * name.
+    *
+    * Locks are never removed, even if no threads are using them anymore, but
+    * the amount of resources that we use is very small so this is not a
+    * problem.
+    */
+  private def getLock(name: String): ThreadSafeLock =
+    localLocks.getOrElseUpdate(name, new ThreadSafeLock(name))
+
+  /** @inheritdoc */
+  override def acquireLock(resourceName: String, lockType: LockType): Lock = {
+    val lock = getLock(resourceName)
+    lockType match {
+      case LockType.Exclusive => lock.acquireWriter()
+      case LockType.Shared    => lock.acquireReader()
+    }
+  }
+
+  /** @inheritdoc */
+  override def tryAcquireLock(
+    resourceName: String,
+    lockType: LockType
+  ): Option[Lock] = {
+    val lock = getLock(resourceName)
+    lockType match {
+      case LockType.Exclusive => lock.tryAcquireWriter()
+      case LockType.Shared    => lock.tryAcquireReader()
+    }
+  }
+}

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/locking/ThreadSafeFileLockManager.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/locking/ThreadSafeFileLockManager.scala
@@ -30,8 +30,8 @@ import java.nio.file.Path
   * @param locksRoot the directory in which lockfiles should be kept
   */
 class ThreadSafeFileLockManager(locksRoot: Path) extends LockManager {
-  private val fileLockManager = new FileLockManager(locksRoot)
-  private val localLocks =
+  val fileLockManager = new FileLockManager(locksRoot)
+  val localLocks =
     collection.concurrent.TrieMap.empty[String, ThreadSafeLock]
 
   /** A thread-safe wrapper for a file lock - ensures that the process holds at
@@ -60,7 +60,7 @@ class ThreadSafeFileLockManager(locksRoot: Path) extends LockManager {
     * waiting to acquire the actual file lock, to guarantee [[tryAcquireLock]]
     * returning without blocking.
     */
-  private class ThreadSafeLock(name: String) { self =>
+  class ThreadSafeLock(name: String) { self =>
     var busy: Boolean          = false
     var writers: Int           = 0
     var readers: Int           = 0

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/releases/testing/FakeReleaseProvider.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/releases/testing/FakeReleaseProvider.scala
@@ -3,7 +3,7 @@ package org.enso.runtimeversionmanager.releases.testing
 import java.nio.file.{Files, Path, StandardCopyOption}
 
 import org.enso.cli.{ProgressListener, TaskProgress}
-import org.enso.runtimeversionmanager.locking.{FileLockManager, LockType}
+import org.enso.runtimeversionmanager.locking.{LockManager, LockType}
 import org.enso.runtimeversionmanager.releases.{
   Asset,
   Release,
@@ -27,8 +27,8 @@ import scala.util.{Success, Try, Using}
   */
 case class FakeReleaseProvider(
   releasesRoot: Path,
-  copyIntoArchiveRoot: Seq[String]              = Seq.empty,
-  lockManagerForAssets: Option[FileLockManager] = None
+  copyIntoArchiveRoot: Seq[String]          = Seq.empty,
+  lockManagerForAssets: Option[LockManager] = None
 ) extends SimpleReleaseProvider {
 
   private val releases =
@@ -56,8 +56,8 @@ case class FakeReleaseProvider(
   */
 case class FakeRelease(
   path: Path,
-  copyIntoArchiveRoot: Seq[String]              = Seq.empty,
-  lockManagerForAssets: Option[FileLockManager] = None
+  copyIntoArchiveRoot: Seq[String]          = Seq.empty,
+  lockManagerForAssets: Option[LockManager] = None
 ) extends Release {
 
   /** @inheritdoc
@@ -88,7 +88,7 @@ case class FakeRelease(
 case class FakeAsset(
   source: Path,
   pathsToCopy: Seq[Path],
-  lockManagerForAssets: Option[FileLockManager] = None
+  lockManagerForAssets: Option[LockManager] = None
 ) extends Asset {
 
   /** @inheritdoc
@@ -124,9 +124,7 @@ case class FakeAsset(
         lockType
       ) match {
         case Some(immediateLock) =>
-          System.err.println(
-            "[TEST] Error: Lock was unexpectedly acquired immediately."
-          )
+          System.err.println(s"[TEST] Lock for $name was acquired immediately.")
           immediateLock
         case None =>
           System.err.println("INTERNAL-TEST-ACQUIRING-LOCK")

--- a/lib/scala/testkit/src/main/scala/org/enso/testkit/OsSpec.scala
+++ b/lib/scala/testkit/src/main/scala/org/enso/testkit/OsSpec.scala
@@ -12,15 +12,24 @@ trait OsSpec extends TestSuite {
   /** Tag test to run on Windows platforms. */
   object OsWindows extends Tag("org.enso.test.os.windows")
 
+  /** Tag test to run on Linux platforms. */
+  object OsLinux extends Tag("org.enso.test.os.linux")
+
   override def withFixture(test: NoArgTest): Outcome = {
     if (test.tags.contains(OsUnix.name)) {
       if (isUnix) super.withFixture(test) else Pending
     } else if (test.tags.contains(OsWindows.name)) {
       if (isWindows) super.withFixture(test) else Pending
+    } else if (test.tags.contains(OsLinux.name)) {
+      if (isLinux) super.withFixture(test) else Pending
     } else {
       super.withFixture(test)
     }
   }
+
+  /** @return `true` if this is a Unix-like system. */
+  protected def isLinux: Boolean =
+    SystemUtils.IS_OS_LINUX
 
   /** @return `true` if this is a Unix-like system. */
   protected def isUnix: Boolean =


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Close #1254

Adds an extension to the locking mechanism that makes it usable for both inter-process and intra-process (inter-thread) synchronization.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
