### PR TITLE
Use Cached Value when Computing Visualizations

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualisationCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualisationCmd.scala
@@ -1,11 +1,7 @@
 package org.enso.interpreter.instrument.command
 
 import org.enso.interpreter.instrument.execution.RuntimeContext
-import org.enso.interpreter.instrument.job.{
-  EnsureCompiledJob,
-  ExecuteJob,
-  UpsertVisualisationJob
-}
+import org.enso.interpreter.instrument.job.{ExecuteJob, UpsertVisualisationJob}
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.polyglot.runtime.Runtime.Api.RequestId
 
@@ -54,17 +50,9 @@ class AttachVisualisationCmd(
         )
       )
 
-    maybeFutureExecutable flatMap {
-      case None =>
-        Future.successful(())
-
-      case Some(executable) =>
-        for {
-          _ <- Future {
-            ctx.jobProcessor.run(EnsureCompiledJob(executable.stack))
-          }
-          _ <- ctx.jobProcessor.run(new ExecuteJob(executable))
-        } yield ()
+    maybeFutureExecutable.flatMap {
+      case None             => Future.successful(())
+      case Some(executable) => ctx.jobProcessor.run(new ExecuteJob(executable))
     }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -158,7 +158,7 @@ trait ProgramExecutionSupport {
     val logger = ctx.executionService.getLogger
     logger.log(
       Level.FINEST,
-      s"Run program $updatedVisualisations $sendMethodCallUpdates"
+      s"Run program updatedVisualisations=$updatedVisualisations sendMethodCallUpdates=$sendMethodCallUpdates"
     )
     @scala.annotation.tailrec
     def unwind(

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -155,7 +155,11 @@ trait ProgramExecutionSupport {
     updatedVisualisations: Seq[Api.ExpressionId],
     sendMethodCallUpdates: Boolean
   )(implicit ctx: RuntimeContext): Option[Api.ExecutionResult] = {
-    ctx.executionService.getLogger.log(Level.FINEST, s"Run program $stack")
+    val logger = ctx.executionService.getLogger
+    logger.log(
+      Level.FINEST,
+      s"Run program $updatedVisualisations $sendMethodCallUpdates"
+    )
     @scala.annotation.tailrec
     def unwind(
       stack: List[InstrumentFrame],
@@ -172,34 +176,25 @@ trait ProgramExecutionSupport {
       }
 
     val onCachedMethodCallCallback: Consumer[ExpressionValue] = { value =>
-      ctx.executionService.getLogger.log(
-        Level.FINEST,
-        s"ON_CACHED_CALL ${value.getExpressionId}"
-      )
+      logger.log(Level.FINEST, s"ON_CACHED_CALL ${value.getExpressionId}")
       sendValueUpdate(contextId, value, sendMethodCallUpdates)
     }
 
     val onCachedValueCallback: Consumer[ExpressionValue] = { value =>
       if (updatedVisualisations.contains(value.getExpressionId)) {
-        ctx.executionService.getLogger.log(
-          Level.FINEST,
-          s"ON_CACHED_VALUE ${value.getExpressionId}"
-        )
+        logger.log(Level.FINEST, s"ON_CACHED_VALUE ${value.getExpressionId}")
         fireVisualisationUpdates(contextId, value)
       }
     }
 
     val onComputedValueCallback: Consumer[ExpressionValue] = { value =>
-      ctx.executionService.getLogger.log(
-        Level.FINEST,
-        s"ON_COMPUTED ${value.getExpressionId}"
-      )
+      logger.log(Level.FINEST, s"ON_COMPUTED ${value.getExpressionId}")
       sendValueUpdate(contextId, value, sendMethodCallUpdates)
       fireVisualisationUpdates(contextId, value)
     }
 
     val onExceptionalCallback: Consumer[Throwable] = { value =>
-      ctx.executionService.getLogger.log(Level.FINEST, s"ON_ERROR $value")
+      logger.log(Level.FINEST, s"ON_ERROR $value")
       sendErrorUpdate(contextId, value)
     }
 
@@ -223,8 +218,7 @@ trait ProgramExecutionSupport {
           )
           .leftMap(onExecutionError(stackItem.item, _))
     } yield ()
-    ctx.executionService.getLogger
-      .log(Level.FINEST, s"Run program result $executionResult")
+    logger.log(Level.FINEST, s"Execution finished: $executionResult")
     executionResult.fold(Some(_), _ => None)
   }
 
@@ -396,21 +390,39 @@ trait ProgramExecutionSupport {
         value.getExpressionId
       )
     visualisations foreach { visualisation =>
-      emitVisualisationUpdate(contextId, value, visualisation)
+      emitVisualisationUpdate(
+        contextId,
+        visualisation,
+        value.getExpressionId,
+        value.getValue
+      )
     }
   }
 
-  private def emitVisualisationUpdate(
+  /** Compute the visualisation of the expression value and send an update.
+    *
+    * @param contextId an identifier of an execution context
+    * @param visualisation the visualisation data
+    * @param expressionId the id of expression to visualise
+    * @param expressionValue the value of expression to visualise
+    * @param ctx the runtime context
+    */
+  def emitVisualisationUpdate(
     contextId: ContextId,
-    value: ExpressionValue,
-    visualisation: Visualisation
+    visualisation: Visualisation,
+    expressionId: UUID,
+    expressionValue: AnyRef
   )(implicit ctx: RuntimeContext): Unit = {
     val errorMsgOrVisualisationData =
       Either
         .catchNonFatal {
+          ctx.executionService.getLogger.log(
+            Level.FINEST,
+            s"Executing visualisation ${visualisation.expressionId}"
+          )
           ctx.executionService.callFunction(
             visualisation.callback,
-            value.getValue
+            expressionValue
           )
         }
         .leftMap(_.getMessage)
@@ -432,13 +444,17 @@ trait ProgramExecutionSupport {
         )
 
       case Right(data) =>
+        ctx.executionService.getLogger.log(
+          Level.FINEST,
+          s"Sending visualisation ${visualisation.expressionId}"
+        )
         ctx.endpoint.sendToClient(
           Api.Response(
             Api.VisualisationUpdate(
               Api.VisualisationContext(
                 visualisation.id,
                 contextId,
-                value.getExpressionId
+                expressionId
               ),
               data
             )


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1360 

PR adds an optimization to the visualization computing logic. We don't need to schedule the program execution if the expression value is already in the cache.

Changelog:
- update: program execution logic to use the cached expression value when computing the visualization

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
