### PR TITLE
Fix doc parser's tags and unrecognized characters.

### DIFF
--- a/distribution/std-lib/Base/src/Data/Text/Extensions.enso
+++ b/distribution/std-lib/Base/src/Data/Text/Extensions.enso
@@ -12,7 +12,7 @@ polyglot java import org.enso.base.Text_Utils
 ## Computes the number of characters in the text.
 
    A character is defined as an Extended Grapheme Cluster, see Unicode
-   [Standard Annex #29](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries).
+   [Standard Annex 29](https://unicode.org/reports/tr29/Grapheme_Cluster_Boundaries).
 
    This is the smallest unit that still has semantic meaning in most
    text-processing applications.
@@ -31,7 +31,7 @@ Text.length =
 ## Applies `function` to each character in `this`.
 
    A character is defined as an Extended Grapheme Cluster, see Unicode
-   [Standard Annex #29](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries).
+   [Standard Annex 29](https://unicode.org/reports/tr29/Grapheme_Cluster_Boundaries).
 
    This is the smallest unit that still has semantic meaning in most
    text-processing applications.
@@ -53,7 +53,7 @@ Text.each function =
 ## Returns a vector containing all characters in the given text.
 
    A character is defined as an Extended Grapheme Cluster, see Unicode
-   [Standard Annex #29](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries).
+   [Standard Annex 29](https://unicode.org/reports/tr29/Grapheme_Cluster_Boundaries).
 
    This is the smallest unit that still has semantic meaning in most
    text-processing applications.
@@ -84,7 +84,7 @@ Text.split (separator = Split_Kind.Whitespace) =
 ## Returns a vector containing all words in the given text.
 
    A word is defined based on the definition of Word Boundaries in the Unicode
-   [Standard Annex #29](https://www.unicode.org/reports/tr29/#Word_Boundaries),
+   [Standard Annex 29](https://www.unicode.org/reports/tr29/Word_Boundaries),
    supplemented by language-specific dictionaries for Chinese, Japanese, Thai,
    and Khmer.
 

--- a/distribution/std-lib/Base/src/Data/Text/Extensions.enso
+++ b/distribution/std-lib/Base/src/Data/Text/Extensions.enso
@@ -11,7 +11,8 @@ polyglot java import org.enso.base.Text_Utils
 
 ## Computes the number of characters in the text.
 
-   A character is defined as an Extended Grapheme Cluster.
+   A character is defined as an Extended Grapheme Cluster, see
+   Unicode Standard Annex 29.
 
    This is the smallest unit that still has semantic meaning in most
    text-processing applications.
@@ -29,7 +30,8 @@ Text.length =
 
 ## Applies `function` to each character in `this`.
 
-   A character is defined as an Extended Grapheme Cluster.
+   A character is defined as an Extended Grapheme Cluster, see
+   Unicode Standard Annex 29.
 
    This is the smallest unit that still has semantic meaning in most
    text-processing applications.
@@ -50,7 +52,8 @@ Text.each function =
 
 ## Returns a vector containing all characters in the given text.
 
-   A character is defined as an Extended Grapheme Cluster.
+   A character is defined as an Extended Grapheme Cluster, see
+   Unicode Standard Annex 29.
 
    This is the smallest unit that still has semantic meaning in most
    text-processing applications.

--- a/distribution/std-lib/Base/src/Data/Text/Extensions.enso
+++ b/distribution/std-lib/Base/src/Data/Text/Extensions.enso
@@ -11,8 +11,7 @@ polyglot java import org.enso.base.Text_Utils
 
 ## Computes the number of characters in the text.
 
-   A character is defined as an Extended Grapheme Cluster, see Unicode
-   [Standard Annex 29](https://unicode.org/reports/tr29/Grapheme_Cluster_Boundaries).
+   A character is defined as an Extended Grapheme Cluster.
 
    This is the smallest unit that still has semantic meaning in most
    text-processing applications.
@@ -30,8 +29,7 @@ Text.length =
 
 ## Applies `function` to each character in `this`.
 
-   A character is defined as an Extended Grapheme Cluster, see Unicode
-   [Standard Annex 29](https://unicode.org/reports/tr29/Grapheme_Cluster_Boundaries).
+   A character is defined as an Extended Grapheme Cluster.
 
    This is the smallest unit that still has semantic meaning in most
    text-processing applications.
@@ -52,8 +50,7 @@ Text.each function =
 
 ## Returns a vector containing all characters in the given text.
 
-   A character is defined as an Extended Grapheme Cluster, see Unicode
-   [Standard Annex 29](https://unicode.org/reports/tr29/Grapheme_Cluster_Boundaries).
+   A character is defined as an Extended Grapheme Cluster.
 
    This is the smallest unit that still has semantic meaning in most
    text-processing applications.
@@ -84,9 +81,8 @@ Text.split (separator = Split_Kind.Whitespace) =
 ## Returns a vector containing all words in the given text.
 
    A word is defined based on the definition of Word Boundaries in the Unicode
-   [Standard Annex 29](https://www.unicode.org/reports/tr29/Word_Boundaries),
-   supplemented by language-specific dictionaries for Chinese, Japanese, Thai,
-   and Khmer.
+   Standard Annex 29, supplemented by language-specific dictionaries for
+   Chinese, Japanese, Thai, and Khmer.
 
    By default, the function doesn't include the whitespace between words, but
    this can be enabled.

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
@@ -158,8 +158,8 @@ case class DocParserDef() extends Parser[Doc] {
               val possibleTagType = elem.split(" ").head
               if (possibleTagType.matches("\\b[A-Z]{2,}\\b")) {
                 pushTag(section.currentIndentRaw, Tags.Tag.Unrecognized, in)
+                containsTag = true
               }
-              containsTag = true
             }
           }
 

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
@@ -141,7 +141,7 @@ case class DocParserDef() extends Parser[Doc] {
 
     def checkIfTagExistInPushedText(in: String): Boolean =
       logger.trace {
-        val inArray     = in.split(" ")
+        var inArray     = in.split(" ")
         var containsTag = false
 
         def tryFindingTagInAvailableTags(elem: String): Unit =
@@ -159,11 +159,13 @@ case class DocParserDef() extends Parser[Doc] {
             }
           }
 
-        if (inArray.isEmpty || inArray.head.isEmpty) {
-          section.currentIndentRaw += 1
-        } else {
+        if (inArray.nonEmpty) {
+          while (inArray.nonEmpty && inArray.head.isEmpty) {
+            section.currentIndentRaw += 1
+            inArray = inArray.tail
+          }
           val elem = inArray.head
-          if (elem.matches("\\b[A-Z]{2,}\\b")) {
+          if (elem.matches("^\\b[A-Z]{2,}\\b")) {
             tryFindingTagInAvailableTags(elem)
           }
         }

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
@@ -61,7 +61,7 @@ case class DocParserDef() extends Parser[Doc] {
 
   val char: Pattern = lowerChar | upperChar
   val specialChars: Pattern =
-    "," | "." | ":" | "/" | "’" | "=" | "'" | "|" | "+" | "-"
+    "," | "." | ":" | ";" | "/" | "\\" | "’" | "=" | "'" | "|" | "+" | "-" | "#" | "\""
   val possibleChars: Pattern = char | digit | whitespace | specialChars
 
   val normalText: Pattern = possibleChars.many1

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
@@ -15,11 +15,11 @@ case class DocParserDef() extends Parser[Doc] {
 
   override def getResult(): Option[Doc] = result.doc
 
-  /** result - used to manage result from Doc Parser
+  /** result - used to manage result from Doc Parser.
     *
-    * current - used to hold elem parser works on
-    * doc - used to hold ready to get Doc after parsing
-    * stack - used to hold stack of elems
+    * current - used to hold elem parser works on.
+    * doc - used to hold ready to get Doc after parsing.
+    * stack - used to hold stack of elems.
     */
   final object result {
     var current: Option[Elem] = None
@@ -70,8 +70,7 @@ case class DocParserDef() extends Parser[Doc] {
   //// Text ////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  /** text - used to manage normal text, made of Strings
-    */
+  /** text - used to manage normal text, made of Strings. */
   final object text {
     def onPushing(in: String): Unit =
       logger.trace {
@@ -112,10 +111,10 @@ case class DocParserDef() extends Parser[Doc] {
   //// Tags ////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  /** tags - used to manage potentially tagged documentation
+  /** tags - used to manage potentially tagged documentation.
     *
-    * possibleTagsList - holds every correct tag possible to create
-    * stack - holds applied tags
+    * possibleTagsList - holds every correct tag possible to create.
+    * stack - holds applied tags.
     */
   final object tags {
     val possibleTagsList: List[Tags.Tag.Type] =
@@ -150,26 +149,25 @@ case class DocParserDef() extends Parser[Doc] {
             for (tagType <- possibleTagsList) {
               if (elem == tagType.toString.toUpperCase) {
                 containsTag = true
-                val tagDet = in.replaceFirst(tagType.toString.toUpperCase, "")
+                val tagDet = inArray.tail.mkString(" ")
                 pushTag(section.currentIndentRaw, tagType, tagDet)
               }
             }
             if (!containsTag && !elem.contains(newline)) {
-              val possibleTagType = elem.split(" ").head
-              if (possibleTagType.matches("\\b[A-Z]{2,}\\b")) {
-                pushTag(section.currentIndentRaw, Tags.Tag.Unrecognized, in)
-                containsTag = true
-              }
+              pushTag(section.currentIndentRaw, Tags.Tag.Unrecognized, in)
+              containsTag = true
             }
           }
 
-        for (elem <- inArray) {
-          if (elem.isEmpty) {
-            section.currentIndentRaw += 1
-          } else if (elem == elem.toUpperCase) {
+        if (inArray.isEmpty || inArray.head.isEmpty) {
+          section.currentIndentRaw += 1
+        } else {
+          val elem = inArray.head
+          if (elem.matches("\\b[A-Z]{2,}\\b")) {
             tryFindingTagInAvailableTags(elem)
           }
         }
+
         containsTag
       }
   }
@@ -178,8 +176,7 @@ case class DocParserDef() extends Parser[Doc] {
   //// Code ////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  /** code - used to manage code in documentation
-    */
+  /** code - used to manage code in documentation. */
   final object code {
     def onPushingInline(in: String): Unit =
       logger.trace {
@@ -224,9 +221,9 @@ case class DocParserDef() extends Parser[Doc] {
   //// Formatter ///////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  /** formatter - used to manage text formatters
+  /** formatter - used to manage text formatters.
     *
-    * stack - holds applied formatters until they're closed
+    * stack - holds applied formatters until they're closed.
     */
   final object formatter {
     var stack: List[Elem.Formatter.Type] = Nil
@@ -315,8 +312,7 @@ case class DocParserDef() extends Parser[Doc] {
   //// Header //////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  /** header - used to create section headers in Documentation
-    */
+  /** header - used to create section headers in Documentation. */
   final object header {
     def create(): Unit =
       logger.trace {
@@ -351,9 +347,9 @@ case class DocParserDef() extends Parser[Doc] {
   //// Links ///////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  /** link - used to create links in Documentation
+  /** link - used to create links in Documentation.
     *
-    * there are 2 possible link types - Image and normal URL
+    * there are 2 possible link types - Image and normal URL.
     */
   final object link {
     def onCreatingURL(): Unit =
@@ -433,9 +429,9 @@ case class DocParserDef() extends Parser[Doc] {
   //// Indent Management & New line ////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  /** indent - used to manage text and block indentation
+  /** indent - used to manage text and block indentation.
     *
-    * stack - holds indents for code blocks and lists
+    * stack - holds indents for code blocks and lists.
     */
   final object indent {
     var stack: List[Int] = Nil
@@ -572,9 +568,9 @@ case class DocParserDef() extends Parser[Doc] {
   //// Lists ///////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  /** list - used to create lists for documentation
+  /** list - used to create lists for documentation.
     *
-    * there are 2 possible types of lists - ordered and unordered
+    * there are 2 possible types of lists - ordered and unordered.
     */
   final object list {
     var inListFlag: Boolean = false
@@ -659,7 +655,7 @@ case class DocParserDef() extends Parser[Doc] {
   //// Section /////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  /** section - used to manage sections in Documentation
+  /** section - used to manage sections in Documentation.
     *
     * there are 2 possible types of sections - marked and raw.
     * there are 3 possible types of marked sections:
@@ -667,10 +663,10 @@ case class DocParserDef() extends Parser[Doc] {
     *   - info
     *   - example
     *
-    * stack - holds every section in document
-    * current - holds current section type
-    * currentIndentRaw - holds indent for Raw
-    * indentBeforeM & indentAfterM - holds appropriate indents for Marked
+    * stack - holds every section in document.
+    * current - holds current section type.
+    * currentIndentRaw - holds indent for Raw.
+    * indentBeforeM & indentAfterM - holds appropriate indents for Marked.
     */
   final object section {
     var stack: List[Section]                 = Nil
@@ -810,10 +806,11 @@ case class DocParserDef() extends Parser[Doc] {
   //// Documentation ///////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
-  /** documentation - used to manage every action in case of end of file
-    * prepares data to be ready to output to user, also depicts type of
+  /** documentation - used to manage every action in case of end of file.
+    *
+    * Prepares data to be ready to output to user, also depicts type of
     * documentation - is it invoked from Parser as Multi Line or Single Line or
-    * is it just ran as DocParser - for example in test suite
+    * is it just ran as DocParser - for example in test suite.
     */
   final object documentation {
     def reverseSectionsStackOnEOF(): Unit =

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
@@ -155,7 +155,10 @@ case class DocParserDef() extends Parser[Doc] {
               }
             }
             if (!containsTag && !elem.contains(newline)) {
-              pushTag(section.currentIndentRaw, Tags.Tag.Unrecognized, in)
+              val possibleTagType = elem.split(" ").head
+              if (possibleTagType.matches("\\b[A-Z]{2,}\\b")) {
+                pushTag(section.currentIndentRaw, Tags.Tag.Unrecognized, in)
+              }
               containsTag = true
             }
           }

--- a/lib/scala/syntax/specialization/shared/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/lib/scala/syntax/specialization/shared/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -528,7 +528,7 @@ object Main extends scala.App {
       |   a value and take action, always accounting for the None case.
       |
       |type Option a
-      |    ## The `Some` type #indicates a presence of a value.
+      |    ## The `Some` type indicates a presence of a value.
       |    type Some a
       |
       |    ## The `None` type indicates a lack of a value.

--- a/lib/scala/syntax/specialization/shared/src/main/scala/org/enso/syntax/text/Parser.scala
+++ b/lib/scala/syntax/specialization/shared/src/main/scala/org/enso/syntax/text/Parser.scala
@@ -528,7 +528,7 @@ object Main extends scala.App {
       |   a value and take action, always accounting for the None case.
       |
       |type Option a
-      |    ## The `Some` type indicates a presence of a value.
+      |    ## The `Some` type #indicates a presence of a value.
       |    type Some a
       |
       |    ## The `None` type indicates a lack of a value.


### PR DESCRIPTION
### Pull Request Description
Fixes docparser's characters.
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes
Removal of '#' in links because of scala parser breaking the doc string, by thinking it is a commented out code. To be reverted in the future.
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
