### PR TITLE
Fix Logging Service Preventing Normal Shutdown

### DIFF
--- a/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/LoggingServiceAlreadyInitializedException.scala
+++ b/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/LoggingServiceAlreadyInitializedException.scala
@@ -1,0 +1,7 @@
+package org.enso.loggingservice
+
+case class LoggingServiceAlreadyInitializedException()
+    extends RuntimeException(
+      "The logging service was already initialized. " +
+      "If it should be restarted, it should be torn down first."
+    )

--- a/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/LoggingServiceManager.scala
+++ b/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/LoggingServiceManager.scala
@@ -1,7 +1,7 @@
 package org.enso.loggingservice
 
-import org.enso.loggingservice.internal.service.{Client, Local, Server, Service}
 import org.enso.loggingservice.internal._
+import org.enso.loggingservice.internal.service.{Client, Local, Server, Service}
 import org.enso.loggingservice.printers.{Printer, StderrPrinter}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/LoggingServiceManager.scala
+++ b/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/LoggingServiceManager.scala
@@ -168,9 +168,7 @@ object LoggingServiceManager {
   ): InitializationResult = {
     this.synchronized {
       if (currentService.isDefined) {
-        throw new IllegalStateException(
-          "The logging service has already been set up."
-        )
+        throw new LoggingServiceAlreadyInitializedException()
       }
 
       val (service, result): (Service, InitializationResult) = mode match {

--- a/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/LoggingServiceSetupHelper.scala
+++ b/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/LoggingServiceSetupHelper.scala
@@ -11,8 +11,8 @@ import org.enso.loggingservice.printers.{
   StderrPrinterWithColors
 }
 
-import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 

--- a/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/LoggingServiceSetupHelper.scala
+++ b/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/LoggingServiceSetupHelper.scala
@@ -145,6 +145,12 @@ abstract class LoggingServiceSetupHelper(implicit
     LoggingServiceManager
       .setup(LoggerMode.Server(createPrinters()), logLevel)
       .onComplete {
+        case Failure(LoggingServiceAlreadyInitializedException()) =>
+          logger.warn(
+            "Failed to initialize the logger because the logging service " +
+            "was already initialized."
+          )
+          loggingServiceEndpointPromise.trySuccess(None)
         case Failure(exception) =>
           logger.error(
             s"Failed to initialize the logging service server: $exception",
@@ -158,6 +164,12 @@ abstract class LoggingServiceSetupHelper(implicit
               logLevel
             )
             .onComplete {
+              case Failure(LoggingServiceAlreadyInitializedException()) =>
+                logger.warn(
+                  "Failed to initialize the fallback logger because the " +
+                  "logging service was already initialized."
+                )
+                loggingServiceEndpointPromise.trySuccess(None)
               case Failure(fallbackException) =>
                 System.err.println(
                   s"Failed to initialize the fallback logger: " +

--- a/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/internal/service/Server.scala
+++ b/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/internal/service/Server.scala
@@ -86,10 +86,6 @@ class Server(
       .map { serverBinding =>
         bindingOption = Some(serverBinding)
       }
-      .map { id =>
-        Thread.sleep(5000)
-        id
-      }
   }
 
   /** Returns the binding that describes how to connect to the started server.

--- a/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/internal/service/Server.scala
+++ b/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/internal/service/Server.scala
@@ -86,6 +86,10 @@ class Server(
       .map { serverBinding =>
         bindingOption = Some(serverBinding)
       }
+      .map { id =>
+        Thread.sleep(5000)
+        id
+      }
   }
 
   /** Returns the binding that describes how to connect to the started server.

--- a/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/internal/service/ServiceWithActorSystem.scala
+++ b/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/internal/service/ServiceWithActorSystem.scala
@@ -51,6 +51,7 @@ trait ServiceWithActorSystem extends Service {
         "akka.coordinated-shutdown.run-by-actor-system-terminate",
         ConfigValueFactory.fromAnyRef("off")
       )
+      .withValue("akka.daemonic", ConfigValueFactory.fromAnyRef("on"))
     ActorSystem(
       name,
       config,

--- a/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/internal/service/ServiceWithActorSystem.scala
+++ b/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/internal/service/ServiceWithActorSystem.scala
@@ -40,7 +40,7 @@ trait ServiceWithActorSystem extends Service {
     val loggers: java.lang.Iterable[String] =
       Seq("akka.event.Logging$StandardOutLogger").asJava
     val config = ConfigFactory
-      .load()
+      .empty()
       .withValue("akka.loggers", ConfigValueFactory.fromAnyRef(loggers))
       .withValue(
         "akka.logging-filter",

--- a/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/internal/service/ThreadProcessingService.scala
+++ b/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/internal/service/ThreadProcessingService.scala
@@ -1,11 +1,11 @@
 package org.enso.loggingservice.internal.service
 
 import org.enso.loggingservice.LogLevel
+import org.enso.loggingservice.internal.protocol.WSLogMessage
 import org.enso.loggingservice.internal.{
   BlockingConsumerMessageQueue,
   InternalLogger
 }
-import org.enso.loggingservice.internal.protocol.WSLogMessage
 
 import scala.util.control.NonFatal
 
@@ -47,6 +47,8 @@ trait ThreadProcessingService extends Service {
     }
 
     val thread = new Thread(() => runQueue())
+    thread.setName("logging-service-processing-thread")
+    thread.setDaemon(true)
     queueThread = Some(thread)
     thread.start()
   }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

The logging service did not mark its threads as daemons, preventing shutdown in case of all threads exiting. Most code paths were not affected, because they force shutdown by using `System.exit`, but some codepaths finish for example by an exception and it was possible for the runner to get stuck in such situations.

This PR ensures that the logging service does not prevent shutdown when other threads finish their work.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
