### PR TITLE
Fix Dataflow Analysis of Undefined Variables

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/Passes.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Passes.scala
@@ -59,10 +59,10 @@ class Passes(passes: Option[List[PassGroup]] = None) {
       TailCall,
       Patterns,
       AliasAnalysis,
+      UndefinedVariables,
       DataflowAnalysis,
       CachePreferenceAnalysis,
-      UnusedBindings,
-      UndefinedVariables
+      UnusedBindings
     )
   )
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/UndefinedVariables.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/UndefinedVariables.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.pass.analyse
 
 import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
+import org.enso.compiler.core.ir.MetadataStorage._
 import org.enso.compiler.pass.IRPass
 
 /** Reports errors for local variables that are not linked to a definition
@@ -61,7 +62,9 @@ case object UndefinedVariables extends IRPass {
         occ.graph.defLinkFor(occ.id) match {
           case Some(_) => name
           case None =>
-            IR.Error.Resolution(name, IR.Error.Resolution.VariableNotInScope)
+            val errorResolutionNode =
+              IR.Error.Resolution(name, IR.Error.Resolution.VariableNotInScope)
+            errorResolutionNode.updateMetadata(AliasAnalysis -->> occ)
         }
       } else { name }
 

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
@@ -845,6 +845,31 @@ class DataflowAnalysisTest extends CompilerTest {
       depInfo.getDirect(bindingExprId) shouldEqual Some(Set(bindingId))
     }
 
+    "work properly for undefined variables" in {
+      implicit val inlineContext: InlineContext = mkInlineContext
+
+      val ir =
+        """
+          |x = undefined
+          |""".stripMargin.preprocessExpression.get.analyse
+
+      val depInfo = ir.getMetadata(DataflowAnalysis).get
+
+      val binding     = ir.asInstanceOf[IR.Expression.Binding]
+      val bindingName = binding.name.asInstanceOf[IR.Name.Literal]
+      val bindingExpr = binding.expression.asInstanceOf[IR.Error.Resolution]
+
+      // The IDs
+      val bindingId     = mkStaticDep(binding.getId)
+      val bindingNameId = mkStaticDep(bindingName.getId)
+      val bindingExprId = mkStaticDep(bindingExpr.getId)
+
+      // The Test
+      depInfo.getDirect(bindingId) should not be defined
+      depInfo.getDirect(bindingNameId) shouldEqual Some(Set(bindingId))
+      depInfo.getDirect(bindingExprId) shouldEqual Some(Set(bindingId))
+    }
+
     "work properly for vector literals" in {
       implicit val inlineContext: InlineContext = mkInlineContext
 

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
@@ -322,7 +322,7 @@ class DataflowAnalysisTest extends CompilerTest {
 
     // The `frobnicate` return expression
     val frobExpr = fnBody.returnValue.asInstanceOf[IR.Application.Prefix]
-    val frobFn   = frobExpr.function.asInstanceOf[IR.Name.Literal]
+    val frobFn   = frobExpr.function.asInstanceOf[IR.Error.Resolution]
     val frobArgA =
       frobExpr.arguments.head.asInstanceOf[IR.CallArgument.Specified]
     val frobArgAExpr = frobArgA.value.asInstanceOf[IR.Name.Literal]
@@ -705,7 +705,7 @@ class DataflowAnalysisTest extends CompilerTest {
       val depInfo = ir.getMetadata(DataflowAnalysis).get
 
       val app   = ir.asInstanceOf[IR.Application.Prefix]
-      val appFn = app.function.asInstanceOf[IR.Name.Literal]
+      val appFn = app.function.asInstanceOf[IR.Error.Resolution]
       val appArg10 =
         app.arguments.head.asInstanceOf[IR.CallArgument.Specified]
       val appArg10Expr = appArg10.value.asInstanceOf[IR.Literal.Number]


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1406 

`UndefinedVariables` compiler pass wraps undefined variables in `IR.Error.Resolution` constructor, and should be executed before `DataflowAnalysis`.

Changelog:
- fix: the ordering of compiler phases

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
