### PR TITLE
Add Null Check when Executing Host Values

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/syntax/HostValueToEnsoNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/syntax/HostValueToEnsoNode.java
@@ -58,7 +58,7 @@ public abstract class HostValueToEnsoNode extends Node {
     return Text.create(txt);
   }
 
-  @Specialization(guards = "o == null || nulls.isNull(o)")
+  @Specialization(guards = {"o != null", "nulls.isNull(o)"})
   Atom doNull(
       Object o,
       @CachedLibrary(limit = "3") InteropLibrary nulls,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/syntax/HostValueToEnsoNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/syntax/HostValueToEnsoNode.java
@@ -58,7 +58,7 @@ public abstract class HostValueToEnsoNode extends Node {
     return Text.create(txt);
   }
 
-  @Specialization(guards = "nulls.isNull(o)")
+  @Specialization(guards = "o == null || nulls.isNull(o)")
   Atom doNull(
       Object o,
       @CachedLibrary(limit = "3") InteropLibrary nulls,

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -444,13 +444,13 @@ class RuntimeServerTest
     val moduleName = "Test.Main"
 
     val metadata  = new Metadata
-    val idMain    = metadata.addItem(45, 24)
-    val idMainFoo = metadata.addItem(61, 8)
+    val idMain    = metadata.addItem(49, 24)
+    val idMainFoo = metadata.addItem(65, 8)
 
     val code =
       """from Builtins import all
         |
-        |foo a=0 = a
+        |foo a=0 = a + 1
         |
         |main =
         |    IO.println here.foo
@@ -516,7 +516,7 @@ class RuntimeServerTest
       ),
       context.executionComplete(contextId)
     )
-    context.consumeOut shouldEqual List("0")
+    context.consumeOut shouldEqual List("1")
 
     // push foo call
     context.send(
@@ -529,7 +529,7 @@ class RuntimeServerTest
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       context.executionComplete(contextId)
     )
-    context.consumeOut shouldEqual List("0")
+    context.consumeOut shouldEqual List("1")
   }
 
   it should "send method pointer updates" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -438,6 +438,100 @@ class RuntimeServerTest
     )
   }
 
+  it should "push method with default arguments" in {
+    val contextId  = UUID.randomUUID()
+    val requestId  = UUID.randomUUID()
+    val moduleName = "Test.Main"
+
+    val metadata  = new Metadata
+    val idMain    = metadata.addItem(45, 24)
+    val idMainFoo = metadata.addItem(61, 8)
+
+    val code =
+      """from Builtins import all
+        |
+        |foo a=0 = a
+        |
+        |main =
+        |    IO.println here.foo
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // open file
+    context.send(
+      Api.Request(Api.OpenFileNotification(mainFile, contents, true))
+    )
+    context.receiveNone shouldEqual None
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, "Test.Main", "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+    context.receive(4) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      Api.Response(
+        Api.ExpressionValuesComputed(
+          contextId,
+          Vector(
+            Api.ExpressionValueUpdate(
+              idMainFoo,
+              Some(Constants.INTEGER),
+              Some(Api.MethodPointer(moduleName, "Test.Main", "foo")),
+              Vector(ProfilingInfo.ExecutionTime(0)),
+              false
+            )
+          )
+        )
+      ),
+      Api.Response(
+        Api.ExpressionValuesComputed(
+          contextId,
+          Vector(
+            Api.ExpressionValueUpdate(
+              idMain,
+              Some(Constants.NOTHING),
+              None,
+              Vector(ProfilingInfo.ExecutionTime(0)),
+              false
+            )
+          )
+        )
+      ),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual List("0")
+
+    // push foo call
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(contextId, Api.StackItem.LocalCall(idMainFoo))
+      )
+    )
+    context.receive(2) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual List("0")
+  }
+
   it should "send method pointer updates" in {
     val contextId  = UUID.randomUUID()
     val requestId  = UUID.randomUUID()


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1401 

Fix the execution of default arguments (represented with null values) by adding an extra null check.

Changelog:
- add: extra null check, because `isNull` doesn't allow `null` arguments

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
