### PR TITLE
Enso Docs: Proper indentation in HTML render of code block and `copy` button.

### DIFF
--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Doc.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Doc.scala
@@ -178,7 +178,7 @@ object Doc {
         val uniqueIDBtn  = Random.alphanumeric.take(8).mkString("")
         val htmlIdCode   = HTML.`id` := uniqueIDCode
         val htmlIdBtn    = HTML.`id` := uniqueIDBtn
-        val htmlStyle    = HTML.`style` := "display: inline-block"
+        val htmlStyle    = HTML.`style` := "display: block"
         val elemsHTML    = elems.toList.map(elem => elem.html)
         val btnAction = onclick :=
           s"""var code = document.getElementById("$uniqueIDCode");
@@ -194,8 +194,9 @@ object Doc {
              |range.select().createTextRange();
              |document.execCommand("copy");""".stripMargin
             .replaceAll("\n", "")
-        val btn     = HTML.button(btnAction)(htmlIdBtn)("Show")
-        val copyBtn = HTML.button(copyAction)("Copy")
+        val btnStyle = HTML.`style` := "display: flex"
+        val btn      = HTML.button(btnAction)(htmlIdBtn)("Show")
+        val copyBtn  = HTML.button(copyAction)(btnStyle)("Copy")
         if (isInGui) {
           Seq(HTML.div(HTML.div(htmlCls())(htmlStyle)(elemsHTML), copyBtn))
         } else {
@@ -221,7 +222,7 @@ object Doc {
       }
       final case class Line(indent: Int, elem: String) extends Elem {
         val repr: Repr.Builder = R + indent + elem
-        val html: HTML         = Seq(HTML.code(elem), HTML.br)
+        val html: HTML         = Seq(HTML.code(" " * indent + elem), HTML.br)
       }
     }
 

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Doc.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Doc.scala
@@ -179,7 +179,11 @@ object Doc {
         val htmlIdCode   = HTML.`id` := uniqueIDCode
         val htmlIdBtn    = HTML.`id` := uniqueIDBtn
         val htmlStyle    = HTML.`style` := "display: block"
-        val elemsHTML    = elems.toList.map(elem => elem.html)
+        val firstIndent  = elems.head.indent
+        val elemsHTML = elems.toList.map(elem => {
+          elem.indent -= firstIndent
+          elem.html
+        })
         val btnAction = onclick :=
           s"""var code = document.getElementById("$uniqueIDCode");
              |var btn  = document.getElementById("$uniqueIDBtn").firstChild;

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Doc.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Doc.scala
@@ -178,20 +178,30 @@ object Doc {
         val uniqueIDBtn  = Random.alphanumeric.take(8).mkString("")
         val htmlIdCode   = HTML.`id` := uniqueIDCode
         val htmlIdBtn    = HTML.`id` := uniqueIDBtn
-        val htmlStyle    = HTML.`style` := "inline-block"
+        val htmlStyle    = HTML.`style` := "display: inline-block"
         val elemsHTML    = elems.toList.map(elem => elem.html)
         val btnAction = onclick :=
           s"""var code = document.getElementById("$uniqueIDCode");
-             |var btn = document.getElementById("$uniqueIDBtn").firstChild;
+             |var btn  = document.getElementById("$uniqueIDBtn").firstChild;
              |btn.data = btn.data == "Show" ? "Hide" : "Show";
              |code.style.display = code.style.display ==
              |"inline-block" ? "none" : "inline-block";""".stripMargin
             .replaceAll("\n", "")
-        val btn = HTML.button(btnAction)(htmlIdBtn)("Show")
+        val copyAction = onclick :=
+          s"""var code  = document.getElementById("$uniqueIDCode");
+             |var range = document.body.createTextRange();
+             |range.moveToElementText(code);
+             |range.select().createTextRange();
+             |document.execCommand("copy");""".stripMargin
+            .replaceAll("\n", "")
+        val btn     = HTML.button(btnAction)(htmlIdBtn)("Show")
+        val copyBtn = HTML.button(copyAction)("Copy")
         if (isInGui) {
-          Seq(HTML.div(htmlCls())(htmlStyle)(elemsHTML))
+          Seq(HTML.div(HTML.div(htmlCls())(htmlStyle)(elemsHTML), copyBtn))
         } else {
-          Seq(HTML.div(btn, HTML.div(htmlCls())(htmlIdCode)(elemsHTML)))
+          Seq(
+            HTML.div(btn, HTML.div(htmlCls())(htmlIdCode)(elemsHTML), copyBtn)
+          )
         }
       }
     }

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Doc.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/Doc.scala
@@ -178,34 +178,42 @@ object Doc {
         val uniqueIDBtn  = Random.alphanumeric.take(8).mkString("")
         val htmlIdCode   = HTML.`id` := uniqueIDCode
         val htmlIdBtn    = HTML.`id` := uniqueIDBtn
-        val htmlStyle    = HTML.`style` := "display: block"
         val firstIndent  = elems.head.indent
-        val elemsHTML = elems.toList.map(elem => {
-          elem.indent -= firstIndent
-          elem.html
-        })
+        val elemsHTML    = elems.toList.map(elem => elem.htmlOffset(firstIndent))
         val btnAction = onclick :=
           s"""var code = document.getElementById("$uniqueIDCode");
              |var btn  = document.getElementById("$uniqueIDBtn").firstChild;
              |btn.data = btn.data == "Show" ? "Hide" : "Show";
-             |code.style.display = code.style.display ==
+             |code.style.display = code.style.display == 
              |"inline-block" ? "none" : "inline-block";""".stripMargin
             .replaceAll("\n", "")
         val copyAction = onclick :=
           s"""var code  = document.getElementById("$uniqueIDCode");
-             |var range = document.body.createTextRange();
-             |range.moveToElementText(code);
-             |range.select().createTextRange();
-             |document.execCommand("copy");""".stripMargin
-            .replaceAll("\n", "")
+             |var range = document.createRange();
+             |range.selectNode(code);
+             |window.getSelection().removeAllRanges();
+             |window.getSelection().addRange(range);
+             |document.execCommand("copy");
+             |window.getSelection().removeAllRanges();""".stripMargin
         val btnStyle = HTML.`style` := "display: flex"
         val btn      = HTML.button(btnAction)(htmlIdBtn)("Show")
         val copyBtn  = HTML.button(copyAction)(btnStyle)("Copy")
         if (isInGui) {
-          Seq(HTML.div(HTML.div(htmlCls())(htmlStyle)(elemsHTML), copyBtn))
-        } else {
+          val htmlStyle = HTML.`style` := "display: block"
           Seq(
-            HTML.div(btn, HTML.div(htmlCls())(htmlIdCode)(elemsHTML), copyBtn)
+            HTML.div(
+              HTML.div(htmlCls())(htmlStyle)(htmlIdCode)(elemsHTML),
+              copyBtn
+            )
+          )
+        } else {
+          val htmlStyle = HTML.`style` := "display: none"
+          Seq(
+            HTML.div(
+              btn,
+              HTML.div(htmlCls())(htmlStyle)(htmlIdCode)(elemsHTML),
+              copyBtn
+            )
           )
         }
       }
@@ -227,6 +235,8 @@ object Doc {
       final case class Line(indent: Int, elem: String) extends Elem {
         val repr: Repr.Builder = R + indent + elem
         val html: HTML         = Seq(HTML.code(" " * indent + elem), HTML.br)
+        def htmlOffset(off: Int): HTML =
+          Seq(HTML.code(" " * (indent - off) + elem), HTML.br)
       }
     }
 


### PR DESCRIPTION
### Pull Request Description

Introduces copy button which enables user to easily copy examples, as well as fixes rendering.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
