### PR TITLE
Safepoint without invalidation

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ClosureRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ClosureRootNode.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.node;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.frame.FrameUtil;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -63,6 +64,9 @@ public class ClosureRootNode extends EnsoRootNode {
    */
   @Override
   public Object execute(VirtualFrame frame) {
+    if (CompilerDirectives.inCompilationRoot() || CompilerDirectives.inInterpreter()) {
+      lookupContextReference(Language.class).get().getThreadManager().poll();
+    }
     Object state = Function.ArgumentsHelper.getState(frame.getArguments());
     frame.setObject(this.getStateFrameSlot(), state);
     Object result = body.executeGeneric(frame);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/ExecuteCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/ExecuteCallNode.java
@@ -56,9 +56,7 @@ public abstract class ExecuteCallNode extends Node {
       Object state,
       Object[] arguments,
       @Cached("function.getCallTarget()") RootCallTarget cachedTarget,
-      @Cached("create(cachedTarget)") DirectCallNode callNode,
-      @CachedContext(Language.class) Context ctx) {
-    ctx.getThreadManager().poll();
+      @Cached("create(cachedTarget)") DirectCallNode callNode) {
     return (Stateful)
         callNode.call(
             Function.ArgumentsHelper.buildArguments(function, callerInfo, state, arguments));
@@ -83,9 +81,7 @@ public abstract class ExecuteCallNode extends Node {
       CallerInfo callerInfo,
       Object state,
       Object[] arguments,
-      @Cached IndirectCallNode callNode,
-      @CachedContext(Language.class) Context ctx) {
-    ctx.getThreadManager().poll();
+      @Cached IndirectCallNode callNode) {
     return (Stateful)
         callNode.call(
             function.getCallTarget(),

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/LoopingCallOptimiserNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/LoopingCallOptimiserNode.java
@@ -14,6 +14,7 @@ import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.nodes.RepeatingNode;
+import org.enso.interpreter.Language;
 import org.enso.interpreter.node.callable.ExecuteCallNode;
 import org.enso.interpreter.node.callable.ExecuteCallNodeGen;
 import org.enso.interpreter.runtime.callable.CallerInfo;
@@ -208,6 +209,7 @@ public abstract class LoopingCallOptimiserNode extends CallOptimiserNode {
      */
     @Override
     public boolean executeRepeating(VirtualFrame frame) {
+      lookupContextReference(Language.class).get().getThreadManager().poll();
       try {
         Object function = getNextFunction(frame);
         Object state = getNextState(frame);


### PR DESCRIPTION
### Pull Request Description
Makes safepoints use a volatile boolean flag instead of an assumption. This results in 0%-40% slowdowns across our benchmark suites (where the impact becomes smaller, the more memory is involved). This should be revised when a better safepoint mechanism makes it into Truffle.

### Important Notes
The safepoints are moved around – the approach we've taken so far ("safepoint on every method call") is not
sustainable with this solution (resulting in benchmarks becoming even 3x slower). Therefore safepoints are inserted:
1. At the start of non-builtin non-inlined Enso methods.
2. At the beginning of each `@TailCall` loop iteration.
This may turn out to be too sparse, in which more `poll` calls can be sprinkled.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
