### PR TITLE
Add Stack Traces in Tests

### DIFF
--- a/distribution/std-lib/Test/src/Test.enso
+++ b/distribution/std-lib/Test/src/Test.enso
@@ -164,8 +164,8 @@ run_spec ~behavior =
         case ex of
             Failure _ -> ex
             Finished_With_Error x -> 
-                Failure ("An unexpected error was returned: " + x.to_text)
-            _ -> Failure ("An unexpected panic was thrown: " + ex.to_text)
+                Failure ("An unexpected error was returned: " + x.to_text + "\n" + maybeExc.get_stack_trace_text)
+            _ -> Failure ("An unexpected panic was thrown: " + ex.to_text + "\n" + maybeExc.get_stack_trace_text)
     result
 
 ## Creates a new test group, desribing properties of the object

--- a/distribution/std-lib/Test/src/Test.enso
+++ b/distribution/std-lib/Test/src/Test.enso
@@ -164,8 +164,8 @@ run_spec ~behavior =
         case ex of
             Failure _ -> ex
             Finished_With_Error x -> 
-                Failure ("An unexpected error was returned: " + x.to_text + "\n" + maybeExc.get_stack_trace_text)
-            _ -> Failure ("An unexpected panic was thrown: " + ex.to_text + "\n" + maybeExc.get_stack_trace_text)
+                Failure ("An unexpected error was returned: " + x.to_text + '\n' + maybeExc.get_stack_trace_text)
+            _ -> Failure ("An unexpected panic was thrown: " + ex.to_text + '\n' + maybeExc.get_stack_trace_text)
     result
 
 ## Creates a new test group, desribing properties of the object

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
@@ -184,7 +184,7 @@ public class ReplDebuggerInstrument extends TruffleInstrument {
     @Override
     protected void onEnter(VirtualFrame frame) {
       CallerInfo lastScope = Function.ArgumentsHelper.getCallerInfo(frame.getArguments());
-      Object lastReturn = lookupContextReference(Language.class).get().getUnit().newInstance();
+      Object lastReturn = lookupContextReference(Language.class).get().getNothing().newInstance();
       // Note [Safe Access to State in the Debugger Instrument]
       Object lastState = Function.ArgumentsHelper.getState(frame.getArguments());
       nodeState = new ReplExecutionEventNodeState(lastReturn, lastState, lastScope);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/IfThenNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/IfThenNode.java
@@ -11,7 +11,6 @@ import org.enso.interpreter.dsl.Suspend;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
 import org.enso.interpreter.runtime.Context;
-import org.enso.interpreter.runtime.callable.argument.Thunk;
 import org.enso.interpreter.runtime.state.Stateful;
 
 @BuiltinMethod(
@@ -34,7 +33,7 @@ public abstract class IfThenNode extends Node {
     if (condProfile.profile(_this)) {
       return leftThunkExecutorNode.executeThunk(if_true, state, BaseNode.TailStatus.TAIL_DIRECT);
     } else {
-      return new Stateful(state, context.getUnit().newInstance());
+      return new Stateful(state, context.getNothing().newInstance());
     }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/debug/DebugBreakpointNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/debug/DebugBreakpointNode.java
@@ -48,7 +48,7 @@ public abstract class DebugBreakpointNode extends Node implements Instrumentable
       Object state,
       Object _this,
       @CachedContext(Language.class) Context context) {
-    return new Stateful(state, context.getUnit().newInstance());
+    return new Stateful(state, context.getNothing().newInstance());
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/GetStackTraceTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/GetStackTraceTextNode.java
@@ -1,0 +1,79 @@
+package org.enso.interpreter.node.expression.builtin.error;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.TruffleStackTrace;
+import com.oracle.truffle.api.TruffleStackTraceElement;
+import com.oracle.truffle.api.dsl.CachedContext;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import java.util.ArrayList;
+import java.util.Collections;
+import org.enso.interpreter.Language;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.error.DataflowError;
+
+@BuiltinMethod(
+    type = "Error",
+    name = "get_stack_trace_text",
+    description = "Returns a textual representation of the stack trace attached to an error.")
+public class GetStackTraceTextNode extends Node {
+
+  Text execute(DataflowError _this) {
+    String repr = printStackTrace(_this);
+    return Text.create(repr);
+  }
+
+
+  @TruffleBoundary
+  String printStackTrace(Throwable throwable) {
+    var sb = new StringBuilder();
+    var truffleStack = TruffleStackTrace.getStackTrace(throwable);
+    if (truffleStack == null) {
+      sb.append("The error has no stacktrace attached to it.\n");
+    } else {
+      var fullStack = new ArrayList<>(truffleStack);
+      var dropInitJava = new ArrayList<TruffleStackTraceElement>();
+      boolean isInit = true;
+      for (int i = fullStack.size() - 1; i >= 0; i--) {
+        var elem = fullStack.get(i);
+        if (isInit) {
+          if (elem.getLocation().getRootNode().getLanguageInfo() != null) {
+            isInit = false;
+          }
+        }
+
+        if (!isInit) {
+          dropInitJava.add(elem);
+        }
+      }
+      Collections.reverse(dropInitJava);
+      var stack = dropInitJava;
+      if (dropInitJava.isEmpty()) {
+        stack = fullStack;
+      }
+
+      for (var errorFrame : stack) {
+        var rootNode = errorFrame.getLocation().getRootNode();
+        var languageInfo = rootNode.getLanguageInfo();
+        var langId = (languageInfo == null) ? "java" : languageInfo.getId();
+        var fName = rootNode.getName();
+        System.out.println(fName);
+        var src = "Internal";
+        var sourceLoc = errorFrame.getLocation().getSourceSection();
+        if (sourceLoc != null) {
+          System.out.println("SRC: " + sourceLoc);
+          var path = sourceLoc.getSource().getPath();
+          var ident = (path != null) ? path : sourceLoc.getSource().getName();
+          var loc = (sourceLoc.getStartLine() == sourceLoc.getEndLine()) ?
+              (sourceLoc.getStartLine() + ":" + sourceLoc.getStartColumn() + "-" + sourceLoc.getEndColumn()) :
+              (sourceLoc.getStartLine() + "-" + sourceLoc.getEndLine());
+          src = ident + ":" + loc;
+        }
+        sb.append("        at <" + langId + "> " + fName + "(" + src + ")\n");
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/GetStackTraceTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/GetStackTraceTextNode.java
@@ -54,16 +54,15 @@ public class GetStackTraceTextNode extends Node {
         stack = fullStack;
       }
 
+      boolean first = true;
       for (var errorFrame : stack) {
         var rootNode = errorFrame.getLocation().getRootNode();
         var languageInfo = rootNode.getLanguageInfo();
         var langId = (languageInfo == null) ? "java" : languageInfo.getId();
         var fName = rootNode.getName();
-        System.out.println(fName);
         var src = "Internal";
-        var sourceLoc = errorFrame.getLocation().getSourceSection();
+        var sourceLoc = errorFrame.getLocation().getEncapsulatingSourceSection();
         if (sourceLoc != null) {
-          System.out.println("SRC: " + sourceLoc);
           var path = sourceLoc.getSource().getPath();
           var ident = (path != null) ? path : sourceLoc.getSource().getName();
           var loc = (sourceLoc.getStartLine() == sourceLoc.getEndLine()) ?
@@ -71,7 +70,12 @@ public class GetStackTraceTextNode extends Node {
               (sourceLoc.getStartLine() + "-" + sourceLoc.getEndLine());
           src = ident + ":" + loc;
         }
-        sb.append("        at <" + langId + "> " + fName + "(" + src + ")\n");
+        if (first) {
+          first = false;
+        } else {
+          sb.append('\n');
+        }
+        sb.append("        at <" + langId + "> " + fName + "(" + src + ")");
       }
     }
     return sb.toString();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/GetStackTraceTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/GetStackTraceTextNode.java
@@ -25,7 +25,6 @@ public class GetStackTraceTextNode extends Node {
     return Text.create(repr);
   }
 
-
   @TruffleBoundary
   String printStackTrace(Throwable throwable) {
     var sb = new StringBuilder();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
@@ -16,11 +16,9 @@ import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.node.callable.InvokeCallableNode;
 import org.enso.interpreter.node.expression.builtin.text.util.ExpectStringNode;
-import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
-import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.state.Stateful;
 import org.enso.interpreter.runtime.type.TypesGen;
 
@@ -49,7 +47,7 @@ public abstract class PrintErrNode extends Node {
     } catch (UnsupportedMessageException e) {
       throw new IllegalStateException("Impossible. self is guaranteed to be a string");
     }
-    return new Stateful(state, ctx.getUnit().newInstance());
+    return new Stateful(state, ctx.getNothing().newInstance());
   }
 
   @Specialization(guards = "!strings.isString(message)")
@@ -65,7 +63,7 @@ public abstract class PrintErrNode extends Node {
       @Cached ExpectStringNode expectStringNode) {
     Stateful str = invokeCallableNode.execute(symbol, frame, state, new Object[] {message});
     print(ctx.getErr(), expectStringNode.execute(str.getValue()));
-    return new Stateful(str.getState(), ctx.getUnit().newInstance());
+    return new Stateful(str.getState(), ctx.getNothing().newInstance());
   }
 
   @CompilerDirectives.TruffleBoundary

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
@@ -16,11 +16,9 @@ import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.node.callable.InvokeCallableNode;
 import org.enso.interpreter.node.expression.builtin.text.util.ExpectStringNode;
-import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
-import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.state.Stateful;
 import org.enso.interpreter.runtime.type.TypesGen;
 
@@ -48,7 +46,7 @@ public abstract class PrintlnNode extends Node {
     } catch (UnsupportedMessageException e) {
       throw new IllegalStateException("Impossible. self is guaranteed to be a string");
     }
-    return new Stateful(state, ctx.getUnit().newInstance());
+    return new Stateful(state, ctx.getNothing().newInstance());
   }
 
   @Specialization(guards = "!strings.isString(message)")
@@ -64,7 +62,7 @@ public abstract class PrintlnNode extends Node {
       @Cached ExpectStringNode expectStringNode) {
     Stateful str = invokeCallableNode.execute(symbol, frame, state, new Object[] {message});
     print(ctx.getOut(), expectStringNode.execute(str.getValue()));
-    return new Stateful(str.getState(), ctx.getUnit().newInstance());
+    return new Stateful(str.getState(), ctx.getNothing().newInstance());
   }
 
   boolean isText(Object o) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
@@ -44,7 +44,7 @@ public abstract class AssignmentNode extends ExpressionNode {
     frame.getFrameDescriptor().setFrameSlotKind(getFrameSlot(), FrameSlotKind.Long);
     frame.setLong(getFrameSlot(), value);
 
-    return ctx.getUnit().newInstance();
+    return ctx.getNothing().newInstance();
   }
 
   /**
@@ -61,7 +61,7 @@ public abstract class AssignmentNode extends ExpressionNode {
     frame.getFrameDescriptor().setFrameSlotKind(getFrameSlot(), FrameSlotKind.Object);
     frame.setObject(getFrameSlot(), value);
 
-    return ctx.getUnit().newInstance();
+    return ctx.getNothing().newInstance();
   }
 
   boolean isLongOrIllegal(VirtualFrame frame) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
@@ -288,12 +288,12 @@ public class Context {
   }
 
   /**
-   * Returns the atom constructor corresponding to the {@code Unit} type, for builtin constructs
+   * Returns the atom constructor corresponding to the {@code Nothing} type, for builtin constructs
    * that need to return an atom of this type.
    *
-   * @return the builtin {@code Unit} atom constructor
+   * @return the builtin {@code Nothing} atom constructor
    */
-  public AtomConstructor getUnit() {
+  public AtomConstructor getNothing() {
     return getBuiltins().nothing();
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/DataflowError.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/DataflowError.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.runtime.builtin;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.node.expression.builtin.error.CatchErrorMethodGen;
 import org.enso.interpreter.node.expression.builtin.error.ErrorToTextMethodGen;
+import org.enso.interpreter.node.expression.builtin.error.GetStackTraceTextMethodGen;
 import org.enso.interpreter.node.expression.builtin.error.ThrowErrorMethodGen;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.scope.ModuleScope;
@@ -16,6 +17,7 @@ public class DataflowError {
     scope.registerConstructor(error);
     scope.registerMethod(error, "throw", ThrowErrorMethodGen.makeFunction(language));
     scope.registerMethod(error, "catch_primitive", CatchErrorMethodGen.makeFunction(language));
+    scope.registerMethod(error, "get_stack_trace_text", GetStackTraceTextMethodGen.makeFunction(language));
     scope.registerMethod(error, "to_text", ErrorToTextMethodGen.makeFunction(language));
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
@@ -180,7 +180,7 @@ public class TopLevelScope implements TruffleObject {
         throws ArityException, UnsupportedTypeException {
       String name = Types.extractArguments(arguments, String.class);
       scope.modules.remove(name);
-      return context.getUnit().newInstance();
+      return context.getNothing().newInstance();
     }
 
     private static Object leakContext(Context context) {

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -224,6 +224,12 @@ type Error
     catch_primitive : (Error -> Any) -> Any
     catch_primitive handler = @Builtin_Method "Any.catch"
 
+    ## INTERNAL UNSTABLE
+
+       Returns a textual representation of the stack trace attached to an error.
+    get_stack_trace_text : Text
+    get_stack_trace_text = @Builtin_Method "Error.get_stack_trace_text"
+
     ## Converts an error to a corresponding textual representation.
     to_text : Text
     to_text = @Builtin_Method "Error.to_text"

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -224,7 +224,8 @@ type Error
     catch_primitive : (Error -> Any) -> Any
     catch_primitive handler = @Builtin_Method "Any.catch"
 
-    ## INTERNAL UNSTABLE
+    ## PRIVATE 
+       UNSTABLE
 
        Returns a textual representation of the stack trace attached to an error.
     get_stack_trace_text : Text
@@ -1798,4 +1799,3 @@ type Ordering
     ## A representation that the first value orders as greater than the second.
     @Builtin_Type
     type Greater
-


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Adds a builtin generating a textual stack trace representation which is used in the test suite to display better errors, like:
```
        Reason: An unexpected panic was thrown: (No_Such_Method_Error (Table org.enso.table.data.table.Table@5f0d8937) UnresolvedSymbol<foobar>)
        at <enso> Panic.recover(Internal)
        at <enso> argument<1>(/my-distr-path/std-lib/Test/src/Test.enso:168:84-112)
        at <enso> argument<0>(/my-distr-path/std-lib/Test/src/Test.enso:168:27-112)
...
```

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [ ] All code has been tested where possible.
