### PR TITLE
Resolve Expression Ids for Errors

### DIFF
--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -24,6 +24,7 @@ transport formats, please look [here](./protocol-architecture).
   - [`StackItem`](#stackitem)
   - [`MethodPointer`](#methodpointer)
   - [`ExpressionValueUpdate`](#expressionvalueupdate)
+  - [`ExpressionUpdate`](#expressionupdate)
   - [`VisualisationConfiguration`](#visualisationconfiguration)
   - [`SuggestionEntryArgument`](#suggestionentryargument)
   - [`SuggestionEntry`](#suggestionentry)
@@ -111,6 +112,7 @@ transport formats, please look [here](./protocol-architecture).
   - [`executionContext/pop`](#executioncontextpop)
   - [`executionContext/recompute`](#executioncontextrecompute)
   - [`executionContext/expressionValuesComputed`](#executioncontextexpressionvaluescomputed)
+  - [`executionContext/expressionUpdates`](#executioncontextexpressionupdates)
   - [`executionContext/executionFailed`](#executioncontextexecutionfailed)
   - [`executionContext/executionStatus`](#executioncontextexecutionstatus)
   - [`executionContext/attachVisualisation`](#executioncontextattachvisualisation)
@@ -239,6 +241,62 @@ interface ExpressionValueUpdate {
 
   /** The updated pointer to the method call */
   methodPointer?: SuggestionId;
+}
+```
+
+### `ExpressionUpdate`
+
+```typescript
+type ExpressionUpdate = Computed | Failed | Poisoned;
+
+/**
+ * An update about computed expression.
+ */
+interface Computed {
+  /**
+   * The id of updated expression.
+   */
+  expressionId: ExpressionId;
+
+  /**
+   * The updated type of the expression.
+   */
+  type?: String;
+
+  /**
+   * The updated pointer to the method call.
+   */
+  methodPointer?: SuggestionId;
+}
+
+/**
+ * An update about failed expression.
+ */
+interface Failed {
+  /**
+   * The id of updated expression.
+   */
+  expressionId: ExpressionId;
+
+  /**
+   * The error message.
+   */
+  message: String;
+}
+
+/**
+ * An update about expression not executed due to the failed dependency.
+ */
+interface Poisoned {
+  /**
+   * The id of updated expression.
+   */
+  expressionId: ExpressionId;
+
+  /**
+   * The failed expression that prevents the execution of this expression.
+   */
+  failedExpressionId: ExpressionId;
 }
 ```
 
@@ -1200,6 +1258,7 @@ given execution context.
 #### Enables
 
 - [`executionContext/expressionValuesComputed`](#executioncontextexpressionvaluescomputed)
+- [`executionContext/expressionUpdates`](#executioncontextexpressionupdates)
 - [`executionContext/executionFailed`](#executioncontextexecutionfailed)
 - [`executionContext/executionStatus`](#executioncontextexecutionstatus)
 
@@ -2570,6 +2629,31 @@ expressions becoming available.
 {
   contextId: ContextId;
   updates: [ExpressionValueUpdate];
+}
+```
+
+#### Errors
+
+None
+
+### `executionContext/expressionUpdates`
+
+Sent from the server to the client to inform about new information for certain
+expressions becoming available. Supersedes the
+`executionContext/expressionValuesComputed` notification, that will be removed
+in future versions.
+
+- **Type:** Notification
+- **Direction:** Server -> Client
+- **Connection:** Protocol
+- **Visibility:** Public
+
+#### Parameters
+
+```typescript
+{
+  contextId: ContextId;
+  updates: [ExpressionUpdate];
 }
 ```
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
@@ -172,10 +172,12 @@ class JsonConnectionController(
         ExecutionContextExpressionUpdates,
         ExecutionContextExpressionUpdates.Params(contextId, updates)
       )
-      webActor ! Notification(
-        ExecutionContextExpressionValuesComputed,
-        ExecutionContextExpressionValuesComputed.Params(contextId, updatesOld)
-      )
+      updatesOld.foreach { value =>
+        webActor ! Notification(
+          ExecutionContextExpressionValuesComputed,
+          ExecutionContextExpressionValuesComputed.Params(contextId, value)
+        )
+      }
 
     case ContextRegistryProtocol.ExecutionFailedNotification(
           contextId,

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
@@ -167,10 +167,14 @@ class JsonConnectionController(
       )
 
     case ContextRegistryProtocol
-          .ExpressionValuesComputedNotification(contextId, updates) =>
+          .ExpressionUpdatesNotification(contextId, updates, updatesOld) =>
+      webActor ! Notification(
+        ExecutionContextExpressionUpdates,
+        ExecutionContextExpressionUpdates.Params(contextId, updates)
+      )
       webActor ! Notification(
         ExecutionContextExpressionValuesComputed,
-        ExecutionContextExpressionValuesComputed.Params(contextId, updates)
+        ExecutionContextExpressionValuesComputed.Params(contextId, updatesOld)
       )
 
     case ContextRegistryProtocol.ExecutionFailedNotification(

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonRpc.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonRpc.scala
@@ -66,6 +66,7 @@ object JsonRpc {
     .registerNotification(TextDidChange)
     .registerNotification(EventFile)
     .registerNotification(ExecutionContextExpressionValuesComputed)
+    .registerNotification(ExecutionContextExpressionUpdates)
     .registerNotification(ExecutionContextExecutionFailed)
     .registerNotification(ExecutionContextExecutionStatus)
     .registerNotification(StandardOutputAppended)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
@@ -211,7 +211,8 @@ final class ContextEventsListener(
     ExecutionStackTraceElement(
       element.functionName,
       element.file.flatMap(config.findRelativePath),
-      element.location
+      element.location,
+      element.expressionId
     )
 }
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
@@ -120,7 +120,7 @@ final class ContextEventsListener(
       val notification = ContextRegistryProtocol.ExpressionUpdatesNotification(
         contextId,
         updates.result(),
-        Vector()
+        None
       )
       if (notification.updates.nonEmpty) {
         sessionRouter ! DeliverToJsonController(
@@ -180,7 +180,7 @@ final class ContextEventsListener(
         val payload = ContextRegistryProtocol.ExpressionUpdatesNotification(
           contextId,
           computedExpressions,
-          computedExpressions.map(toExpressionValueUpdate)
+          Some(computedExpressions.map(toExpressionValueUpdate))
         )
         DeliverToJsonController(rpcSession.clientId, payload)
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
@@ -174,7 +174,11 @@ final class ContextEventsListener(
                   log.error(s"Unable to find suggestion for $pointer")
                   None
               }
-            }
+            },
+            update.profilingInfo.map { case Api.ProfilingInfo.ExecutionTime(t) =>
+              ProfilingInfo.ExecutionTime(t)
+            },
+            update.fromCache
           )
         }
         val payload = ContextRegistryProtocol.ExpressionUpdatesNotification(
@@ -192,7 +196,13 @@ final class ContextEventsListener(
   private def toExpressionValueUpdate(
     m: ContextRegistryProtocol.ExpressionUpdate.ExpressionComputed
   ): ExpressionValueUpdate =
-    ExpressionValueUpdate(m.expressionId, m.`type`, m.methodPointer)
+    ExpressionValueUpdate(
+      m.expressionId,
+      m.`type`,
+      m.methodPointer,
+      m.profilingInfo,
+      m.fromCache
+    )
 
   /** Convert the runtime failure message to the context registry protocol
     * representation.

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
@@ -181,6 +181,7 @@ final class ContextEventsListener(
       diagnostic.message,
       diagnostic.file.flatMap(config.findRelativePath),
       diagnostic.location,
+      diagnostic.expressionId,
       diagnostic.stack.map(toStackTraceElement)
     )
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
@@ -261,7 +261,6 @@ object ContextEventsListener {
 
   /** The action to process the expression updates. */
   case object RunExpressionUpdates
-  case object RunExpressionUpdatesOld
 
   /** Creates a configuration object used to create a [[ContextEventsListener]].
     *

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
@@ -64,9 +64,7 @@ final class ContextEventsListener(
 
   override def receive: Receive = withState(Vector())
 
-  def withState(
-    expressionUpdates: Vector[Api.ExpressionValueUpdate]
-  ): Receive = {
+  def withState(expressionUpdates: Vector[Api.ExpressionUpdate]): Receive = {
     case Api.VisualisationUpdate(ctx, data) if ctx.contextId == contextId =>
       val payload =
         VisualisationUpdate(
@@ -79,8 +77,10 @@ final class ContextEventsListener(
         )
       sessionRouter ! DeliverToBinaryController(rpcSession.clientId, payload)
 
-    case Api.ExpressionValuesComputed(`contextId`, apiUpdates) =>
-      context.become(withState(expressionUpdates :++ apiUpdates))
+    case Api.ExpressionUpdates(`contextId`, apiUpdates) =>
+      context.become(
+        withState(expressionUpdates :++ apiUpdates)
+      )
 
     case Api.ExecutionFailed(`contextId`, error) =>
       val payload =
@@ -101,57 +101,98 @@ final class ContextEventsListener(
     case Api.VisualisationEvaluationFailed(`contextId`, msg) =>
       val payload =
         ContextRegistryProtocol.VisualisationEvaluationFailed(contextId, msg)
-
       sessionRouter ! DeliverToJsonController(rpcSession.clientId, payload)
 
     case RunExpressionUpdates if expressionUpdates.nonEmpty =>
-      def toMethodPointer(call: Api.MethodPointer): (String, String, String) =
-        (call.module, call.definedOnType, call.name)
-      val methodPointerToExpression = expressionUpdates
-        .flatMap(update =>
-          update.methodCall.map(call =>
-            toMethodPointer(call) -> update.expressionId
-          )
+      val updates = Vector.newBuilder[ContextRegistryProtocol.ExpressionUpdate]
+      val computedExpressions =
+        Vector.newBuilder[Api.ExpressionUpdate.ExpressionComputed]
+      expressionUpdates.foreach {
+        case m: Api.ExpressionUpdate.ExpressionComputed =>
+          computedExpressions += m
+        case m: Api.ExpressionUpdate.ExpressionFailed =>
+          updates += ContextRegistryProtocol.ExpressionUpdate
+            .ExpressionFailed(m.expressionId, m.message)
+        case m: Api.ExpressionUpdate.ExpressionPoisoned =>
+          updates += ContextRegistryProtocol.ExpressionUpdate
+            .ExpressionPoisoned(m.expressionId, m.failedExpressionId)
+      }
+      val notification = ContextRegistryProtocol.ExpressionUpdatesNotification(
+        contextId,
+        updates.result(),
+        Vector()
+      )
+      if (notification.updates.nonEmpty) {
+        sessionRouter ! DeliverToJsonController(
+          rpcSession.clientId,
+          notification
         )
-        .toMap
-      val methodPointers = methodPointerToExpression.keys.toSeq
-      repo
-        .getAllMethods(methodPointers)
-        .map { suggestionIds =>
-          val methodPointerToSuggestion =
-            methodPointers
-              .zip(suggestionIds)
-              .collect { case (ptr, Some(suggestionId)) =>
-                ptr -> suggestionId
-              }
-              .toMap
-          val valueUpdates = expressionUpdates.map { update =>
-            ExpressionValueUpdate(
-              update.expressionId,
-              update.expressionType,
-              update.methodCall.flatMap { call =>
-                val pointer = toMethodPointer(call)
-                methodPointerToSuggestion.get(pointer) match {
-                  case suggestionId @ Some(_) => suggestionId
-                  case None =>
-                    log.error(s"Unable to find suggestion for $pointer")
-                    None
-                }
-              }
-            )
-          }
-          val payload =
-            ContextRegistryProtocol.ExpressionValuesComputedNotification(
-              contextId,
-              valueUpdates
-            )
-          DeliverToJsonController(rpcSession.clientId, payload)
-        }
-        .pipeTo(sessionRouter)
+      }
+      runExpressionComputed(computedExpressions.result())
       context.become(withState(Vector()))
 
     case RunExpressionUpdates if expressionUpdates.isEmpty =>
   }
+
+  /** Process `ExpressionComputed` notifications.
+    *
+    * Function resolves method pointers to the corresponding suggestion ids in
+    * the suggestions database, and creates the API updates.
+    */
+  private def runExpressionComputed(
+    expressionUpdates: Vector[Api.ExpressionUpdate.ExpressionComputed]
+  ): Unit = {
+    def toMethodPointer(call: Api.MethodPointer): (String, String, String) =
+      (call.module, call.definedOnType, call.name)
+
+    val methodPointerToExpression =
+      expressionUpdates.flatMap { update =>
+        update.methodCall.map(call =>
+          toMethodPointer(call) -> update.expressionId
+        )
+      }.toMap
+    val methodPointers = methodPointerToExpression.keys.toSeq
+    repo
+      .getAllMethods(methodPointers)
+      .map { suggestionIds =>
+        val methodPointerToSuggestion =
+          methodPointers
+            .zip(suggestionIds)
+            .collect { case (ptr, Some(suggestionId)) =>
+              ptr -> suggestionId
+            }
+            .toMap
+        val computedExpressions = expressionUpdates.map { update =>
+          ContextRegistryProtocol.ExpressionUpdate.ExpressionComputed(
+            update.expressionId,
+            update.expressionType,
+            update.methodCall.flatMap { call =>
+              val pointer = toMethodPointer(call)
+              methodPointerToSuggestion.get(pointer) match {
+                case suggestionId @ Some(_) => suggestionId
+                case None =>
+                  log.error(s"Unable to find suggestion for $pointer")
+                  None
+              }
+            }
+          )
+        }
+        val payload = ContextRegistryProtocol.ExpressionUpdatesNotification(
+          contextId,
+          computedExpressions,
+          computedExpressions.map(toExpressionValueUpdate)
+        )
+        DeliverToJsonController(rpcSession.clientId, payload)
+
+      }
+      .pipeTo(sessionRouter)
+  }
+
+  /** Conversion between the new and the old expression update message. */
+  private def toExpressionValueUpdate(
+    m: ContextRegistryProtocol.ExpressionUpdate.ExpressionComputed
+  ): ExpressionValueUpdate =
+    ExpressionValueUpdate(m.expressionId, m.`type`, m.methodPointer)
 
   /** Convert the runtime failure message to the context registry protocol
     * representation.
@@ -220,6 +261,7 @@ object ContextEventsListener {
 
   /** The action to process the expression updates. */
   case object RunExpressionUpdates
+  case object RunExpressionUpdatesOld
 
   /** Creates a configuration object used to create a [[ContextEventsListener]].
     *

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistry.scala
@@ -70,7 +70,7 @@ final class ContextRegistry(
 
   override def preStart(): Unit = {
     context.system.eventStream
-      .subscribe(self, classOf[Api.ExpressionValuesComputed])
+      .subscribe(self, classOf[Api.ExpressionUpdates])
     context.system.eventStream
       .subscribe(self, classOf[Api.VisualisationUpdate])
     context.system.eventStream
@@ -88,7 +88,7 @@ final class ContextRegistry(
     case Ping =>
       sender() ! Pong
 
-    case update: Api.ExpressionValuesComputed =>
+    case update: Api.ExpressionUpdates =>
       store.getListener(update.contextId).foreach(_ ! update)
 
     case update: Api.VisualisationUpdate =>

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
@@ -92,15 +92,53 @@ object ContextRegistryProtocol {
     */
   case class RecomputeContextResponse(contextId: ContextId)
 
-  /** A notification that new information about some expressions is available.
+  /** A notification about updated expressions of execution context.
     *
     * @param contextId execution context identifier
-    * @param updates a list of updated expressions
+    * @param updates a list of updated expressions.
     */
-  case class ExpressionValuesComputedNotification(
+  case class ExpressionUpdatesNotification(
     contextId: ContextId,
-    updates: Vector[ExpressionValueUpdate]
+    updates: Vector[ExpressionUpdate],
+    updatesOld: Vector[ExpressionValueUpdate]
   )
+
+  sealed trait ExpressionUpdate
+  object ExpressionUpdate {
+
+    /** An update about computed expression.
+      *
+      * @param expressionId the id of updated expression
+      * @param `type` the updated type of expression
+      * @param methodPointer the suggestion id of the updated method pointer
+      */
+    case class ExpressionComputed(
+      expressionId: UUID,
+      `type`: Option[String],
+      methodPointer: Option[Long]
+    ) extends ExpressionUpdate
+
+    /** An update about failed expression.
+      *
+      * @param expressionId the expression id
+      * @param message the error message
+      */
+    case class ExpressionFailed(
+      expressionId: UUID,
+      message: String
+    ) extends ExpressionUpdate
+
+    /** An update about expression not executed due to the failed dependency.
+      *
+      * @param expressionId the expression id
+      * @param failedExpressionId failed expression that blocks the execution
+      * of this expression
+      */
+    case class ExpressionPoisoned(
+      expressionId: UUID,
+      failedExpressionId: UUID
+    ) extends ExpressionUpdate
+  }
 
   /** Signals that user doesn't have access to the requested context.
     */

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
@@ -1,7 +1,6 @@
 package org.enso.languageserver.runtime
 
 import java.util.UUID
-
 import enumeratum._
 import org.enso.languageserver.data.ClientId
 import org.enso.languageserver.filemanager.{FileSystemFailure, Path}
@@ -161,6 +160,7 @@ object ContextRegistryProtocol {
     * @param message the error message
     * @param path the file path
     * @param location the range in the source text containing a diagnostic
+    * @param expressionId the id of related expression
     * @param stack the stack trace
     */
   case class ExecutionDiagnostic(
@@ -168,6 +168,7 @@ object ContextRegistryProtocol {
     message: String,
     path: Option[Path],
     location: Option[model.Range],
+    expressionId: Option[UUID],
     stack: Vector[ExecutionStackTraceElement]
   )
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
@@ -115,11 +115,15 @@ object ContextRegistryProtocol {
       * @param expressionId the id of updated expression
       * @param `type` the updated type of expression
       * @param methodPointer the suggestion id of the updated method pointer
+      * @param profilingInfo profiling information about the expression
+      * @param fromCache whether or not the expression's value came from the cache
       */
     case class ExpressionComputed(
       expressionId: UUID,
       `type`: Option[String],
-      methodPointer: Option[Long]
+      methodPointer: Option[Long],
+      profilingInfo: Vector[ProfilingInfo],
+      fromCache: Boolean
     ) extends ExpressionUpdate
 
     /** An update about failed expression.

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
@@ -147,11 +147,13 @@ object ContextRegistryProtocol {
     * @param functionName the function containing the stack call
     * @param path the location of a file
     * @param location the location of the element in a file
+    * @param expressionId the id of related expression
     */
   case class ExecutionStackTraceElement(
     functionName: String,
     path: Option[Path],
-    location: Option[model.Range]
+    location: Option[model.Range],
+    expressionId: Option[UUID]
   )
 
   /** A diagnostic message produced as a compilation outcome.

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
@@ -149,7 +149,6 @@ object ContextRegistryProtocol {
     }
 
     private object ExpressionUpdateType {
-
       val Computed = "Computed"
 
       val Failed = "Failed"

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExecutionApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExecutionApi.scala
@@ -98,6 +98,19 @@ object ExecutionApi {
     }
   }
 
+  case object ExecutionContextExpressionUpdates
+      extends Method("executionContext/expressionUpdates") {
+
+    case class Params(
+      contextId: ContextId,
+      updates: Vector[ContextRegistryProtocol.ExpressionUpdate]
+    )
+
+    implicit val hasParams = new HasParams[this.type] {
+      type Params = ExecutionContextExpressionUpdates.Params
+    }
+  }
+
   case object ExecutionContextExecutionFailed
       extends Method("executionContext/executionFailed") {
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
@@ -240,6 +240,7 @@ class ContextEventsListenerSpec
                   message,
                   None,
                   None,
+                  None,
                   Vector()
                 )
               )

--- a/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
@@ -108,11 +108,13 @@ class ContextEventsListenerSpec
                   Some(suggestionIds(1).get)
                 )
               ),
-              Vector(
-                ExpressionValueUpdate(
-                  Suggestions.method.externalId.get,
-                  Some(Suggestions.method.returnType),
-                  Some(suggestionIds(1).get)
+              Some(
+                Vector(
+                  ExpressionValueUpdate(
+                    Suggestions.method.externalId.get,
+                    Some(Suggestions.method.returnType),
+                    Some(suggestionIds(1).get)
+                  )
                 )
               )
             )
@@ -143,7 +145,7 @@ class ContextEventsListenerSpec
                   "Method failure"
                 )
               ),
-              Vector()
+              None
             )
           )
         )
@@ -172,7 +174,7 @@ class ContextEventsListenerSpec
                   Suggestions.method.externalId.get
                 )
               ),
-              Vector()
+              None
             )
           )
         )
@@ -233,16 +235,18 @@ class ContextEventsListenerSpec
                   None
                 )
               ),
-              Vector(
-                ExpressionValueUpdate(
-                  Suggestions.method.externalId.get,
-                  None,
-                  None
-                ),
-                ExpressionValueUpdate(
-                  Suggestions.local.externalId.get,
-                  None,
-                  None
+              Some(
+                Vector(
+                  ExpressionValueUpdate(
+                    Suggestions.method.externalId.get,
+                    None,
+                    None
+                  ),
+                  ExpressionValueUpdate(
+                    Suggestions.local.externalId.get,
+                    None,
+                    None
+                  )
                 )
               )
             )

--- a/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
@@ -117,7 +117,9 @@ class ContextEventsListenerSpec
                   ExpressionValueUpdate(
                     Suggestions.method.externalId.get,
                     Some(Suggestions.method.returnType),
-                    Some(suggestionIds(1).get)
+                    Some(suggestionIds(1).get),
+                    Vector(),
+                    false
                   )
                 )
               )
@@ -252,12 +254,16 @@ class ContextEventsListenerSpec
                   ExpressionValueUpdate(
                     Suggestions.method.externalId.get,
                     None,
-                    None
+                    None,
+                    Vector(),
+                    false
                   ),
                   ExpressionValueUpdate(
                     Suggestions.local.externalId.get,
                     None,
-                    None
+                    None,
+                    Vector(),
+                    false
                   )
                 )
               )

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -366,7 +366,7 @@ object Runtime {
       */
     case class ExpressionUpdates(
       contextId: ContextId,
-      updates: Seq[ExpressionUpdate]
+      updates: Set[ExpressionUpdate]
     ) extends ApiNotification
 
     /** Represents a visualisation context.

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -547,11 +547,13 @@ object Runtime {
       * @param functionName the function containing the stack call
       * @param file the location of a file
       * @param location the location of the element in a file
+      * @param expressionId the id of an expression
       */
     case class StackTraceElement(
       functionName: String,
       file: Option[File],
-      location: Option[Range]
+      location: Option[Range],
+      expressionId: Option[ExpressionId]
     )
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -3,6 +3,7 @@ package org.enso.polyglot.runtime
 import java.io.File
 import java.nio.ByteBuffer
 import java.util.UUID
+
 import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -268,7 +268,15 @@ object Runtime {
       Array(
         new JsonSubTypes.Type(
           value = classOf[ExpressionUpdate.ExpressionComputed],
-          name  = "expressionComputed"
+          name  = "expressionUpdateComputed"
+        ),
+        new JsonSubTypes.Type(
+          value = classOf[ExpressionUpdate.ExpressionFailed],
+          name  = "expressionUpdateFailed"
+        ),
+        new JsonSubTypes.Type(
+          value = classOf[ExpressionUpdate.ExpressionPoisoned],
+          name  = "expressionUpdatePoisoned"
         )
       )
     )

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -295,11 +295,17 @@ object Runtime {
         * @param expressionId the expression id
         * @param expressionType the type of expression
         * @param methodCall the pointer to a method definithin
+        * @param profilingInfo profiling information about the execution of this
+        * expression
+        * @param fromCache whether or not the value for this expression came
+        * from the cache
         */
       case class ExpressionComputed(
         expressionId: ExpressionId,
         expressionType: Option[String],
-        methodCall: Option[MethodPointer]
+        methodCall: Option[MethodPointer],
+        profilingInfo: Vector[ProfilingInfo],
+        fromCache: Boolean
       ) extends ExpressionUpdate
 
       /** An update about failed expression.

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -263,6 +263,7 @@ object Runtime {
       methodCall: Option[MethodPointer]
     )
 
+    /** Base trait for expression updates. */
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
     @JsonSubTypes(
       Array(
@@ -283,17 +284,34 @@ object Runtime {
     sealed trait ExpressionUpdate
     object ExpressionUpdate {
 
+      /** An update about computed expression.
+        *
+        * @param expressionId the expression id
+        * @param expressionType the type of expression
+        * @param methodCall the pointer to a method definithin
+        */
       case class ExpressionComputed(
         expressionId: ExpressionId,
         expressionType: Option[String],
         methodCall: Option[MethodPointer]
       ) extends ExpressionUpdate
 
+      /** An update about failed expression.
+        *
+        * @param expressionId the expression id
+        * @param message the error message
+        */
       case class ExpressionFailed(
         expressionId: ExpressionId,
         message: String
       ) extends ExpressionUpdate
 
+      /** An update about expression not executed due to a failed dependency.
+        *
+        * @param expressionId the expression id
+        * @param failedExpressionId failed expression that blocks the execution
+        * of this expression
+        */
       case class ExpressionPoisoned(
         expressionId: ExpressionId,
         failedExpressionId: ExpressionId

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -349,6 +349,7 @@ object Runtime {
           extends InvalidatedExpressions
     }
 
+    // TODO: [DB] Remove when IDE implements new updates API
     /** A notification about updated expressions of the context.
       *
       * @param contextId the context's id.

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/ErrorHandler.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/ErrorHandler.scala
@@ -1,0 +1,69 @@
+package org.enso.interpreter.instrument.execution
+
+import com.oracle.truffle.api.TruffleException
+import com.oracle.truffle.api.source.SourceSection
+import org.enso.compiler.pass.analyse.DataflowAnalysis
+import org.enso.polyglot.LanguageInfo
+import org.enso.polyglot.runtime.Runtime.Api
+
+object ErrorHandler {
+
+  def createUpdates(error: Throwable)(implicit
+    ctx: RuntimeContext
+  ): Seq[Api.ExpressionUpdate] = {
+    getErrorSource(error) match {
+      case Some(section) =>
+        val moduleName = section.getSource.getName
+        val moduleOpt  = ctx.executionService.getContext.findModule(moduleName)
+        moduleOpt
+          .map { module =>
+            val meta = module.getIr.unsafeGetMetadata(
+              DataflowAnalysis,
+              "Empty dataflow analysis metadata during program execution."
+            )
+            LocationResolver
+              .getExpressionId(section, module)
+              .map { expressionId =>
+                val poisoned = meta
+                  .getExternal(toDataflowDependencyType(expressionId))
+                  .getOrElse(Set())
+                  .map(
+                    Api.ExpressionUpdate
+                      .ExpressionPoisoned(_, expressionId.externalId)
+                  )
+                  .toSeq
+                val failed =
+                  Api.ExpressionUpdate
+                    .ExpressionFailed(expressionId.externalId, error.getMessage)
+                failed +: poisoned
+              }
+              .getOrElse(Seq())
+          }
+          .orElse(Seq())
+      case None =>
+        Seq()
+    }
+  }
+
+  private def getErrorSource(error: Throwable): Option[SourceSection] =
+    error match {
+      case ex: TruffleException
+          if getLanguage(ex).forall(_ == LanguageInfo.ID) =>
+        Option(ex.getSourceLocation)
+      case _ =>
+        None
+    }
+
+  private def getLanguage(ex: TruffleException): Option[String] =
+    for {
+      location <- Option(ex.getSourceLocation)
+      source   <- Option(location.getSource)
+    } yield source.getLanguage
+
+  private def toDataflowDependencyType(
+    id: LocationResolver.ExpressionId
+  ): DataflowAnalysis.DependencyInfo.Type.Static =
+    DataflowAnalysis.DependencyInfo.Type
+      .Static(id.internalId, Some(id.externalId))
+
+}

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/ErrorResolver.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/ErrorResolver.scala
@@ -6,7 +6,7 @@ import org.enso.compiler.pass.analyse.DataflowAnalysis
 import org.enso.polyglot.LanguageInfo
 import org.enso.polyglot.runtime.Runtime.Api
 
-object ErrorHandler {
+object ErrorResolver {
 
   def createUpdates(error: Throwable)(implicit
     ctx: RuntimeContext

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/ErrorResolver.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/ErrorResolver.scala
@@ -18,7 +18,7 @@ object ErrorResolver {
     */
   def createUpdates(error: Throwable)(implicit
     ctx: RuntimeContext
-  ): Seq[Api.ExpressionUpdate] = {
+  ): Set[Api.ExpressionUpdate] = {
     getErrorSource(error) match {
       case Some(section) =>
         val moduleName = section.getSource.getName
@@ -32,24 +32,23 @@ object ErrorResolver {
             LocationResolver
               .getExpressionId(section, module)
               .map { expressionId =>
-                val poisoned = meta
+                val poisoned: Set[Api.ExpressionUpdate] = meta
                   .getExternal(toDataflowDependencyType(expressionId))
                   .getOrElse(Set())
                   .map(
                     Api.ExpressionUpdate
                       .ExpressionPoisoned(_, expressionId.externalId)
                   )
-                  .toSeq
                 val failed =
                   Api.ExpressionUpdate
                     .ExpressionFailed(expressionId.externalId, error.getMessage)
-                failed +: poisoned
+                poisoned + failed
               }
-              .getOrElse(Seq())
+              .getOrElse(Set())
           }
-          .orElse(Seq())
+          .orElse(Set())
       case None =>
-        Seq()
+        Set()
     }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/ErrorResolver.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/ErrorResolver.scala
@@ -6,8 +6,16 @@ import org.enso.compiler.pass.analyse.DataflowAnalysis
 import org.enso.polyglot.LanguageInfo
 import org.enso.polyglot.runtime.Runtime.Api
 
+/** Methods for handling exceptions in the interpreter. */
 object ErrorResolver {
 
+  /** Create expression updates about the failed expression and expressions
+    * that were not executed (poisoned) due to the failed expression.
+    *
+    * @param error the runtime exception
+    * @param ctx the runtime context
+    * @return the list of updates about the expressions not executed
+    */
   def createUpdates(error: Throwable)(implicit
     ctx: RuntimeContext
   ): Seq[Api.ExpressionUpdate] = {
@@ -45,6 +53,11 @@ object ErrorResolver {
     }
   }
 
+  /** Get the source location of the runtime exception.
+    *
+    * @param error the runtime exception
+    * @return the error location in the source file
+    */
   private def getErrorSource(error: Throwable): Option[SourceSection] =
     error match {
       case ex: TruffleException
@@ -54,12 +67,18 @@ object ErrorResolver {
         None
     }
 
+  /** Get the language produced the runtime exception.
+    *
+    * @param ex the runtime exception
+    * @return the language of the source file produced the runtime exception
+    */
   private def getLanguage(ex: TruffleException): Option[String] =
     for {
       location <- Option(ex.getSourceLocation)
       source   <- Option(location.getSource)
     } yield source.getLanguage
 
+  /** Convert this expression id to the dataflow dependency type. */
   private def toDataflowDependencyType(
     id: LocationResolver.ExpressionId
   ): DataflowAnalysis.DependencyInfo.Type.Static =

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/LocationResolver.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/LocationResolver.scala
@@ -1,0 +1,95 @@
+package org.enso.interpreter.instrument.execution
+
+import com.oracle.truffle.api.source.SourceSection
+import org.enso.compiler.core.IR
+import org.enso.interpreter.runtime.Module
+import org.enso.syntax.text.Location
+import org.enso.text.editing.{model, IndexedSource}
+
+object LocationResolver {
+
+  case class ExpressionId(internalId: IR.Identifier, externalId: IR.ExternalId)
+
+  def getExpressionId(section: SourceSection)(implicit
+    ctx: RuntimeContext
+  ): Option[ExpressionId] = {
+    val moduleName = section.getSource.getName
+    val moduleOpt  = ctx.executionService.getContext.findModule(moduleName)
+    if (moduleOpt.isEmpty) None
+    else {
+      val module   = moduleOpt.get()
+      val location = sectionToLocation(section, module.getLiteralSource)
+      getExpressionId(module.getIr, location)
+    }
+  }
+
+  def getExpressionId(
+    section: SourceSection,
+    module: Module
+  ): Option[ExpressionId] = {
+    val location = sectionToLocation(section, module.getLiteralSource)
+    getExpressionId(module.getIr, location)
+  }
+
+  def getExpressionId(
+    ir: IR,
+    location: IR.IdentifiedLocation
+  ): Option[ExpressionId] =
+    ir.preorder
+      .find(_.location.contains(location))
+      .flatMap(getExpressionId)
+
+  def getExpressionId(
+    ir: IR,
+    location: Location
+  ): Option[ExpressionId] =
+    ir.preorder
+      .find(_.location.map(_.location).contains(location))
+      .flatMap(getExpressionId)
+
+  def getExpressionId(ir: IR): Option[ExpressionId] =
+    ir.getExternalId.map(ExpressionId(ir.getId, _))
+
+  /** Convert truffle source section to the range of text.
+    *
+    * @param section the source section
+    * @return the corresponding text range in the source file
+    */
+  def sectionToRange(section: SourceSection): model.Range =
+    model.Range(
+      model.Position(section.getStartLine - 1, section.getStartColumn - 1),
+      model.Position(section.getEndLine - 1, section.getEndColumn)
+    )
+
+  /** Convert truffle source section to the IR location.
+    *
+    * @param section the source section
+    * @param source the source text
+    * @return location of the source section within the source
+    */
+  def sectionToLocation[A: IndexedSource](
+    section: SourceSection,
+    source: A
+  ): Location = {
+    val range = sectionToRange(section)
+    Location(
+      IndexedSource[A].toIndex(range.start, source),
+      IndexedSource[A].toIndex(range.end, source)
+    )
+  }
+
+  /** Convert the IR location to the text range in the source file.
+    *
+    * @param location the location of IR node
+    * @param source the source text
+    * @return the corresponding text range in the source file
+    */
+  def locationToRange[A: IndexedSource](
+    location: Location,
+    source: A
+  ): model.Range =
+    model.Range(
+      IndexedSource[A].toPosition(location.start, source),
+      IndexedSource[A].toPosition(location.end, source)
+    )
+}

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/LocationResolver.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/LocationResolver.scala
@@ -6,10 +6,24 @@ import org.enso.interpreter.runtime.Module
 import org.enso.syntax.text.Location
 import org.enso.text.editing.{model, IndexedSource}
 
+/** Helper methods to convert between the `IR` and source locations, and
+  * resolving the expression ids in the source text.
+  */
 object LocationResolver {
 
+  /** Identifier of the `IR` node with an external id.
+    *
+    * @param internalId the internal node id
+    * @param externalId the external node id
+    */
   case class ExpressionId(internalId: IR.Identifier, externalId: IR.ExternalId)
 
+  /** Resolve expression id of the given source section.
+    *
+    * @param section the source section
+    * @param ctx the runtime context
+    * @return the expression id of the given source section
+    */
   def getExpressionId(section: SourceSection)(implicit
     ctx: RuntimeContext
   ): Option[ExpressionId] = {
@@ -23,6 +37,11 @@ object LocationResolver {
     }
   }
 
+  /** Resolve expression id of the given source section.
+    * @param section the source section
+    * @param module the module of the section
+    * @return the expression id of the given source section
+    */
   def getExpressionId(
     section: SourceSection,
     module: Module
@@ -31,6 +50,12 @@ object LocationResolver {
     getExpressionId(module.getIr, location)
   }
 
+  /** Resolve expression id of the given `IR` location.
+    *
+    * @param ir the corresponding `IR`
+    * @param location the location in the `IR`
+    * @return the expression id of the location in the given ir
+    */
   def getExpressionId(
     ir: IR,
     location: IR.IdentifiedLocation
@@ -39,6 +64,12 @@ object LocationResolver {
       .find(_.location.contains(location))
       .flatMap(getExpressionId)
 
+  /** Resolve expression id of the given source location.
+    *
+    * @param ir the corresponding `IR`
+    * @param location the location in the source text
+    * @return the expression id of the source location in the given ir
+    */
   def getExpressionId(
     ir: IR,
     location: Location
@@ -47,6 +78,11 @@ object LocationResolver {
       .find(_.location.map(_.location).contains(location))
       .flatMap(getExpressionId)
 
+  /** Get the id of the given `IR`.
+    *
+    * @param ir the `IR` to get id from
+    * @return the id of the given `IR`
+    */
   def getExpressionId(ir: IR): Option[ExpressionId] =
     ir.getExternalId.map(ExpressionId(ir.getId, _))
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -2,7 +2,6 @@ package org.enso.interpreter.instrument.job
 
 import java.io.{File, IOException}
 import java.util.logging.Level
-
 import cats.implicits._
 import org.enso.compiler.context.{
   Changeset,
@@ -17,13 +16,15 @@ import org.enso.compiler.pass.analyse.{
 }
 import org.enso.compiler.phase.ImportResolver
 import org.enso.interpreter.instrument.{CacheInvalidation, InstrumentFrame}
-import org.enso.interpreter.instrument.execution.RuntimeContext
+import org.enso.interpreter.instrument.execution.{
+  LocationResolver,
+  RuntimeContext
+}
 import org.enso.interpreter.runtime.Module
 import org.enso.polyglot.Suggestion
 import org.enso.polyglot.data.Tree
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.text.buffer.Rope
-import org.enso.text.editing.model.{Position, Range}
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
@@ -296,23 +297,18 @@ class EnsureCompiledJob(protected val files: Iterable[File])
     module: Module,
     diagnostic: IR.Diagnostic
   ): Api.ExecutionResult.Diagnostic = {
-    val fileOpt = Option(module.getPath).map(new File(_))
-    val locationOpt =
-      diagnostic.location.map { loc =>
-        val section = module.getSource.createSection(
-          loc.location.start,
-          loc.location.length
-        )
-        Range(
-          Position(section.getStartLine - 1, section.getStartColumn - 1),
-          Position(section.getEndLine - 1, section.getEndColumn)
-        )
-      }
     Api.ExecutionResult.Diagnostic(
       kind,
       diagnostic.message,
-      fileOpt,
-      locationOpt,
+      Option(module.getPath).map(new File(_)),
+      diagnostic.location
+        .map(loc =>
+          LocationResolver
+            .locationToRange(loc.location, module.getLiteralSource)
+        ),
+      diagnostic.location
+        .flatMap(LocationResolver.getExpressionId(module.getIr, _))
+        .map(_.externalId),
       Vector()
     )
   }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -2,6 +2,7 @@ package org.enso.interpreter.instrument.job
 
 import java.io.{File, IOException}
 import java.util.logging.Level
+
 import cats.implicits._
 import org.enso.compiler.context.{
   Changeset,

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecutionItem.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecutionItem.scala
@@ -1,0 +1,45 @@
+package org.enso.interpreter.instrument.job
+
+import org.enso.interpreter.node.callable.FunctionCallInstrumentationNode
+import org.enso.pkg.QualifiedName
+import org.enso.polyglot.runtime.Runtime.Api
+
+/** An execution item. */
+sealed trait ExecutionItem
+
+object ExecutionItem {
+
+  /** The explicit method call.
+    *
+    * @param module the module containing the method
+    * @param constructor the type on which the method is defined
+    * @param function the method name
+    */
+  case class Method(
+    module: QualifiedName,
+    constructor: QualifiedName,
+    function: String
+  ) extends ExecutionItem
+
+  object Method {
+
+    /** Construct the method call from the [[Api.StackItem.ExplicitCall]].
+      *
+      * @param call the Api call
+      * @return the method call
+      */
+    def apply(call: Api.StackItem.ExplicitCall): Method =
+      Method(
+        QualifiedName.fromString(call.methodPointer.module),
+        QualifiedName.fromString(call.methodPointer.definedOnType),
+        call.methodPointer.name
+      )
+  }
+
+  /** The call data captured during the program execution.
+    *
+    * @param callData the fucntion call data
+    */
+  case class CallData(callData: FunctionCallInstrumentationNode.FunctionCall)
+      extends ExecutionItem
+}

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.util.{Objects, UUID}
 import java.util.function.Consumer
 import java.util.logging.Level
+
 import cats.implicits._
 import com.oracle.truffle.api.{
   TruffleException,

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -335,12 +335,13 @@ trait ProgramExecutionSupport {
     val node = element.getLocation
     node.getEncapsulatingSourceSection match {
       case null =>
-        Api.StackTraceElement(node.getRootNode.getName, None, None)
+        Api.StackTraceElement(node.getRootNode.getName, None, None, None)
       case section =>
         Api.StackTraceElement(
           element.getTarget.getRootNode.getName,
           findFileByModuleName(section.getSource.getName),
-          Some(LocationResolver.sectionToRange(section))
+          Some(LocationResolver.sectionToRange(section)),
+          LocationResolver.getExpressionId(section).map(_.externalId)
         )
     }
   }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -413,7 +413,11 @@ trait ProgramExecutionSupport {
               Api.ExpressionUpdate.ExpressionComputed(
                 value.getExpressionId,
                 Option(value.getType),
-                methodPointer
+                methodPointer,
+                value.getProfilingInfo.map { case e: ExecutionTime =>
+                  Api.ProfilingInfo.ExecutionTime(e.getNanoTimeElapsed)
+                }.toVector,
+                value.wasCached()
               )
             )
           )

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -361,7 +361,7 @@ trait ProgramExecutionSupport {
 
   private def sendExpressionUpdates(
     contextId: ContextId,
-    updates: Seq[Api.ExpressionUpdate]
+    updates: Set[Api.ExpressionUpdate]
   )(implicit ctx: RuntimeContext): Unit = {
     if (updates.nonEmpty) {
       ctx.endpoint.sendToClient(
@@ -383,12 +383,27 @@ trait ProgramExecutionSupport {
       !Objects.equals(value.getCallInfo, value.getCachedCallInfo) ||
       !Objects.equals(value.getType, value.getCachedType)
     ) {
+      // TODO: [DB] Remove when IDE implements new updates API
       ctx.endpoint.sendToClient(
         Api.Response(
           Api.ExpressionValuesComputed(
             contextId,
             Vector(
               Api.ExpressionValueUpdate(
+                value.getExpressionId,
+                Option(value.getType),
+                methodPointer
+              )
+            )
+          )
+        )
+      )
+      ctx.endpoint.sendToClient(
+        Api.Response(
+          Api.ExpressionUpdates(
+            contextId,
+            Set(
+              Api.ExpressionUpdate.ExpressionComputed(
                 value.getExpressionId,
                 Option(value.getType),
                 methodPointer

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -15,7 +15,7 @@ import org.enso.interpreter.instrument.IdExecutionInstrument.{
   ExpressionValue
 }
 import org.enso.interpreter.instrument.execution.{
-  ErrorHandler,
+  ErrorResolver,
   LocationResolver,
   RuntimeContext
 }
@@ -247,7 +247,7 @@ trait ProgramExecutionSupport {
         ctx.executionService.getLogger
           .log(Level.FINEST, s"Error executing a function $itemName.", error)
     }
-    sendExpressionUpdates(contextId, ErrorHandler.createUpdates(error).take(0))
+    sendExpressionUpdates(contextId, ErrorResolver.createUpdates(error))
     executionUpdate.getOrElse(
       Api.ExecutionResult
         .Failure(s"Error in function $itemName.", None)

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
@@ -110,7 +110,7 @@ class ExpressionErrorsTest
     val Some(Api.Response(_, Api.InitializedNotification())) = context.receive
   }
 
-  it should "return all expressions in method body" in {
+  it should "return all errors in method body" in {
     val contextId  = UUID.randomUUID()
     val requestId  = UUID.randomUUID()
     val moduleName = "Test.Main"
@@ -187,12 +187,16 @@ class ExpressionErrorsTest
                   Some(mainFile),
                   Some(
                     model.Range(model.Position(1, 14), model.Position(1, 19))
-                  )
+                  ),
+                  Some(fooBodyId)
                 ),
                 Api.StackTraceElement(
                   "Main.main",
                   Some(mainFile),
-                  Some(model.Range(model.Position(3, 8), model.Position(3, 16)))
+                  Some(
+                    model.Range(model.Position(3, 8), model.Position(3, 16))
+                  ),
+                  Some(yId)
                 )
               )
             )
@@ -277,19 +281,24 @@ class ExpressionErrorsTest
                   Some(mainFile),
                   Some(
                     model.Range(model.Position(4, 12), model.Position(4, 19))
-                  )
+                  ),
+                  Some(bazId)
                 ),
                 Api.StackTraceElement(
                   "Main.bar",
                   Some(mainFile),
                   Some(
                     model.Range(model.Position(2, 12), model.Position(2, 26))
-                  )
+                  ),
+                  Some(barId)
                 ),
                 Api.StackTraceElement(
                   "Main.main",
                   Some(mainFile),
-                  Some(model.Range(model.Position(0, 7), model.Position(0, 19)))
+                  Some(
+                    model.Range(model.Position(0, 7), model.Position(0, 19))
+                  ),
+                  Some(mainId)
                 )
               )
             )

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
@@ -162,7 +162,7 @@ class ExpressionErrorsTest
       Api.Response(
         Api.ExpressionUpdates(
           contextId,
-          Seq(
+          Set(
             Api.ExpressionUpdate.ExpressionFailed(
               fooBodyId,
               "No_Such_Method_Error UnresolvedSymbol<undefined> UnresolvedSymbol<+>"
@@ -258,7 +258,7 @@ class ExpressionErrorsTest
       Api.Response(
         Api.ExpressionUpdates(
           contextId,
-          Seq(
+          Set(
             Api.ExpressionUpdate.ExpressionFailed(
               bazId,
               "No_Such_Method_Error UnresolvedSymbol<x> UnresolvedSymbol<+>"

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
@@ -1,0 +1,210 @@
+package org.enso.interpreter.test.instrument
+
+import org.enso.interpreter.test.Metadata
+import org.enso.pkg.{Package, PackageManager}
+import org.enso.polyglot._
+import org.enso.polyglot.runtime.Runtime.Api
+import org.enso.text.editing.model
+import org.enso.text.{ContentVersion, Sha3_224VersionCalculator}
+import org.graalvm.polyglot.Context
+import org.graalvm.polyglot.io.MessageEndpoint
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.{ByteArrayOutputStream, File}
+import java.nio.ByteBuffer
+import java.nio.file.Files
+import java.util.UUID
+import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
+
+@scala.annotation.nowarn("msg=multiarg infix syntax")
+class ExpressionErrorsTest
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterEach {
+
+  var context: TestContext = _
+
+  class TestContext(packageName: String) {
+    var endPoint: MessageEndpoint = _
+    val messageQueue: LinkedBlockingQueue[Api.Response] =
+      new LinkedBlockingQueue()
+
+    val tmpDir: File = Files.createTempDirectory("enso-test-packages").toFile
+
+    val pkg: Package[File] =
+      PackageManager.Default.create(tmpDir, packageName, "0.0.1")
+    val out: ByteArrayOutputStream = new ByteArrayOutputStream()
+    val executionContext = new PolyglotContext(
+      Context
+        .newBuilder(LanguageInfo.ID)
+        .allowExperimentalOptions(true)
+        .allowAllAccess(true)
+        .option(RuntimeOptions.PACKAGES_PATH, pkg.root.getAbsolutePath)
+        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+        .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
+        .option(RuntimeServerInfo.ENABLE_OPTION, "true")
+        .out(out)
+        .serverTransport { (uri, peer) =>
+          if (uri.toString == RuntimeServerInfo.URI) {
+            endPoint = peer
+            new MessageEndpoint {
+              override def sendText(text: String): Unit = {}
+
+              override def sendBinary(data: ByteBuffer): Unit =
+                Api.deserializeResponse(data).foreach(messageQueue.add)
+
+              override def sendPing(data: ByteBuffer): Unit = {}
+
+              override def sendPong(data: ByteBuffer): Unit = {}
+
+              override def sendClose(): Unit = {}
+            }
+          } else null
+        }
+        .build()
+    )
+    executionContext.context.initialize(LanguageInfo.ID)
+
+    def writeMain(contents: String): File =
+      Files.write(pkg.mainFile.toPath, contents.getBytes).toFile
+
+    def writeFile(file: File, contents: String): File =
+      Files.write(file.toPath, contents.getBytes).toFile
+
+    def writeInSrcDir(moduleName: String, contents: String): File = {
+      val file = new File(pkg.sourceDir, s"$moduleName.enso")
+      Files.write(file.toPath, contents.getBytes).toFile
+    }
+
+    def send(msg: Api.Request): Unit = endPoint.sendBinary(Api.serialize(msg))
+
+    def receiveNone: Option[Api.Response] = {
+      Option(messageQueue.poll())
+    }
+
+    def receive: Option[Api.Response] = {
+      Option(messageQueue.poll(3, TimeUnit.SECONDS))
+    }
+
+    def receive(n: Int): List[Api.Response] = {
+      Iterator.continually(receive).take(n).flatten.toList
+    }
+
+    def consumeOut: List[String] = {
+      val result = out.toString
+      out.reset()
+      result.linesIterator.toList
+    }
+
+    def executionComplete(contextId: UUID): Api.Response =
+      Api.Response(Api.ExecutionComplete(contextId))
+  }
+
+  def contentsVersion(content: String): ContentVersion =
+    Sha3_224VersionCalculator.evalVersion(content)
+
+  override protected def beforeEach(): Unit = {
+    context = new TestContext("Test")
+    val Some(Api.Response(_, Api.InitializedNotification())) = context.receive
+  }
+
+  it should "return error unresolved symbol" in {
+    val contextId  = UUID.randomUUID()
+    val requestId  = UUID.randomUUID()
+    val moduleName = "Test.Main"
+    val metadata   = new Metadata
+    @scala.annotation.unused
+    val mainId = metadata.addItem(7, 12)
+    @scala.annotation.unused
+    val barId = metadata.addItem(33, 14)
+    val bazId = metadata.addItem(61, 7)
+    val code =
+      """main = here.bar x 2
+        |
+        |bar x1 x2 = here.baz x1 x2
+        |
+        |baz y1 y2 = y1 + y2
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // Open the new file
+    context.send(
+      Api.Request(Api.OpenFileNotification(mainFile, contents, true))
+    )
+    context.receiveNone shouldEqual None
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, "Test.Main", "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+    context.receive(4) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      Api.Response(
+        Api.ExpressionUpdates(
+          contextId,
+          Seq(
+            Api.ExpressionUpdate.ExpressionFailed(
+              bazId,
+              "No_Such_Method_Error UnresolvedSymbol<x> UnresolvedSymbol<+>"
+            )
+          )
+        )
+      ),
+      Api.Response(
+        Api.ExecutionUpdate(
+          contextId,
+          Seq(
+            Api.ExecutionResult.Diagnostic.error(
+              "No_Such_Method_Error UnresolvedSymbol<x> UnresolvedSymbol<+>",
+              Some(mainFile),
+              Some(model.Range(model.Position(4, 12), model.Position(4, 19))),
+              Some(bazId),
+              Vector(
+                Api.StackTraceElement(
+                  "Main.baz",
+                  Some(mainFile),
+                  Some(
+                    model.Range(model.Position(4, 12), model.Position(4, 19))
+                  )
+                ),
+                Api.StackTraceElement(
+                  "Main.bar",
+                  Some(mainFile),
+                  Some(
+                    model.Range(model.Position(2, 12), model.Position(2, 26))
+                  )
+                ),
+                Api.StackTraceElement(
+                  "Main.main",
+                  Some(mainFile),
+                  Some(model.Range(model.Position(0, 7), model.Position(0, 19)))
+                )
+              )
+            )
+          )
+        )
+      ),
+      context.executionComplete(contextId)
+    )
+  }
+
+}

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -3355,7 +3355,10 @@ class RuntimeServerTest
                 Api.StackTraceElement(
                   "Main.main",
                   Some(mainFile),
-                  Some(model.Range(model.Position(0, 7), model.Position(0, 24)))
+                  Some(
+                    model.Range(model.Position(0, 7), model.Position(0, 24))
+                  ),
+                  None
                 )
               )
             )
@@ -3422,12 +3425,16 @@ class RuntimeServerTest
                   Some(mainFile),
                   Some(
                     model.Range(model.Position(2, 14), model.Position(2, 23))
-                  )
+                  ),
+                  None
                 ),
                 Api.StackTraceElement(
                   "Main.main",
                   Some(mainFile),
-                  Some(model.Range(model.Position(0, 7), model.Position(0, 21)))
+                  Some(
+                    model.Range(model.Position(0, 7), model.Position(0, 21))
+                  ),
+                  None
                 )
               )
             )
@@ -3489,18 +3496,22 @@ class RuntimeServerTest
               None,
               None,
               Vector(
-                Api.StackTraceElement("Text.+", None, None),
+                Api.StackTraceElement("Text.+", None, None, None),
                 Api.StackTraceElement(
                   "Main.bar",
                   Some(mainFile),
                   Some(
                     model.Range(model.Position(2, 10), model.Position(2, 15))
-                  )
+                  ),
+                  None
                 ),
                 Api.StackTraceElement(
                   "Main.main",
                   Some(mainFile),
-                  Some(model.Range(model.Position(0, 7), model.Position(0, 23)))
+                  Some(
+                    model.Range(model.Position(0, 7), model.Position(0, 23))
+                  ),
+                  None
                 )
               )
             )
@@ -3566,7 +3577,10 @@ class RuntimeServerTest
                 Api.StackTraceElement(
                   "Main.main",
                   Some(mainFile),
-                  Some(model.Range(model.Position(2, 7), model.Position(2, 16)))
+                  Some(
+                    model.Range(model.Position(2, 7), model.Position(2, 16))
+                  ),
+                  None
                 )
               )
             )
@@ -3639,28 +3653,38 @@ class RuntimeServerTest
               None,
               None,
               Vector(
-                Api.StackTraceElement("Small_Integer.+", None, None),
+                Api.StackTraceElement("Small_Integer.+", None, None, None),
                 Api.StackTraceElement(
                   "Main.baz",
                   Some(mainFile),
                   Some(
                     model.Range(model.Position(11, 8), model.Position(11, 17))
-                  )
+                  ),
+                  None
                 ),
                 Api.StackTraceElement(
                   "Main.bar",
                   Some(mainFile),
-                  Some(model.Range(model.Position(8, 8), model.Position(8, 16)))
+                  Some(
+                    model.Range(model.Position(8, 8), model.Position(8, 16))
+                  ),
+                  None
                 ),
                 Api.StackTraceElement(
                   "Main.foo",
                   Some(mainFile),
-                  Some(model.Range(model.Position(5, 8), model.Position(5, 16)))
+                  Some(
+                    model.Range(model.Position(5, 8), model.Position(5, 16))
+                  ),
+                  None
                 ),
                 Api.StackTraceElement(
                   "Main.main",
                   Some(mainFile),
-                  Some(model.Range(model.Position(2, 7), model.Position(2, 15)))
+                  Some(
+                    model.Range(model.Position(2, 7), model.Position(2, 15))
+                  ),
+                  None
                 )
               )
             )
@@ -3720,7 +3744,8 @@ class RuntimeServerTest
             Api.ExecutionResult.Diagnostic.warning(
               "Unused variable x.",
               Some(mainFile),
-              Some(model.Range(model.Position(2, 7), model.Position(2, 8)))
+              Some(model.Range(model.Position(2, 7), model.Position(2, 8))),
+              None
             )
           )
         )

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -664,7 +664,8 @@ class RuntimeServerTest
                         .Argument("this", "Test.Main", false, false, None),
                       Suggestion
                         .Argument("a", Constants.ANY, false, false, None),
-                      Suggestion.Argument("b", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("b", Constants.ANY, false, false, None)
                     ),
                     "Test.Main",
                     Constants.ANY,
@@ -791,7 +792,8 @@ class RuntimeServerTest
                         .Argument("this", "Test.Main", false, false, None),
                       Suggestion
                         .Argument("a", Constants.ANY, false, false, None),
-                      Suggestion.Argument("b", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("b", Constants.ANY, false, false, None)
                     ),
                     "Test.Main",
                     Constants.ANY,
@@ -1167,7 +1169,8 @@ class RuntimeServerTest
                         .Argument("this", "Test.Main", false, false, None),
                       Suggestion
                         .Argument("a", Constants.ANY, false, false, None),
-                      Suggestion.Argument("b", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("b", Constants.ANY, false, false, None)
                     ),
                     "Test.Main",
                     Constants.ANY,
@@ -1349,7 +1352,8 @@ class RuntimeServerTest
                           false,
                           None
                         ),
-                      Suggestion.Argument("x", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("x", Constants.ANY, false, false, None)
                     ),
                     Constants.NUMBER,
                     Constants.ANY,
@@ -1806,7 +1810,8 @@ class RuntimeServerTest
                         false,
                         None
                       ),
-                      Suggestion.Argument("y", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("y", Constants.ANY, false, false, None)
                     ),
                     Constants.NUMBER,
                     Constants.ANY,
@@ -2641,7 +2646,9 @@ class RuntimeServerTest
       Api.Response(
         Api.ExpressionValuesComputed(
           contextId,
-          Vector(Api.ExpressionValueUpdate(idMain, Some(Constants.INTEGER), None))
+          Vector(
+            Api.ExpressionValueUpdate(idMain, Some(Constants.INTEGER), None)
+          )
         )
       )
     val version = contentsVersion(context.Main.code)
@@ -2767,7 +2774,8 @@ class RuntimeServerTest
                     Seq(
                       Suggestion
                         .Argument("this", Constants.NUMBER, false, false, None),
-                      Suggestion.Argument("x", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("x", Constants.ANY, false, false, None)
                     ),
                     Constants.NUMBER,
                     Constants.ANY,
@@ -3342,6 +3350,7 @@ class RuntimeServerTest
               "Object 42 is not invokable.",
               Some(mainFile),
               Some(model.Range(model.Position(0, 7), model.Position(0, 24))),
+              None,
               Vector(
                 Api.StackTraceElement(
                   "Main.main",
@@ -3406,6 +3415,7 @@ class RuntimeServerTest
               "No_Such_Method_Error UnresolvedSymbol<x> UnresolvedSymbol<+>",
               Some(mainFile),
               Some(model.Range(model.Position(2, 14), model.Position(2, 23))),
+              None,
               Vector(
                 Api.StackTraceElement(
                   "Main.bar",
@@ -3475,6 +3485,7 @@ class RuntimeServerTest
           Seq(
             Api.ExecutionResult.Diagnostic.error(
               "Unexpected type provided for argument `that` in Text.+",
+              None,
               None,
               None,
               Vector(
@@ -3550,6 +3561,7 @@ class RuntimeServerTest
               "No_Such_Method_Error Number UnresolvedSymbol<pi>",
               Some(mainFile),
               Some(model.Range(model.Position(2, 7), model.Position(2, 16))),
+              None,
               Vector(
                 Api.StackTraceElement(
                   "Main.main",
@@ -3623,6 +3635,7 @@ class RuntimeServerTest
           Seq(
             Api.ExecutionResult.Diagnostic.error(
               "Unexpected type provided for argument `that` in Integer.+",
+              None,
               None,
               None,
               Vector(
@@ -4149,7 +4162,8 @@ class RuntimeServerTest
                         false,
                         None
                       ),
-                      Suggestion.Argument("x", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("x", Constants.ANY, false, false, None)
                     ),
                     "Test.Visualisation",
                     Constants.ANY,
@@ -4173,7 +4187,8 @@ class RuntimeServerTest
                         false,
                         None
                       ),
-                      Suggestion.Argument("x", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("x", Constants.ANY, false, false, None)
                     ),
                     "Test.Visualisation",
                     Constants.ANY,
@@ -4322,7 +4337,8 @@ class RuntimeServerTest
                         false,
                         None
                       ),
-                      Suggestion.Argument("x", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("x", Constants.ANY, false, false, None)
                     ),
                     "Test.Visualisation",
                     Constants.ANY,
@@ -4346,7 +4362,8 @@ class RuntimeServerTest
                         false,
                         None
                       ),
-                      Suggestion.Argument("x", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("x", Constants.ANY, false, false, None)
                     ),
                     "Test.Visualisation",
                     Constants.ANY,
@@ -4513,7 +4530,8 @@ class RuntimeServerTest
                         false,
                         None
                       ),
-                      Suggestion.Argument("x", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("x", Constants.ANY, false, false, None)
                     ),
                     "Test.Visualisation",
                     Constants.ANY,
@@ -4537,7 +4555,8 @@ class RuntimeServerTest
                         false,
                         None
                       ),
-                      Suggestion.Argument("x", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("x", Constants.ANY, false, false, None)
                     ),
                     "Test.Visualisation",
                     Constants.ANY,
@@ -4637,7 +4656,8 @@ class RuntimeServerTest
                     Seq(
                       Suggestion
                         .Argument("this", Constants.NUMBER, false, false, None),
-                      Suggestion.Argument("x", Constants.ANY, false, false, None)
+                      Suggestion
+                        .Argument("x", Constants.ANY, false, false, None)
                     ),
                     Constants.NUMBER,
                     Constants.ANY,

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -723,36 +723,22 @@ class RuntimeServerTest
         )
       )
     )
-    context.receive(4) should contain theSameElementsAs Seq(
+    context.receive(6) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              idMainFoo,
-              Some(Constants.INTEGER),
-              Some(Api.MethodPointer(moduleName, "Test.Main", "foo")),
-              Vector(ProfilingInfo.ExecutionTime(0)),
-              false
-            )
-          )
-        )
+      context.Message.updateOld(
+        contextId,
+        idMainFoo,
+        Constants.INTEGER,
+        Api.MethodPointer(moduleName, "Test.Main", "foo")
       ),
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              idMain,
-              Some(Constants.NOTHING),
-              None,
-              Vector(ProfilingInfo.ExecutionTime(0)),
-              false
-            )
-          )
-        )
+      context.Message.update(
+        contextId,
+        idMainFoo,
+        Constants.INTEGER,
+        Api.MethodPointer(moduleName, "Test.Main", "foo")
       ),
+      context.Message.updateOld(contextId, idMain, Constants.NOTHING),
+      context.Message.update(contextId, idMain, Constants.NOTHING),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("1")

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -8,7 +8,6 @@ import org.enso.pkg.{Package, PackageManager}
 import org.enso.polyglot._
 import org.enso.polyglot.data.Tree
 import org.enso.polyglot.runtime.Runtime.Api
-import org.enso.polyglot.runtime.Runtime.Api.ProfilingInfo
 import org.enso.text.editing.model
 import org.enso.text.editing.model.TextEdit
 import org.enso.text.{ContentVersion, Sha3_224VersionCalculator}
@@ -133,7 +132,7 @@ class RuntimeServerTest
           Api.ExpressionUpdates(
             contextId,
             Set(
-              Api.ExpressionUpdate.ExpressionComputed(expressionId, None, None)
+              Api.ExpressionUpdate.ExpressionComputed(expressionId, None, None, Vector(Api.ProfilingInfo.ExecutionTime(0)), false)
             )
           )
         )
@@ -150,7 +149,9 @@ class RuntimeServerTest
               Api.ExpressionUpdate.ExpressionComputed(
                 expressionId,
                 Some(expressionType),
-                None
+                None,
+                Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                false
               )
             )
           )
@@ -162,6 +163,15 @@ class RuntimeServerTest
         expressionType: String,
         methodPointer: Api.MethodPointer
       ): Api.Response =
+        update(contextId, expressionId, expressionType, methodPointer, false)
+
+      def update(
+        contextId: UUID,
+        expressionId: UUID,
+        expressionType: String,
+        methodPointer: Api.MethodPointer,
+        fromCache: Boolean
+      ): Api.Response =
         Api.Response(
           Api.ExpressionUpdates(
             contextId,
@@ -169,7 +179,9 @@ class RuntimeServerTest
               Api.ExpressionUpdate.ExpressionComputed(
                 expressionId,
                 Some(expressionType),
-                Some(methodPointer)
+                Some(methodPointer),
+                Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                fromCache
               )
             )
           )
@@ -182,7 +194,7 @@ class RuntimeServerTest
         Api.Response(
           Api.ExpressionValuesComputed(
             contextId,
-            Vector(Api.ExpressionValueUpdate(expressionId, None, None))
+            Vector(Api.ExpressionValueUpdate(expressionId, None, None, Vector(Api.ProfilingInfo.ExecutionTime(0)), false))
           )
         )
 
@@ -198,7 +210,9 @@ class RuntimeServerTest
               Api.ExpressionValueUpdate(
                 expressionId,
                 Some(expressionType),
-                None
+                None,
+                Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                false
               )
             )
           )
@@ -210,6 +224,15 @@ class RuntimeServerTest
         expressionType: String,
         methodPointer: Api.MethodPointer
       ): Api.Response =
+        updateOld(contextId, expressionId, expressionType, methodPointer, false)
+
+      def updateOld(
+        contextId: UUID,
+        expressionId: UUID,
+        expressionType: String,
+        methodPointer: Api.MethodPointer,
+        fromCache: Boolean
+      ): Api.Response =
         Api.Response(
           Api.ExpressionValuesComputed(
             contextId,
@@ -217,7 +240,9 @@ class RuntimeServerTest
               Api.ExpressionValueUpdate(
                 expressionId,
                 Some(expressionType),
-                Some(methodPointer)
+                Some(methodPointer),
+                Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                fromCache
               )
             )
           )
@@ -256,7 +281,7 @@ class RuntimeServerTest
 
       object Update {
 
-        def mainX(contextId: UUID): Api.Response =
+        def mainX(contextId: UUID, fromCache: Boolean = false): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -264,13 +289,15 @@ class RuntimeServerTest
                 Api.ExpressionUpdate.ExpressionComputed(
                   Main.idMainX,
                   Some(Constants.INTEGER),
-                  None
+                  None,
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  fromCache
                 )
               )
             )
           )
 
-        def mainY(contextId: UUID): Api.Response =
+        def mainY(contextId: UUID, fromCache: Boolean = false): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -284,13 +311,15 @@ class RuntimeServerTest
                       Constants.NUMBER,
                       "foo"
                     )
-                  )
+                  ),
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  fromCache
                 )
               )
             )
           )
 
-        def mainZ(contextId: UUID): Api.Response =
+        def mainZ(contextId: UUID, fromCache: Boolean = false): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -298,13 +327,15 @@ class RuntimeServerTest
                 Api.ExpressionUpdate.ExpressionComputed(
                   Main.idMainZ,
                   Some(Constants.INTEGER),
-                  None
+                  None,
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  fromCache
                 )
               )
             )
           )
 
-        def fooY(contextId: UUID): Api.Response =
+        def fooY(contextId: UUID, fromCache: Boolean = false): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -312,13 +343,15 @@ class RuntimeServerTest
                 Api.ExpressionUpdate.ExpressionComputed(
                   Main.idFooY,
                   Some(Constants.INTEGER),
-                  None
+                  None,
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  fromCache
                 )
               )
             )
           )
 
-        def fooZ(contextId: UUID): Api.Response =
+        def fooZ(contextId: UUID, fromCache: Boolean = false): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -326,7 +359,9 @@ class RuntimeServerTest
                 Api.ExpressionUpdate.ExpressionComputed(
                   Main.idFooZ,
                   Some(Constants.INTEGER),
-                  None
+                  None,
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  fromCache
                 )
               )
             )
@@ -335,7 +370,7 @@ class RuntimeServerTest
 
       object UpdateOld {
 
-        def mainX(contextId: UUID) =
+        def mainX(contextId: UUID, fromCache: Boolean = false) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -344,14 +379,14 @@ class RuntimeServerTest
                   Main.idMainX,
                   Some(Constants.INTEGER),
                   None,
-                  Vector(ProfilingInfo.ExecutionTime(0)),
-                  false
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  fromCache
                 )
               )
             )
           )
 
-        def mainY(contextId: UUID) =
+        def mainY(contextId: UUID, fromCache: Boolean = false) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -366,14 +401,14 @@ class RuntimeServerTest
                       "foo"
                     )
                   ),
-                  Vector(ProfilingInfo.ExecutionTime(0)),
-                  false
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  fromCache
                 )
               )
             )
           )
 
-        def mainZ(contextId: UUID) =
+        def mainZ(contextId: UUID, fromCache: Boolean = false) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -382,14 +417,14 @@ class RuntimeServerTest
                   Main.idMainZ,
                   Some(Constants.INTEGER),
                   None,
-                  Vector(ProfilingInfo.ExecutionTime(0)),
-                  false
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  fromCache
                 )
               )
             )
           )
 
-        def fooY(contextId: UUID) =
+        def fooY(contextId: UUID, fromCache: Boolean = false) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -398,14 +433,14 @@ class RuntimeServerTest
                   Main.idFooY,
                   Some(Constants.INTEGER),
                   None,
-                  Vector(ProfilingInfo.ExecutionTime(0)),
-                  false
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  fromCache
                 )
               )
             )
           )
 
-        def fooZ(contextId: UUID) =
+        def fooZ(contextId: UUID, fromCache: Boolean = false) =
           Api.Response(
             Api.ExpressionValuesComputed(
               contextId,
@@ -414,8 +449,8 @@ class RuntimeServerTest
                   Main.idFooZ,
                   Some(Constants.INTEGER),
                   None,
-                  Vector(ProfilingInfo.ExecutionTime(0)),
-                  false
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  fromCache
                 )
               )
             )
@@ -459,7 +494,9 @@ class RuntimeServerTest
                 Api.ExpressionUpdate.ExpressionComputed(
                   idMainY,
                   Some(Constants.INTEGER),
-                  Some(Api.MethodPointer("Test.Main", "Test.Main", "foo"))
+                  Some(Api.MethodPointer("Test.Main", "Test.Main", "foo")),
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  false
                 )
               )
             )
@@ -473,7 +510,9 @@ class RuntimeServerTest
                 Api.ExpressionUpdate.ExpressionComputed(
                   idMainZ,
                   Some(Constants.INTEGER),
-                  Some(Api.MethodPointer("Test.Main", "Test.Main", "bar"))
+                  Some(Api.MethodPointer("Test.Main", "Test.Main", "bar")),
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
+                  false
                 )
               )
             )
@@ -491,7 +530,7 @@ class RuntimeServerTest
                   idMainY,
                   Some(Constants.INTEGER),
                   Some(Api.MethodPointer("Test.Main", "Test.Main", "foo")),
-                  Vector(ProfilingInfo.ExecutionTime(0)),
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   false
                 )
               )
@@ -507,7 +546,7 @@ class RuntimeServerTest
                   idMainZ,
                   Some(Constants.INTEGER),
                   Some(Api.MethodPointer("Test.Main", "Test.Main", "bar")),
-                  Vector(ProfilingInfo.ExecutionTime(0)),
+                  Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   false
                 )
               )
@@ -620,8 +659,8 @@ class RuntimeServerTest
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
     context.receive(4) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PopContextResponse(contextId)),
-      context.Main.UpdateOld.mainY(contextId, true),
-      context.Main.Update.mainY(contextId, true),
+      context.Main.UpdateOld.mainY(contextId, fromCache = true),
+      context.Main.Update.mainY(contextId, fromCache = true),
       context.executionComplete(contextId)
     )
 
@@ -766,33 +805,6 @@ class RuntimeServerTest
         idMainQ,
         Constants.INTEGER,
         Api.MethodPointer("Test.A", "Test.A", "bar")
-||||||| 3b48fc7e
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              idMain,
-              Some(Constants.NOTHING),
-              None
-            )
-          )
-        )
-=======
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              idMain,
-              Some(Constants.NOTHING),
-              None,
-              Vector(ProfilingInfo.ExecutionTime(0)),
-              false
-            )
-          )
-        )
->>>>>>> main
       ),
       context.Message.updateOld(contextId, idMainF, Constants.INTEGER),
       context.Message.update(contextId, idMainF, Constants.INTEGER),
@@ -1596,8 +1608,8 @@ class RuntimeServerTest
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
     context.receive(4) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PopContextResponse(contextId)),
-      context.Main.UpdateOld.mainY(contextId),
-      context.Main.Update.mainY(contextId),
+      context.Main.UpdateOld.mainY(contextId, fromCache = true),
+      context.Main.Update.mainY(contextId, fromCache = true),
       context.executionComplete(contextId)
     )
 
@@ -2180,45 +2192,6 @@ class RuntimeServerTest
         id3,
         Constants.INTEGER,
         Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded")
-||||||| 3b48fc7e
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              id3,
-              Some(Constants.INTEGER),
-              Some(
-                Api.MethodPointer(
-                  moduleName,
-                  Constants.NUMBER,
-                  "overloaded"
-                )
-              )
-            )
-          )
-        )
-=======
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              id3,
-              Some(Constants.INTEGER),
-              Some(
-                Api.MethodPointer(
-                  moduleName,
-                  Constants.NUMBER,
-                  "overloaded"
-                )
-              ),
-              Vector(ProfilingInfo.ExecutionTime(0)),
-              false
-            )
-          )
-        )
->>>>>>> main
       ),
       Api.Response(
         Api.SuggestionsDatabaseModuleUpdateNotification(
@@ -2342,13 +2315,15 @@ class RuntimeServerTest
         contextId,
         id1,
         Constants.INTEGER,
-        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded")
+        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded"),
+        fromCache = true
       ),
       context.Message.update(
         contextId,
         id1,
         Constants.INTEGER,
-        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded")
+        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded"),
+        fromCache = true
       ),
       context.Message.updateOld(
         contextId,
@@ -2373,45 +2348,6 @@ class RuntimeServerTest
         id3,
         Constants.INTEGER,
         Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded")
-||||||| 3b48fc7e
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              id3,
-              Some(Constants.INTEGER),
-              Some(
-                Api.MethodPointer(
-                  moduleName,
-                  Constants.NUMBER,
-                  "overloaded"
-                )
-              )
-            )
-          )
-        )
-=======
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              id3,
-              Some(Constants.INTEGER),
-              Some(
-                Api.MethodPointer(
-                  moduleName,
-                  Constants.NUMBER,
-                  "overloaded"
-                )
-              ),
-              Vector(ProfilingInfo.ExecutionTime(0)),
-              fromCache = false
-            )
-          )
-        )
->>>>>>> main
       ),
       context.executionComplete(contextId)
     )
@@ -2439,13 +2375,15 @@ class RuntimeServerTest
         contextId,
         id1,
         Constants.INTEGER,
-        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded")
+        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded"),
+        fromCache = true
       ),
       context.Message.update(
         contextId,
         id1,
         Constants.INTEGER,
-        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded")
+        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded"),
+        fromCache = true
       ),
       context.Message.updateOld(
         contextId,
@@ -2470,45 +2408,6 @@ class RuntimeServerTest
         id3,
         Constants.INTEGER,
         Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded")
-||||||| 3b48fc7e
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              id3,
-              Some(Constants.INTEGER),
-              Some(
-                Api.MethodPointer(
-                  moduleName,
-                  Constants.NUMBER,
-                  "overloaded"
-                )
-              )
-            )
-          )
-        )
-=======
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              id3,
-              Some(Constants.INTEGER),
-              Some(
-                Api.MethodPointer(
-                  moduleName,
-                  Constants.NUMBER,
-                  "overloaded"
-                )
-              ),
-              Vector(ProfilingInfo.ExecutionTime(0)),
-              false
-            )
-          )
-        )
->>>>>>> main
       ),
       context.executionComplete(contextId)
     )
@@ -2536,13 +2435,15 @@ class RuntimeServerTest
         contextId,
         id1,
         Constants.INTEGER,
-        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded")
+        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded"),
+        fromCache = true
       ),
       context.Message.update(
         contextId,
         id1,
         Constants.INTEGER,
-        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded")
+        Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded"),
+        fromCache = true
       ),
       context.Message.updateOld(
         contextId,
@@ -2567,45 +2468,6 @@ class RuntimeServerTest
         id3,
         Constants.INTEGER,
         Api.MethodPointer(moduleName, Constants.NUMBER, "overloaded")
-||||||| 3b48fc7e
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              id3,
-              Some(Constants.INTEGER),
-              Some(
-                Api.MethodPointer(
-                  moduleName,
-                  Constants.NUMBER,
-                  "overloaded"
-                )
-              )
-            )
-          )
-        )
-=======
-      Api.Response(
-        Api.ExpressionValuesComputed(
-          contextId,
-          Vector(
-            Api.ExpressionValueUpdate(
-              id3,
-              Some(Constants.INTEGER),
-              Some(
-                Api.MethodPointer(
-                  moduleName,
-                  Constants.NUMBER,
-                  "overloaded"
-                )
-              ),
-              Vector(ProfilingInfo.ExecutionTime(0)),
-              false
-            )
-          )
-        )
->>>>>>> main
       ),
       context.executionComplete(contextId)
     )
@@ -3011,8 +2873,8 @@ class RuntimeServerTest
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
     context.receive(4) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PopContextResponse(contextId)),
-      context.Main.UpdateOld.mainY(contextId),
-      context.Main.Update.mainY(contextId),
+      context.Main.UpdateOld.mainY(contextId, fromCache = true),
+      context.Main.Update.mainY(contextId, fromCache = true),
       context.executionComplete(contextId)
     )
 


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1283

PR adds the new `executionContext/expressionUpdates` API that replaces `executionContext/expressionValueUpdates` notification, and in the future will be extended to support the dataflow errors.

Changelog:
- add: `executionContext/expressionUpdates` notification that returns information about computed, failed and poisoned expressions, superseding the `executionContext/expressionValueUpdates` notification
- update: resolve expression ids for error location
- refactor: runtime tests

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
