### PR TITLE
Dataflow Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <br/>
 </p>
 
-### Get insights you can act on, fast.
+### Get insights you can act on, fast
 
 <p>
   <a href="http://chat.enso.org">

--- a/distribution/std-lib/Test/src/Test.enso
+++ b/distribution/std-lib/Test/src/Test.enso
@@ -48,8 +48,17 @@ Any.should verb argument = verb Verbs this argument
 ## Fail a test with the given message.
 fail message = Panic.throw (Failure message)
 
-## Expect a function to fail with the provided error.
-expect_fail_with ~action matcher =
+## Expect a function to fail with the provided dataflow error.
+expect_error_with ~action matcher =
+    result = action
+    fail_msg = "Expected an error " + matcher.to_text + "but none occurred."
+    if result.is_error.not then here.fail fail_msg else
+        caught = result.catch x->x
+        if caught.is_a matcher then Nothing else
+            here.fail ("Unexpected error " + caught.to_text + " thrown.")
+
+## Expect a function to fail with the provided panic.
+expect_panic_with ~action matcher =
     res = Panic.recover action
     case res of
         _ -> here.fail ("Expected a " + matcher.to_text + " to be thrown, but the action succeeded.")

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.node.callable;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.GenerateUncached;
@@ -15,6 +16,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.NotInvokableException;
+import org.enso.interpreter.runtime.error.PanicSentinel;
 import org.enso.interpreter.runtime.state.Stateful;
 
 /**
@@ -104,6 +106,19 @@ public abstract class IndirectInvokeCallableNode extends Node {
       InvokeCallableNode.ArgumentsExecutionMode argumentsExecutionMode,
       BaseNode.TailStatus isTail) {
     return new Stateful(state, error);
+  }
+
+  @Specialization
+  Stateful invokePanicSentinel(
+      PanicSentinel sentinel,
+      MaterializedFrame callerFrame,
+      Object state,
+      Object[] arguments,
+      CallArgumentInfo[] schema,
+      InvokeCallableNode.DefaultsExecutionMode defaultsExecutionMode,
+      InvokeCallableNode.ArgumentsExecutionMode argumentsExecutionMode,
+      BaseNode.TailStatus isTail) {
+    throw sentinel;
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
@@ -94,6 +94,19 @@ public abstract class IndirectInvokeCallableNode extends Node {
   }
 
   @Specialization
+  Stateful invokeDataflowError(
+      DataflowError error,
+      MaterializedFrame callerFrame,
+      Object state,
+      Object[] arguments,
+      CallArgumentInfo[] schema,
+      InvokeCallableNode.DefaultsExecutionMode defaultsExecutionMode,
+      InvokeCallableNode.ArgumentsExecutionMode argumentsExecutionMode,
+      BaseNode.TailStatus isTail) {
+    return new Stateful(state, error);
+  }
+
+  @Specialization
   public Stateful invokeDynamicSymbol(
       UnresolvedSymbol symbol,
       MaterializedFrame callerFrame,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.node.callable;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.GenerateUncached;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.node.callable;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
@@ -28,6 +29,7 @@ import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.Array;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.DataflowError;
+import org.enso.interpreter.runtime.error.PanicSentinel;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 import org.enso.interpreter.runtime.state.Stateful;
 
@@ -279,6 +281,20 @@ public abstract class IndirectInvokeMethodNode extends Node {
           argumentsExecutionMode,
           isTail);
     }
+  }
+
+  @Specialization
+  Stateful doPanicSentinel(
+      MaterializedFrame frame,
+      Object state,
+      UnresolvedSymbol symbol,
+      PanicSentinel _this,
+      Object[] arguments,
+      CallArgumentInfo[] schema,
+      InvokeCallableNode.DefaultsExecutionMode defaultsExecutionMode,
+      InvokeCallableNode.ArgumentsExecutionMode argumentsExecutionMode,
+      BaseNode.TailStatus isTail) {
+    throw _this;
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
@@ -20,6 +20,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.NotInvokableException;
+import org.enso.interpreter.runtime.error.PanicSentinel;
 import org.enso.interpreter.runtime.state.Stateful;
 
 /**
@@ -146,6 +147,12 @@ public abstract class InvokeCallableNode extends BaseNode {
   Stateful invokeDataflowError(
       DataflowError error, VirtualFrame callerFrame, Object state, Object[] arguments) {
     return new Stateful(state, error);
+  }
+
+  @Specialization
+  Stateful invokePanicSentinel(
+      PanicSentinel sentinel, VirtualFrame callerFrame, Object state, Object[] arguments) {
+    throw sentinel;
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
@@ -143,6 +143,12 @@ public abstract class InvokeCallableNode extends BaseNode {
   }
 
   @Specialization
+  Stateful invokeDataflowError(
+      DataflowError error, VirtualFrame callerFrame, Object state, Object[] arguments) {
+    return new Stateful(state, error);
+  }
+
+  @Specialization
   public Stateful invokeDynamicSymbol(
       UnresolvedSymbol symbol, VirtualFrame callerFrame, Object state, Object[] arguments) {
     if (canApplyThis) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
@@ -1,13 +1,12 @@
 package org.enso.interpreter.node.callable;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.ConditionProfile;
 import com.oracle.truffle.api.source.SourceSection;
-import com.oracle.truffle.dsl.processor.java.model.CodeAnnotationMirror;
+import java.util.UUID;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.dispatch.InvokeFunctionNode;
 import org.enso.interpreter.node.callable.resolver.ArrayResolverNode;
@@ -32,8 +31,6 @@ import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.PanicSentinel;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 import org.enso.interpreter.runtime.state.Stateful;
-
-import java.util.UUID;
 
 public abstract class InvokeMethodNode extends BaseNode {
   private @Child InvokeFunctionNode invokeFunctionNode;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
@@ -7,6 +7,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.ConditionProfile;
 import com.oracle.truffle.api.source.SourceSection;
+import com.oracle.truffle.dsl.processor.java.model.CodeAnnotationMirror;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.dispatch.InvokeFunctionNode;
 import org.enso.interpreter.node.callable.resolver.ArrayResolverNode;
@@ -28,6 +29,7 @@ import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.Array;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.DataflowError;
+import org.enso.interpreter.runtime.error.PanicSentinel;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 import org.enso.interpreter.runtime.state.Stateful;
 
@@ -179,6 +181,16 @@ public abstract class InvokeMethodNode extends BaseNode {
     } else {
       return invokeFunctionNode.execute(function, frame, state, arguments);
     }
+  }
+
+  @Specialization
+  Stateful doPanicSentinel(
+      VirtualFrame frame,
+      Object state,
+      UnresolvedSymbol symbol,
+      PanicSentinel _this,
+      Object[] arguments) {
+    throw _this;
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
@@ -14,6 +14,7 @@ import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.PanicException;
+import org.enso.interpreter.runtime.error.PanicSentinel;
 import org.enso.interpreter.runtime.type.TypesGen;
 
 /**
@@ -56,6 +57,19 @@ public abstract class CaseNode extends ExpressionNode {
   @Specialization
   public Object doError(VirtualFrame frame, DataflowError error) {
     return error;
+  }
+
+  /**
+   * Rethrows a panic sentinel if it encounters one.
+   *
+   * @param frame the stack frame in which to execute
+   * @param sentinel the sentinel being matched against
+   * @return nothing
+   */
+  @Specialization
+  public Object doPanicSentinel(VirtualFrame frame, PanicSentinel sentinel) {
+    CompilerDirectives.transferToInterpreter();
+    throw sentinel;
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
@@ -80,7 +80,7 @@ public abstract class CaseNode extends ExpressionNode {
    * @param ctx the language context reference
    * @return the result of executing the case expression on {@code object}
    */
-  @Specialization(guards = "!isDataflowError(object)")
+  @Specialization(guards = {"!isDataflowError(object)", "!isPanicSentinel(object)"})
   @ExplodeLoop
   public Object doMatch(
       VirtualFrame frame,
@@ -104,6 +104,10 @@ public abstract class CaseNode extends ExpressionNode {
 
   boolean isDataflowError(Object error) {
     return TypesGen.isDataflowError(error);
+  }
+
+  boolean isPanicSentinel(Object sentinel) {
+    return TypesGen.isPanicSentinel(sentinel);
   }
 
   /* Note [Branch Selection Control Flow]

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/atom/InstantiateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/atom/InstantiateNode.java
@@ -51,8 +51,13 @@ public class InstantiateNode extends ExpressionNode {
   public Object executeGeneric(VirtualFrame frame) {
     Object[] argumentValues = new Object[arguments.length];
     for (int i = 0; i < arguments.length; i++) {
+      ConditionProfile profile = profiles[i];
       Object argument = arguments[i].executeGeneric(frame);
-      argumentValues[i] = argument;
+      if (profile.profile(TypesGen.isDataflowError(argument))) {
+        return argument;
+      } else {
+        argumentValues[i] = argument;
+      }
     }
     return constructor.newInstance(argumentValues);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/atom/InstantiateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/atom/InstantiateNode.java
@@ -4,6 +4,7 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.profiles.BranchProfile;
 import com.oracle.truffle.api.profiles.ConditionProfile;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
@@ -18,13 +19,16 @@ public class InstantiateNode extends ExpressionNode {
   private final AtomConstructor constructor;
   private @Children ExpressionNode[] arguments;
   private @CompilationFinal(dimensions = 1) ConditionProfile[] profiles;
+  private @CompilationFinal(dimensions = 1) BranchProfile[] sentinelProfiles;
 
   InstantiateNode(AtomConstructor constructor, ExpressionNode[] arguments) {
     this.constructor = constructor;
     this.arguments = arguments;
     this.profiles = new ConditionProfile[arguments.length];
+    this.sentinelProfiles = new BranchProfile[arguments.length];
     for (int i = 0; i < arguments.length; ++i) {
       this.profiles[i] = ConditionProfile.createCountingProfile();
+      this.sentinelProfiles[i] = BranchProfile.create();
     }
   }
 
@@ -52,9 +56,13 @@ public class InstantiateNode extends ExpressionNode {
     Object[] argumentValues = new Object[arguments.length];
     for (int i = 0; i < arguments.length; i++) {
       ConditionProfile profile = profiles[i];
+      BranchProfile sentinelProfile = sentinelProfiles[i];
       Object argument = arguments[i].executeGeneric(frame);
       if (profile.profile(TypesGen.isDataflowError(argument))) {
         return argument;
+      } else if (TypesGen.isPanicSentinel(argument)) {
+        sentinelProfile.enter();
+        throw TypesGen.asPanicSentinel(argument);
       } else {
         argumentValues[i] = argument;
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.Language;
+import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.node.callable.InvokeCallableNode;
@@ -31,7 +32,7 @@ public abstract class PrintErrNode extends Node {
   }
 
   abstract Stateful execute(
-      VirtualFrame frame, @MonadicState Object state, Object _this, Object message);
+      VirtualFrame frame, @MonadicState Object state, Object _this, @AcceptsError Object message);
 
   @Specialization
   Stateful doPrintText(

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
@@ -1,12 +1,12 @@
 package org.enso.interpreter.node.expression.builtin.io;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
+import java.io.PrintStream;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
@@ -19,8 +19,6 @@ import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.state.Stateful;
 import org.enso.interpreter.runtime.type.TypesGen;
-
-import java.io.PrintStream;
 
 @BuiltinMethod(
     type = "IO",

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
@@ -3,7 +3,6 @@ package org.enso.interpreter.node.expression.builtin.io;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.CachedContext;
-import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
@@ -9,6 +9,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import java.io.PrintStream;
 import org.enso.interpreter.Language;
+import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.node.callable.InvokeCallableNode;
@@ -29,13 +30,13 @@ public abstract class PrintlnNode extends Node {
           InvokeCallableNode.ArgumentsExecutionMode.PRE_EXECUTED);
 
   abstract Stateful execute(
-      VirtualFrame frame, @MonadicState Object state, Object _this, Object message);
+      VirtualFrame frame, @MonadicState Object state, Object _this, @AcceptsError Object message);
 
   @Specialization
   Stateful doPrintText(
       VirtualFrame frame,
       Object state,
-      Object self,
+      Object _this,
       Text message,
       @CachedContext(Language.class) Context ctx,
       @Cached("build()") ToJavaStringNode toJavaStringNode) {
@@ -47,7 +48,7 @@ public abstract class PrintlnNode extends Node {
   Stateful doPrint(
       VirtualFrame frame,
       Object state,
-      Object self,
+      Object _this,
       Object message,
       @CachedContext(Language.class) Context ctx,
       @Cached("buildSymbol(ctx)") UnresolvedSymbol symbol,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsAtomConstructorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsAtomConstructorNode.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.type.TypesGen;
 
@@ -9,7 +10,7 @@ import org.enso.interpreter.runtime.type.TypesGen;
     name = "is_atom_constructor",
     description = "Checks if the argument is a constructor.")
 public class IsAtomConstructorNode extends Node {
-  boolean execute(Object _this, Object value) {
+  boolean execute(Object _this, @AcceptsError Object value) {
     return TypesGen.isAtomConstructor(value);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsAtomNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsAtomNode.java
@@ -1,12 +1,13 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.type.TypesGen;
 
 @BuiltinMethod(type = "Meta", name = "is_atom", description = "Checks if the argument is an atom")
 public class IsAtomNode extends Node {
-  boolean execute(Object _this, Object value) {
+  boolean execute(Object _this, @AcceptsError Object value) {
     return TypesGen.isAtom(value);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsErrorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsErrorNode.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.type.TypesGen;
 
@@ -9,7 +10,7 @@ import org.enso.interpreter.runtime.type.TypesGen;
     name = "is_error",
     description = "Checks if the argument is an error.")
 public class IsErrorNode extends Node {
-  boolean execute(Object _this, Object value) {
+  boolean execute(Object _this, @AcceptsError Object value) {
     return TypesGen.isDataflowError(value);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsPolyglotNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsPolyglotNode.java
@@ -4,6 +4,7 @@ import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.Language;
+import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.type.TypesGen;
@@ -17,7 +18,7 @@ public abstract class IsPolyglotNode extends Node {
     return IsPolyglotNodeGen.create();
   }
 
-  abstract boolean execute(Object _this, Object value);
+  abstract boolean execute(Object _this, @AcceptsError Object value);
 
   @Specialization
   boolean doExecute(Object _this, Object value, @CachedContext(Language.class) Context context) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsPolyglotNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsPolyglotNode.java
@@ -7,7 +7,6 @@ import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
-import org.enso.interpreter.runtime.type.TypesGen;
 
 @BuiltinMethod(
     type = "Meta",

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.type.TypesGen;
 
@@ -9,7 +10,7 @@ import org.enso.interpreter.runtime.type.TypesGen;
     name = "is_same_object",
     description = "Checks if the two arguments share an underlying reference.")
 public class IsSameObjectNode extends Node {
-  boolean execute(Object _this, Object value_1, Object value_2) {
+  boolean execute(Object _this, @AcceptsError Object value_1, @AcceptsError Object value_2) {
     return value_1 == value_2;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsSameObjectNode.java
@@ -3,7 +3,6 @@ package org.enso.interpreter.node.expression.builtin.meta;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
-import org.enso.interpreter.runtime.type.TypesGen;
 
 @BuiltinMethod(
     type = "Meta",

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsUnresolvedSymbolNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsUnresolvedSymbolNode.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.type.TypesGen;
 
@@ -9,7 +10,7 @@ import org.enso.interpreter.runtime.type.TypesGen;
     name = "is_unresolved_symbol",
     description = "Checks if the argument is an unresolved symbol.")
 public class IsUnresolvedSymbolNode extends Node {
-  boolean execute(Object _this, Object value) {
+  boolean execute(Object _this, @AcceptsError Object value) {
     return TypesGen.isUnresolvedSymbol(value);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitShiftNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitShiftNode.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.TruffleLanguage.ContextReference;
 import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
@@ -15,7 +14,6 @@ import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNod
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.DataflowError;
-import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.TypeError;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 
@@ -23,8 +21,10 @@ import org.enso.interpreter.runtime.number.EnsoBigInteger;
 @BuiltinMethod(type = "Big_Integer", name = "bit_shift", description = "Bitwise shift.")
 public abstract class BitShiftNode extends Node {
   private @Child ToEnsoNumberNode toEnsoNumberNode = ToEnsoNumberNode.build();
-  private final ConditionProfile fitsInIntProfileLeftShift = ConditionProfile.createCountingProfile();
-  private final ConditionProfile fitsInIntProfileRightShift = ConditionProfile.createCountingProfile();
+  private final ConditionProfile fitsInIntProfileLeftShift =
+      ConditionProfile.createCountingProfile();
+  private final ConditionProfile fitsInIntProfileRightShift =
+      ConditionProfile.createCountingProfile();
 
   abstract Object execute(Object _this, Object that);
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitShiftNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitShiftNode.java
@@ -14,6 +14,7 @@ import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.TypeError;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
@@ -37,14 +38,14 @@ public abstract class BitShiftNode extends Node {
   }
 
   @Specialization(guards = "that >= 0", replaces = "doBigIntShiftLeft")
-  EnsoBigInteger doBigIntShiftLeftExplicit(
+  Object doBigIntShiftLeftExplicit(
       EnsoBigInteger _this,
       long that,
       @CachedContext(Language.class) ContextReference<Context> ctxRef) {
     if (fitsInIntProfileLeftShift.profile(BigIntegerOps.fitsInInt(that))) {
       return doBigIntShiftLeft(_this, that);
     } else {
-      throw new PanicException(
+      return DataflowError.withDefaultTrace(
           ctxRef.get().getBuiltins().error().getShiftAmountTooLargeError(), this);
     }
   }
@@ -72,8 +73,7 @@ public abstract class BitShiftNode extends Node {
       return BigIntegerOps.nonNegative(_this.getValue()) ? 0L : -1L;
     } else {
       // Note [Well-Formed BigIntegers]
-      CompilerDirectives.transferToInterpreter();
-      throw new PanicException(
+      return DataflowError.withDefaultTrace(
           ctxRef.get().getBuiltins().error().getShiftAmountTooLargeError(), this);
     }
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/DivNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/DivNode.java
@@ -1,7 +1,6 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
 import com.oracle.truffle.api.TruffleLanguage.ContextReference;
-import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/DivNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/DivNode.java
@@ -1,11 +1,17 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
+import com.oracle.truffle.api.TruffleLanguage.ContextReference;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
+import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.TypeError;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 
@@ -20,12 +26,21 @@ public abstract class DivNode extends Node {
   }
 
   @Specialization
-  Object doLong(EnsoBigInteger _this, long that) {
-    return toEnsoNumberNode.execute(BigIntegerOps.divide(_this.getValue(), that));
+  Object doLong(
+      EnsoBigInteger _this,
+      long that,
+      @CachedContext(Language.class) ContextReference<Context> ctxRef) {
+    try {
+      return toEnsoNumberNode.execute(BigIntegerOps.divide(_this.getValue(), that));
+    } catch (ArithmeticException e) {
+      return DataflowError.withDefaultTrace(
+          ctxRef.get().getBuiltins().error().getDivideByZeroError(), this);
+    }
   }
 
   @Specialization
   Object doBigInteger(EnsoBigInteger _this, EnsoBigInteger that) {
+    // No need to trap, as 0 is never represented as an EnsoBigInteger.
     return toEnsoNumberNode.execute(BigIntegerOps.divide(_this.getValue(), that.getValue()));
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/ModNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/ModNode.java
@@ -1,11 +1,16 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
+import com.oracle.truffle.api.TruffleLanguage.ContextReference;
+import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
+import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.TypeError;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 
@@ -20,12 +25,21 @@ public abstract class ModNode extends Node {
   }
 
   @Specialization
-  Object doLong(EnsoBigInteger _this, long that) {
-    return toEnsoNumberNode.execute(BigIntegerOps.modulo(_this.getValue(), that));
+  Object doLong(
+      EnsoBigInteger _this,
+      long that,
+      @CachedContext(Language.class) ContextReference<Context> ctxRef) {
+    try {
+      return toEnsoNumberNode.execute(BigIntegerOps.modulo(_this.getValue(), that));
+    } catch (ArithmeticException e) {
+      return DataflowError.withDefaultTrace(
+          ctxRef.get().getBuiltins().error().getDivideByZeroError(), this);
+    }
   }
 
   @Specialization
   Object doBigInteger(EnsoBigInteger _this, EnsoBigInteger that) {
+    // No need to trap, as 0 is never represented as an EnsoBigInteger.
     return toEnsoNumberNode.execute(BigIntegerOps.modulo(_this.getValue(), that.getValue()));
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitShiftNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitShiftNode.java
@@ -14,6 +14,7 @@ import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.TypeError;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
@@ -48,7 +49,7 @@ public abstract class BitShiftNode extends Node {
     } else if (positiveFitsInInt.profile(BigIntegerOps.fitsInInt(that))) {
       return toEnsoNumberNode.execute(BigIntegerOps.bitShiftLeft(_this, (int) that));
     } else {
-      throw new PanicException(
+      return DataflowError.withDefaultTrace(
           ctxRef.get().getBuiltins().error().getShiftAmountTooLargeError(), this);
     }
   }
@@ -80,8 +81,7 @@ public abstract class BitShiftNode extends Node {
       return _this >= 0 ? 0L : -1L;
     } else {
       // Note [Well-Formed BigIntegers]
-      CompilerDirectives.transferToInterpreter();
-      throw new PanicException(
+      return DataflowError.withDefaultTrace(
           ctxRef.get().getBuiltins().error().getShiftAmountTooLargeError(), this);
     }
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitShiftNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitShiftNode.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.TruffleLanguage.ContextReference;
 import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
@@ -15,7 +14,6 @@ import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNod
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.DataflowError;
-import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.TypeError;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/DivNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/DivNode.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import javax.xml.crypto.Data;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/DivNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/DivNode.java
@@ -1,9 +1,15 @@
 package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 
+import com.oracle.truffle.api.TruffleLanguage.ContextReference;
+import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
+import javax.xml.crypto.Data;
+import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.TypeError;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 
@@ -16,12 +22,19 @@ public abstract class DivNode extends Node {
   }
 
   @Specialization
-  long doLong(long _this, long that) {
-    return _this / that;
+  Object doLong(
+      long _this, long that, @CachedContext(Language.class) ContextReference<Context> ctxRef) {
+    try {
+      return _this / that;
+    } catch (ArithmeticException e) {
+      return DataflowError.withDefaultTrace(
+          ctxRef.get().getBuiltins().error().getDivideByZeroError(), this);
+    }
   }
 
   @Specialization
-  long doBigInteger(long _this, EnsoBigInteger that) {
+  Object doBigInteger(long _this, EnsoBigInteger that) {
+    // No need to trap, as 0 is never represented as an EnsoBigInteger.
     return 0L;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/ModNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/ModNode.java
@@ -1,9 +1,14 @@
 package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 
+import com.oracle.truffle.api.TruffleLanguage.ContextReference;
+import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.TypeError;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 
@@ -16,12 +21,19 @@ public abstract class ModNode extends Node {
   }
 
   @Specialization
-  long doLong(long _this, long that) {
-    return _this % that;
+  Object doLong(
+      long _this, long that, @CachedContext(Language.class) ContextReference<Context> ctxRef) {
+    try {
+      return _this % that;
+    } catch (ArithmeticException e) {
+      return DataflowError.withDefaultTrace(
+          ctxRef.get().getBuiltins().error().getDivideByZeroError(), this);
+    }
   }
 
   @Specialization
   long doBigInteger(long _this, EnsoBigInteger that) {
+    // No need to trap, as 0 is never represented as an EnsoBigInteger.
     return _this;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/GetStateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/GetStateNode.java
@@ -7,6 +7,7 @@ import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.state.data.EmptyMap;
 import org.enso.interpreter.runtime.state.data.SingletonMap;
 import org.enso.interpreter.runtime.state.data.SmallMap;
@@ -50,7 +51,7 @@ public abstract class GetStateNode extends Node {
       @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> ctxRef) {
     int idx = state.indexOf(key);
     if (idx == SmallMap.NOT_FOUND) {
-      throw new PanicException(
+      return DataflowError.withDefaultTrace(
           ctxRef.get().getBuiltins().error().uninitializedState().newInstance(key), this);
     } else {
       return state.getValues()[idx];
@@ -60,12 +61,14 @@ public abstract class GetStateNode extends Node {
   @Specialization
   Object doEmpty(
       EmptyMap state, Object _this, Object key, @CachedContext(Language.class) Context ctx) {
-    throw new PanicException(ctx.getBuiltins().error().uninitializedState().newInstance(key), this);
+    return DataflowError.withDefaultTrace(
+        ctx.getBuiltins().error().uninitializedState().newInstance(key), this);
   }
 
   @Specialization
   Object doSingletonError(
       SingletonMap state, Object _this, Object key, @CachedContext(Language.class) Context ctx) {
-    throw new PanicException(ctx.getBuiltins().error().uninitializedState().newInstance(key), this);
+    return DataflowError.withDefaultTrace(
+        ctx.getBuiltins().error().uninitializedState().newInstance(key), this);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/GetStateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/GetStateNode.java
@@ -1,7 +1,11 @@
 package org.enso.interpreter.node.expression.builtin.state;
 
 import com.oracle.truffle.api.TruffleLanguage;
-import com.oracle.truffle.api.dsl.*;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.CachedContext;
+import com.oracle.truffle.api.dsl.ImportStatic;
+import com.oracle.truffle.api.dsl.ReportPolymorphism;
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
@@ -11,7 +15,6 @@ import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.state.data.EmptyMap;
 import org.enso.interpreter.runtime.state.data.SingletonMap;
 import org.enso.interpreter.runtime.state.data.SmallMap;
-import org.enso.interpreter.runtime.error.PanicException;
 
 @BuiltinMethod(
     type = "State",

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/PutStateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/PutStateNode.java
@@ -1,17 +1,20 @@
 package org.enso.interpreter.node.expression.builtin.state;
 
 import com.oracle.truffle.api.TruffleLanguage;
-import com.oracle.truffle.api.dsl.*;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.CachedContext;
+import com.oracle.truffle.api.dsl.ImportStatic;
+import com.oracle.truffle.api.dsl.ReportPolymorphism;
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.error.DataflowError;
+import org.enso.interpreter.runtime.state.Stateful;
 import org.enso.interpreter.runtime.state.data.SingletonMap;
 import org.enso.interpreter.runtime.state.data.SmallMap;
-import org.enso.interpreter.runtime.error.PanicException;
-import org.enso.interpreter.runtime.state.Stateful;
 
 @BuiltinMethod(type = "State", name = "put", description = "Updates the value of monadic state.")
 @ImportStatic(SmallMap.class)

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/PutStateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/PutStateNode.java
@@ -7,6 +7,7 @@ import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.state.data.SingletonMap;
 import org.enso.interpreter.runtime.state.data.SmallMap;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -53,8 +54,10 @@ public abstract class PutStateNode extends Node {
       @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> ctxRef) {
     int index = state.indexOf(key);
     if (index == SmallMap.NOT_FOUND) {
-      throw new PanicException(
-          ctxRef.get().getBuiltins().error().uninitializedState().newInstance(key), this);
+      return new Stateful(
+          state,
+          DataflowError.withDefaultTrace(
+              ctxRef.get().getBuiltins().error().uninitializedState().newInstance(key), this));
     } else {
       return doExistingMultiCached(state, _this, key, new_state, key, state.getKeys(), index);
     }
@@ -67,6 +70,9 @@ public abstract class PutStateNode extends Node {
       Object key,
       Object new_state,
       @CachedContext(Language.class) Context ctx) {
-    throw new PanicException(ctx.getBuiltins().error().uninitializedState().newInstance(key), this);
+    return new Stateful(
+        state,
+        DataflowError.withDefaultTrace(
+            ctx.getBuiltins().error().uninitializedState().newInstance(key), this));
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
@@ -22,8 +22,10 @@ public class Error {
   private final AtomConstructor invalidArrayIndexError;
 
   private final Atom arithmeticErrorShiftTooBig;
+  private final Atom arithmeticErrorDivideByZero;
 
   private static final Text shiftTooBigMessage = Text.create("Shift amount too large.");
+  private static final Text divideByZeroMessage = Text.create("Cannot divide by zero.");
 
   /**
    * Creates and registers the relevant constructors.
@@ -69,6 +71,7 @@ public class Error {
             .initializeFields(
                 new ArgumentDefinition(0, "message", ArgumentDefinition.ExecutionMode.EXECUTE));
     arithmeticErrorShiftTooBig = arithmeticError.newInstance(shiftTooBigMessage);
+    arithmeticErrorDivideByZero = arithmeticError.newInstance(divideByZeroMessage);
     invalidArrayIndexError =
         new AtomConstructor("Invalid_Array_Index_Error", scope)
             .initializeFields(
@@ -76,6 +79,7 @@ public class Error {
                 new ArgumentDefinition(1, "index", ArgumentDefinition.ExecutionMode.EXECUTE));
 
     scope.registerConstructor(syntaxError);
+    scope.registerConstructor(typeError);
     scope.registerConstructor(compileError);
     scope.registerConstructor(inexhaustivePatternMatchError);
     scope.registerConstructor(uninitializedState);
@@ -163,6 +167,16 @@ public class Error {
     return arithmeticErrorShiftTooBig;
   }
 
+  /** @return An Arithmetic error representing a division by zero. */
+  public Atom getDivideByZeroError() {
+    return arithmeticErrorDivideByZero;
+  }
+
+  /**
+   * @param array the array
+   * @param index the index
+   * @return An error representing that the {@code index} is not valid in {@code array}
+   */
   public Atom makeInvalidArrayIndexError(Object array, Object index) {
     return invalidArrayIndexError.newInstance(array, index);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicSentinel.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicSentinel.java
@@ -1,0 +1,60 @@
+package org.enso.interpreter.runtime.error;
+
+import com.oracle.truffle.api.TruffleException;
+import com.oracle.truffle.api.nodes.Node;
+
+/**
+ * A sentinel value used to trace the propagation of panics through the program.
+ *
+ * <p>This tracing is enabled by the active intervention of the runtime instrumentation, and does
+ * not function in textual mode.
+ */
+public class PanicSentinel extends RuntimeException implements TruffleException {
+  private final PanicException panic;
+  private final Node location;
+
+  /**
+   * Create an instance of the panic sentinel, wrapping the provided panic.
+   *
+   * @param panic the panic to wrap
+   * @param location the location from where the sentinel was thrown
+   */
+  public PanicSentinel(PanicException panic, Node location) {
+    super(panic.getExceptionObject().toString());
+    this.panic = panic;
+    this.location = location;
+  }
+
+  /**
+   * Returns the location where this exception was thrown.
+   *
+   * @return the original throw location
+   */
+  @Override
+  public Node getLocation() {
+    return location;
+  }
+
+  /**
+   * Returns the payload carried by this exception.
+   *
+   * @return the payload object
+   */
+  @Override
+  public Object getExceptionObject() {
+    return panic;
+  }
+
+  /**
+   * Override recommended by the Truffle documentation for better performance.
+   *
+   * @see <a
+   *     href="https://www.graalvm.org/truffle/javadoc/com/oracle/truffle/api/TruffleException.html">Relevant
+   *     documentation</a>
+   * @return this exception
+   */
+  @Override
+  public Throwable fillInStackTrace() {
+    return this;
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
@@ -15,6 +15,7 @@ import org.enso.interpreter.runtime.data.ManagedResource;
 import org.enso.interpreter.runtime.data.Ref;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.DataflowError;
+import org.enso.interpreter.runtime.error.PanicSentinel;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 
@@ -43,7 +44,8 @@ import org.enso.interpreter.runtime.scope.ModuleScope;
   EnsoBigInteger.class,
   ManagedResource.class,
   ModuleScope.class,
-  Ref.class
+  Ref.class,
+  PanicSentinel.class
 })
 public class Types {
 

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -85,9 +85,7 @@ type Boolean
 
        > Example
          Telling the user if a number 27 is divisible by three.
-             if (27 %To join the video meeting, click this link: https://meet.google.com/enz-tecr-jdf
-Otherwise, to join by phone, dial +44 20 3956 9638 and enter this PIN: 686 143 957#
-To view more phone numbers, click this link: https://tel.meet/enz-tecr-jdf?hs=5 3) == 0 then IO.println "Yes" else IO.println "No"
+             if (27 % 3) == 0 then IO.println "Yes" else IO.println "No"
     if_then_else : Any -> Any -> Any
     if_then_else ~on_true ~on_false = @Builtin_Method "Boolean.if_then_else"
 

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -85,7 +85,9 @@ type Boolean
 
        > Example
          Telling the user if a number 27 is divisible by three.
-             if (27 % 3) == 0 then IO.println "Yes" else IO.println "No"
+             if (27 %To join the video meeting, click this link: https://meet.google.com/enz-tecr-jdf
+Otherwise, to join by phone, dial +44 20 3956 9638 and enter this PIN: 686 143 957#
+To view more phone numbers, click this link: https://tel.meet/enz-tecr-jdf?hs=5 3) == 0 then IO.println "Yes" else IO.println "No"
     if_then_else : Any -> Any -> Any
     if_then_else ~on_true ~on_false = @Builtin_Method "Boolean.if_then_else"
 
@@ -997,10 +999,12 @@ type Integer
        Modulus in Enso will undergo automatic conversions such that you need
        not convert between Integer and Decimal manually.
 
+       Returns an error if the shift amount exceeds 2^32.
+
        > Example
          Computing the remainder when dividing 10 by 3 (which is 1).
              10 % 3
-    % : Number -> Number
+    % : Number -> Number ! Arithmetic_Error
     % that = @Builtin_Method "Integer.%"
 
     ## Compute the result of raising this to the power that.
@@ -1110,10 +1114,12 @@ type Integer
 
        Integer division rounds down to the nearest integer.
 
+       Returns an error if `that` is zero.
+
        > Example
          Dividing 10 by 3 to get 3.
              10.div 3
-    div : Integer -> Number
+    div : Integer -> Number ! Arithmetic_Error
     div that = @Builtin_Method "Integer.div"
 
     ## Computes the nearest integer below this integer.
@@ -1207,10 +1213,12 @@ type Integer
        Leftwise bit shifts fill the new bits with zeroes, while rightwise bit
        shifts perform sign extension.
 
+       Returns an error if the shift amount exceeds 2^32.
+
        > Example
          Shift the bits of the number 1 left by four bits.
              1.bit_shift 4
-    bit_shift : Integer -> Integer
+    bit_shift : Integer -> Integer ! Arithmetic_Error
     bit_shift that = @Builtin_Method "Integer.bit_shift"
 
     ## Performs a left-wise bit shift on the bits of this.
@@ -1223,10 +1231,12 @@ type Integer
        Leftwise bit shifts fill the new bits with zeroes, while rightwise bit
        shifts perform sign extension.
 
+       Returns an error if the shift amount exceeds 2^32.
+
        > Example
          Shift the bits of the number 1 left by four bits.
              1.bit_shift_l 4
-    bit_shift_l : Integer -> Integer
+    bit_shift_l : Integer -> Integer ! Arithmetic_Error
     bit_shift_l that = @Builtin_Method "Integer.bit_shift_l"
 
     ## Performs a right-wise bit shift on the bits of this.
@@ -1239,10 +1249,12 @@ type Integer
        Leftwise bit shifts fill the new bits with zeroes, while rightwise bit
        shifts perform sign extension.
 
+       Returns an error if the shift amount exceeds 2^32.
+
        > Example
          Shift the bits of the number 1 right by four bits.
              1.bit_shift_r 4
-    bit_shift_r : Integer -> Integer
+    bit_shift_r : Integer -> Integer ! Arithmetic_Error
     bit_shift_r that = @Builtin_Method "Integer.bpit_shift_r"
 
 ## Decimal numbers.
@@ -1576,6 +1588,9 @@ type State
        Arguments:
        - key: The key into the state to get the associated value for.
 
+       Returns an uninitialized state error if the user tries to read from an
+       uninitialized slot.
+
        > Example
          Get the value of state for a key.
              State.get Decimal
@@ -1589,10 +1604,13 @@ type State
        - key: The key with which to associate the new state.
        - new_state: The new state to store.
 
+       Returns an uninitialized state error if the user tries to read from an
+       uninitialized slot.
+
        > Example
          Store a new value in the state for a given key.
              State.put Text 2821
-    put : Any -> Any -> Any
+    put : Any -> Any -> Any ! Uninitialized_State
     put key new_state = @Builtin_Method "State.put"
 
 ## Functionality for interacting with the host system.

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/DataflowErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/DataflowErrorsTest.scala
@@ -145,7 +145,35 @@ class DataflowErrorsTest extends InterpreterTest {
       eval(code)
       consumeOut shouldEqual List("(Error: My_Error)")
     }
-  }
 
-  // TODO [AA] Builtins need to handle a variety of cases around laziness in arguments.
+    "propagate through builtin methods" in {
+      val code =
+        """from Builtins import all
+          |
+          |type My_Error
+          |
+          |main =
+          |    result = 1 + (Error.throw My_Error)
+          |    IO.println result
+          |""".stripMargin
+
+      eval(code)
+      consumeOut shouldEqual List("(Error: My_Error)")
+    }
+
+    "not propagate when explicitly accepted by type and by annotation" in {
+      val code =
+        """from Builtins import all
+          |
+          |type My_Error
+          |
+          |main =
+          |    text = Error.throw My_Error . to_text
+          |    IO.println text
+          |""".stripMargin
+
+      eval(code)
+      consumeOut shouldEqual List("(Error: My_Error)")
+    }
+  }
 }

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/AcceptsError.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/AcceptsError.java
@@ -1,0 +1,11 @@
+package org.enso.interpreter.dsl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** An interface marking an argument as allowing it to accept a DataflowError. */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.SOURCE)
+public @interface AcceptsError {}

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/model/MethodDefinition.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/model/MethodDefinition.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.dsl.model;
 
+import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.dsl.Suspend;
@@ -186,6 +187,7 @@ public class MethodDefinition {
     private static final String OBJECT = "java.lang.Object";
     private static final String THUNK = "org.enso.interpreter.runtime.callable.argument.Thunk";
     private static final String CALLER_INFO = "org.enso.interpreter.runtime.callable.CallerInfo";
+    private static final String DATAFLOW_ERROR = "org.enso.interpreter.runtime.error.DataflowError";
     private final String typeName;
     private final TypeMirror type;
     private final String name;
@@ -193,6 +195,7 @@ public class MethodDefinition {
     private final boolean isFrame;
     private final boolean isCallerInfo;
     private final boolean isSuspended;
+    private final boolean acceptsError;
     private final int position;
     private final VariableElement element;
 
@@ -211,6 +214,9 @@ public class MethodDefinition {
       name = originalName.equals("_this") ? "this" : originalName;
       isState = element.getAnnotation(MonadicState.class) != null && type.toString().equals(OBJECT);
       isSuspended = element.getAnnotation(Suspend.class) != null;
+      acceptsError =
+          (element.getAnnotation(AcceptsError.class) != null)
+              || type.toString().equals(DATAFLOW_ERROR);
       isFrame = type.toString().equals(VIRTUAL_FRAME);
       isCallerInfo = type.toString().equals(CALLER_INFO);
       this.position = position;
@@ -287,6 +293,11 @@ public class MethodDefinition {
     /** @return whether this argument is expected to be passed suspended. */
     public boolean isSuspended() {
       return isSuspended;
+    }
+
+    /** @return whether thsi argument accepts a dataflow error. */
+    public boolean acceptsError() {
+      return acceptsError;
     }
   }
 }

--- a/test/Tests/src/Data/Noise/Generator_Spec.enso
+++ b/test/Tests/src/Data/Noise/Generator_Spec.enso
@@ -10,7 +10,7 @@ spec =
         gen = Generator.Generator
         Test.specify "should not be invokable" <|
             interval = Interval.inclusive 0 1
-            Test.expect_fail_with (gen.step 1 interval) Extensions.Unimplemented_Error
+            Test.expect_panic_with (gen.step 1 interval) Extensions.Unimplemented_Error
     Test.group "Deterministic Random Noise Generator" <|
         gen = Generator.Deterministic_Random
         Test.specify "should always return the same output for the same input" <|

--- a/test/Tests/src/Data/Numbers_Spec.enso
+++ b/test/Tests/src/Data/Numbers_Spec.enso
@@ -40,6 +40,9 @@ spec =
         Test.specify "should use floating point arithmetic for division" <|
             (3 / 4) . should_equal 0.75 epsilon=eps
             (almost_max_long * 2 / almost_max_long_times_three) . should_equal 0.6666666 epsilon=eps
+        Test.specify "should support integer division" <|
+            (10.div 3) . should_equal 3
+            Test.expect_error_with (10.div 0) Arithmetic_Error
         Test.specify "should support integral binary literals" <|
             lit = 2_01101101
             lit . should_equal 109
@@ -90,28 +93,28 @@ spec =
             positive_bits.bit_shift_l 64 . should_equal 16_6d0000000000000000
             positive_bits.bit_shift_l -2 . should_equal 2_011011
             positive_bits.bit_shift_l -64 . should_equal 0
-            Test.expect_fail_with (positive_bits.bit_shift_l positive_big_bits) Arithmetic_Error
+            Test.expect_error_with (positive_bits.bit_shift_l positive_big_bits) Arithmetic_Error
             positive_bits.bit_shift_l negative_big_bits . should_equal 0
 
             negative_bits.bit_shift_l 2 . should_equal -436
             negative_bits.bit_shift_l 64 . should_equal -2010695104034341126144
             negative_bits.bit_shift_l -2 . should_equal -28
             negative_bits.bit_shift_l -64 . should_equal -1
-            Test.expect_fail_with (negative_bits.bit_shift_l positive_big_bits) Arithmetic_Error
+            Test.expect_error_with (negative_bits.bit_shift_l positive_big_bits) Arithmetic_Error
             negative_bits.bit_shift_l negative_big_bits . should_equal -1
 
             positive_big_bits.bit_shift_l 2 . should_equal 110680464442257309672
             positive_big_bits.bit_shift_l 64 . should_equal 510423550381407695084381446705395007488
             positive_big_bits.bit_shift_l -2 . should_equal 6917529027641081854
             positive_big_bits.bit_shift_l -100 . should_equal 0
-            Test.expect_fail_with (positive_big_bits.bit_shift_l positive_big_bits) Arithmetic_Error
+            Test.expect_error_with (positive_big_bits.bit_shift_l positive_big_bits) Arithmetic_Error
             positive_big_bits.bit_shift_l negative_big_bits . should_equal 0
 
             negative_big_bits.bit_shift_l 2 . should_equal -110680464442257309672
             negative_big_bits.bit_shift_l 64 . should_equal -510423550381407695084381446705395007488
             negative_big_bits.bit_shift_l -2 . should_equal -6917529027641081855
             negative_big_bits.bit_shift_l -100 . should_equal -1
-            Test.expect_fail_with (negative_big_bits.bit_shift_l positive_big_bits) Arithmetic_Error
+            Test.expect_error_with (negative_big_bits.bit_shift_l positive_big_bits) Arithmetic_Error
             negative_big_bits.bit_shift_l negative_big_bits . should_equal -1
         Test.specify "should support right bit shifts, preserving sign" <|
             positive_bits = 2_01101101
@@ -123,28 +126,28 @@ spec =
             positive_bits.bit_shift_r 64 . should_equal (positive_bits.bit_shift_l -64)
             positive_bits.bit_shift_r -2 . should_equal (positive_bits.bit_shift_l 2)
             positive_bits.bit_shift_r -64 . should_equal (positive_bits.bit_shift_l 64)
-            Test.expect_fail_with (positive_bits.bit_shift_r negative_big_bits) Arithmetic_Error
+            Test.expect_error_with (positive_bits.bit_shift_r negative_big_bits) Arithmetic_Error
             positive_bits.bit_shift_r positive_big_bits . should_equal 0
 
             negative_bits.bit_shift_r 2 . should_equal (negative_bits.bit_shift_l -2)
             negative_bits.bit_shift_r 64 . should_equal (negative_bits.bit_shift_l -64)
             negative_bits.bit_shift_r -2 . should_equal (negative_bits.bit_shift_l 2)
             negative_bits.bit_shift_r -64 . should_equal (negative_bits.bit_shift_l 64)
-            Test.expect_fail_with (negative_bits.bit_shift_r negative_big_bits) Arithmetic_Error
+            Test.expect_error_with (negative_bits.bit_shift_r negative_big_bits) Arithmetic_Error
             negative_bits.bit_shift_r positive_big_bits . should_equal -1
 
             positive_big_bits.bit_shift_r 2 . should_equal (positive_big_bits.bit_shift_l -2)
             positive_big_bits.bit_shift_r 64 . should_equal (positive_big_bits.bit_shift_l -64)
             positive_big_bits.bit_shift_r -2 . should_equal (positive_big_bits.bit_shift_l 2)
             positive_big_bits.bit_shift_r -100 . should_equal (positive_big_bits.bit_shift_l 100)
-            Test.expect_fail_with (positive_big_bits.bit_shift_r negative_big_bits) Arithmetic_Error
+            Test.expect_error_with (positive_big_bits.bit_shift_r negative_big_bits) Arithmetic_Error
             positive_big_bits.bit_shift_r positive_big_bits . should_equal 0
 
             negative_big_bits.bit_shift_r 2 . should_equal (negative_big_bits.bit_shift_l -2)
             negative_big_bits.bit_shift_r 64 . should_equal (negative_big_bits.bit_shift_l -64)
             negative_big_bits.bit_shift_r -2 . should_equal (negative_big_bits.bit_shift_l 2)
             negative_big_bits.bit_shift_r -100 . should_equal (negative_big_bits.bit_shift_l 100)
-            Test.expect_fail_with (negative_big_bits.bit_shift_r negative_big_bits) Arithmetic_Error
+            Test.expect_error_with (negative_big_bits.bit_shift_r negative_big_bits) Arithmetic_Error
             negative_big_bits.bit_shift_r positive_big_bits . should_equal -1
     Test.group "Decimals" <|
         Test.specify "should exist and expose basic arithmetic operations" <|

--- a/test/Tests/src/Semantic/Error_Spec.enso
+++ b/test/Tests/src/Semantic/Error_Spec.enso
@@ -4,7 +4,6 @@ import Test
 type My_Type foo
 
 spec =
-    # Test.group "Dataflow Errors" <|
     Test.group "No Method Errors" <|
         Test.specify "should be recoverable" <|
             err_1 = Panic.recover (123 . foobar "baz") . catch e->e

--- a/test/Tests/src/Semantic/Error_Spec.enso
+++ b/test/Tests/src/Semantic/Error_Spec.enso
@@ -4,6 +4,7 @@ import Test
 type My_Type foo
 
 spec =
+    # Test.group "Dataflow Errors" <|
     Test.group "No Method Errors" <|
         Test.specify "should be recoverable" <|
             err_1 = Panic.recover (123 . foobar "baz") . catch e->e


### PR DESCRIPTION
### Pull Request Description
This PR adds comprehensive support for dataflow errors throughout the interpreter. This means that they can flow through far more places in the graph, providing a far better UX. In addition, it adds support for `PanicSentinel`, a marker used by the runtime instrumentation to trace the effects of panics.

Closes #1409.

### Important Notes
There is no performance impact from these changes in compiled code.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
