### PR TITLE
Fix Dependency Analysis

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
@@ -6,7 +6,10 @@ import org.enso.compiler.core.IR.{ExternalId, Pattern}
 import org.enso.compiler.core.ir.MetadataStorage._
 import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.IRPass
-import org.enso.compiler.pass.analyse.DataflowAnalysis.DependencyInfo.Type.asStatic
+import org.enso.compiler.pass.analyse.DataflowAnalysis.DependencyInfo.Type.{
+  asDynamic,
+  asStatic
+}
 
 import scala.collection.mutable
 
@@ -129,7 +132,7 @@ case object DataflowAnalysis extends IRPass {
       case _: IR.Name.Annotation =>
         throw new CompilerError(
           "Annotations should already be associated by the point of " +
-            "dataflow analysis."
+          "dataflow analysis."
         )
       case err: IR.Error => err
     }
@@ -411,10 +414,12 @@ case object DataflowAnalysis extends IRPass {
             aliasInfo.graph.getOccurrence(defLink.target) match {
               case Some(AliasAnalysis.Graph.Occurrence.Def(_, _, id, ext, _)) =>
                 DependencyInfo.Type.Static(id, ext)
-              case _ => DependencyInfo.Type.Dynamic(name.name, None)
+              case _ =>
+                asDynamic(name)
             }
 
-          case None => DependencyInfo.Type.Dynamic(name.name, None)
+          case None =>
+            asDynamic(name)
         }
 
         info.updateAt(key, Set(asStatic(name)))

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/context/ChangesetBuilderTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/context/ChangesetBuilderTest.scala
@@ -345,7 +345,7 @@ class ChangesetBuilderTest extends CompilerTest {
           |#### METADATA ####
           |[[{"index": {"value": 47}, "size": {"value": 1}}, "b95f644b-e877-4e33-b5da-11a65e01068e"],[{"index": {"value": 37}, "size": {"value": 5}}, "17edd47d-b546-4d57-a453-0529036b393f"],[{"index": {"value": 15}, "size": {"value": 13}}, "b1c393b2-67be-488b-b46d-2adba21bca6d"]]
           |[]
-          |""".stripMargin
+          |""".stripMargin.linesIterator.mkString("\n")
       val edit = TextEdit(Range(Position(1, 12), Position(1, 21)), "42")
 
       val ir = code.preprocessModule

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/context/ChangesetBuilderTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/context/ChangesetBuilderTest.scala
@@ -1,12 +1,24 @@
 package org.enso.compiler.test.context
 
-import org.enso.compiler.context.ChangesetBuilder
+import java.util.UUID
+
+import org.enso.compiler.Passes
+import org.enso.compiler.context.{
+  ChangesetBuilder,
+  FreshNameSupply,
+  InlineContext,
+  ModuleContext
+}
 import org.enso.compiler.core.IR
+import org.enso.compiler.pass.PassManager
 import org.enso.compiler.test.CompilerTest
+import org.enso.interpreter.runtime.scope.LocalScope
 import org.enso.text.buffer.Rope
 import org.enso.text.editing.model.{Position, Range, TextEdit}
 
 class ChangesetBuilderTest extends CompilerTest {
+
+  implicit val passManager: PassManager = new Passes().passManager
 
   "DiffChangeset" should {
 
@@ -14,9 +26,12 @@ class ChangesetBuilderTest extends CompilerTest {
       val code = """x = 1 + 2"""
       val edit = TextEdit(Range(Position(0, 8), Position(0, 9)), "42")
 
-      val ir  = code.toIrExpression.get.asInstanceOf[IR.Expression.Binding]
-      val rhs = ir.expression.asInstanceOf[IR.Application.Operator.Binary]
-      val two = rhs.right.value
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
+      val rhs = ir.expression.asInstanceOf[IR.Application.Prefix]
+      val two = rhs.arguments(1).asInstanceOf[IR.CallArgument.Specified].value
 
       invalidated(ir, code, edit) should contain theSameElementsAs Seq(
         two.getId
@@ -27,9 +42,12 @@ class ChangesetBuilderTest extends CompilerTest {
       val code = """x = 1 + 2"""
       val edit = TextEdit(Range(Position(0, 8), Position(0, 8)), "9")
 
-      val ir  = code.toIrExpression.get.asInstanceOf[IR.Expression.Binding]
-      val rhs = ir.expression.asInstanceOf[IR.Application.Operator.Binary]
-      val two = rhs.right.value
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
+      val rhs = ir.expression.asInstanceOf[IR.Application.Prefix]
+      val two = rhs.arguments(1).asInstanceOf[IR.CallArgument.Specified].value
 
       invalidated(ir, code, edit) should contain theSameElementsAs Seq(
         two.getId
@@ -40,9 +58,12 @@ class ChangesetBuilderTest extends CompilerTest {
       val code = """x = 1 + 2"""
       val edit = TextEdit(Range(Position(0, 9), Position(0, 9)), "9")
 
-      val ir  = code.toIrExpression.get.asInstanceOf[IR.Expression.Binding]
-      val rhs = ir.expression.asInstanceOf[IR.Application.Operator.Binary]
-      val two = rhs.right.value
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
+      val rhs = ir.expression.asInstanceOf[IR.Application.Prefix]
+      val two = rhs.arguments(1).asInstanceOf[IR.CallArgument.Specified].value
 
       invalidated(ir, code, edit) should contain theSameElementsAs Seq(
         two.getId
@@ -53,8 +74,11 @@ class ChangesetBuilderTest extends CompilerTest {
       val code = """x1 = 42"""
       val edit = TextEdit(Range(Position(0, 1), Position(0, 2)), "")
 
-      val ir = code.toIrExpression.get.asInstanceOf[IR.Expression.Binding]
-      val x  = ir.name
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
+      val x = ir.name
 
       invalidated(ir, code, edit) should contain theSameElementsAs Seq(
         x.getId
@@ -65,8 +89,11 @@ class ChangesetBuilderTest extends CompilerTest {
       val code = """baz = 42"""
       val edit = TextEdit(Range(Position(0, 1), Position(0, 2)), "oo")
 
-      val ir = code.toIrExpression.get.asInstanceOf[IR.Expression.Binding]
-      val x  = ir.name
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
+      val x = ir.name
 
       invalidated(ir, code, edit) should contain theSameElementsAs Seq(
         x.getId
@@ -77,10 +104,13 @@ class ChangesetBuilderTest extends CompilerTest {
       val code = """x = 1 + 2"""
       val edit = TextEdit(Range(Position(0, 6), Position(0, 9)), "- 42")
 
-      val ir   = code.toIrExpression.get.asInstanceOf[IR.Expression.Binding]
-      val rhs  = ir.expression.asInstanceOf[IR.Application.Operator.Binary]
-      val plus = rhs.operator
-      val two  = rhs.right.value
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
+      val rhs  = ir.expression.asInstanceOf[IR.Application.Prefix]
+      val plus = rhs.function
+      val two  = rhs.arguments(1).asInstanceOf[IR.CallArgument.Specified].value
 
       invalidated(ir, code, edit) should contain theSameElementsAs Seq(
         plus.getId,
@@ -92,10 +122,13 @@ class ChangesetBuilderTest extends CompilerTest {
       val code = """x = 1 + 2"""
       val edit = TextEdit(Range(Position(0, 0), Position(0, 5)), "y = 42")
 
-      val ir  = code.toIrExpression.get.asInstanceOf[IR.Expression.Binding]
-      val rhs = ir.expression.asInstanceOf[IR.Application.Operator.Binary]
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
+      val rhs = ir.expression.asInstanceOf[IR.Application.Prefix]
       val x   = ir.name
-      val one = rhs.left.value
+      val one = rhs.arguments(0).asInstanceOf[IR.CallArgument.Specified].value
 
       invalidated(ir, code, edit) should contain theSameElementsAs Seq(
         x.getId,
@@ -107,14 +140,52 @@ class ChangesetBuilderTest extends CompilerTest {
       val code = """x = 1 + 2"""
       val edit = TextEdit(Range(Position(0, 0), Position(0, 4)), "y = ")
 
-      val ir = code.toIrExpression.get.asInstanceOf[IR.Expression.Binding]
-      val x  = ir.name
-      val one =
-        ir.expression.asInstanceOf[IR.Application.Operator.Binary].left.value
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
+      val x   = ir.name
+      val rhs = ir.expression.asInstanceOf[IR.Application.Prefix]
+      val one = rhs.arguments(0).asInstanceOf[IR.CallArgument.Specified].value
 
       invalidated(ir, code, edit) should contain theSameElementsAs Seq(
         x.getId,
         one.getId
+      )
+    }
+
+    "undefined binding whole" in {
+      val code = """baz = undefined"""
+      val edit = TextEdit(Range(Position(0, 6), Position(0, 15)), "42")
+
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
+      val undefinedExpr = ir.expression.asInstanceOf[IR.Error.Resolution]
+      val undefinedName = undefinedExpr.originalName
+
+      invalidated(ir, code, edit) should contain theSameElementsAs Seq(
+        undefinedName.getId
+      )
+    }
+
+    "single undefined literal whole" in {
+      val code = """x = 1 + undefined"""
+      val edit = TextEdit(Range(Position(0, 8), Position(0, 16)), "42")
+
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
+      val rhs = ir.expression.asInstanceOf[IR.Application.Prefix]
+      val undefinedArg =
+        rhs.arguments(1).asInstanceOf[IR.CallArgument.Specified]
+      val undefinedError = undefinedArg.value.asInstanceOf[IR.Error.Resolution]
+      val undefinedName  = undefinedError.originalName
+
+      invalidated(ir, code, edit) should contain theSameElementsAs Seq(
+        undefinedName.getId
       )
     }
 
@@ -125,12 +196,17 @@ class ChangesetBuilderTest extends CompilerTest {
           |    y + x""".stripMargin.linesIterator.mkString("\n")
       val edit = TextEdit(Range(Position(2, 4), Position(2, 9)), "x")
 
-      val ir = code.toIrExpression.get.asInstanceOf[IR.Function.Lambda]
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Function.Lambda]
       val secondLine =
-        ir.body.children(1).asInstanceOf[IR.Application.Operator.Binary]
-      val y    = secondLine.left.value
-      val plus = secondLine.operator
-      val x    = secondLine.right.value
+        ir.body.children(1).asInstanceOf[IR.Application.Prefix]
+      val y =
+        secondLine.arguments(0).asInstanceOf[IR.CallArgument.Specified].value
+      val plus = secondLine.function
+      val x =
+        secondLine.arguments(1).asInstanceOf[IR.CallArgument.Specified].value
 
       invalidated(ir, code, edit) should contain theSameElementsAs Seq(
         y.getId,
@@ -145,7 +221,12 @@ class ChangesetBuilderTest extends CompilerTest {
           |    y = 5
           |    IO.println y""".stripMargin.linesIterator.mkString("\n")
       val edit = TextEdit(Range(Position(2, 0), Position(2, 0)), "    z = 42\n")
-      val ir   = code.toIrExpression.get.asInstanceOf[IR.Function.Lambda]
+
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Function.Lambda]
+
       invalidated(ir, code, edit) should contain theSameElementsAs Seq()
     }
 
@@ -154,10 +235,15 @@ class ChangesetBuilderTest extends CompilerTest {
         """x ->
           |    y = 5
           |    IO.println y""".stripMargin.linesIterator.mkString("\n")
-      val edit      = TextEdit(Range(Position(1, 9), Position(1, 9)), "\n    z = 7")
-      val ir        = code.toIrExpression.get.asInstanceOf[IR.Function.Lambda]
+      val edit = TextEdit(Range(Position(1, 9), Position(1, 9)), "\n    z = 7")
+
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Function.Lambda]
       val firstLine = ir.body.children(0).asInstanceOf[IR.Expression.Binding]
       val five      = firstLine.expression
+
       invalidated(ir, code, edit) should contain theSameElementsAs Seq(
         five.getId
       )
@@ -171,13 +257,17 @@ class ChangesetBuilderTest extends CompilerTest {
           |    y + x""".stripMargin.linesIterator.mkString("\n")
       val edit = TextEdit(Range(Position(2, 8), Position(3, 7)), s"42\n    y -")
 
-      val ir         = code.toIrExpression.get.asInstanceOf[IR.Function.Lambda]
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Function.Lambda]
       val secondLine = ir.body.children(1).asInstanceOf[IR.Expression.Binding]
       val z          = secondLine.expression
       val thirdLine =
-        ir.body.children(2).asInstanceOf[IR.Application.Operator.Binary]
-      val y    = thirdLine.left.value
-      val plus = thirdLine.operator
+        ir.body.children(2).asInstanceOf[IR.Application.Prefix]
+      val y =
+        thirdLine.arguments(0).asInstanceOf[IR.CallArgument.Specified].value
+      val plus = thirdLine.function
 
       invalidated(ir, code, edit) should contain theSameElementsAs Seq(
         z.getId,
@@ -195,11 +285,14 @@ class ChangesetBuilderTest extends CompilerTest {
         TextEdit(Range(Position(0, 8), Position(0, 10)), "44")
       )
 
-      val ir   = code.toIrExpression.get.asInstanceOf[IR.Expression.Binding]
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
       val x    = ir.name
-      val rhs  = ir.expression.asInstanceOf[IR.Application.Operator.Binary]
-      val one  = rhs.left.value
-      val plus = rhs.operator
+      val rhs  = ir.expression.asInstanceOf[IR.Application.Prefix]
+      val one  = rhs.arguments(0).asInstanceOf[IR.CallArgument.Specified].value
+      val plus = rhs.function
 
       invalidated(ir, code, edits: _*) should contain theSameElementsAs Seq(
         x.getId,
@@ -219,13 +312,17 @@ class ChangesetBuilderTest extends CompilerTest {
         TextEdit(Range(Position(4, 8), Position(5, 7)), "42\n    y -")
       )
 
-      val ir         = code.toIrExpression.get.asInstanceOf[IR.Function.Binding]
-      val secondLine = ir.body.children(1).asInstanceOf[IR.Expression.Binding]
+      val ir = code
+        .preprocessExpression(freshInlineContext)
+        .get
+        .asInstanceOf[IR.Expression.Binding]
+      val body       = ir.expression.asInstanceOf[IR.Function.Lambda].body
+      val secondLine = body.children(1).asInstanceOf[IR.Expression.Binding]
       val z          = secondLine.expression
-      val thirdLine =
-        ir.body.children(2).asInstanceOf[IR.Application.Operator.Binary]
-      val y    = thirdLine.left.value
-      val plus = thirdLine.operator
+      val thirdLine  = body.children(2).asInstanceOf[IR.Application.Prefix]
+      val y =
+        thirdLine.arguments(0).asInstanceOf[IR.CallArgument.Specified].value
+      val plus = thirdLine.function
 
       invalidated(ir, code, edits: _*) should contain theSameElementsAs Seq(
         ir.name.getId,
@@ -234,8 +331,68 @@ class ChangesetBuilderTest extends CompilerTest {
         plus.getId
       )
     }
+
+    "module with undefined literal" in {
+      implicit val moduleContext: ModuleContext = freshModuleContext
+
+      val code =
+        """main =
+          |    x = 1 + undefined
+          |    y = x - 1
+          |    y
+          |
+          |
+          |#### METADATA ####
+          |[[{"index": {"value": 47}, "size": {"value": 1}}, "b95f644b-e877-4e33-b5da-11a65e01068e"],[{"index": {"value": 37}, "size": {"value": 5}}, "17edd47d-b546-4d57-a453-0529036b393f"],[{"index": {"value": 15}, "size": {"value": 13}}, "b1c393b2-67be-488b-b46d-2adba21bca6d"]]
+          |[]
+          |""".stripMargin
+      val edit = TextEdit(Range(Position(1, 12), Position(1, 21)), "42")
+
+      val ir = code.preprocessModule
+      val main =
+        ir.bindings(0).asInstanceOf[IR.Module.Scope.Definition.Method.Explicit]
+      val mainBody = main.body
+        .asInstanceOf[IR.Function.Lambda]
+        .body
+        .asInstanceOf[IR.Expression.Block]
+      val x     = mainBody.expressions(0).asInstanceOf[IR.Expression.Binding]
+      val xExpr = x.expression.asInstanceOf[IR.Application.Prefix]
+      val undefinedName = xExpr
+        .arguments(1)
+        .asInstanceOf[IR.CallArgument.Specified]
+        .value
+        .asInstanceOf[IR.Error.Resolution]
+        .originalName
+
+      invalidated(ir, code, edit) should contain theSameElementsAs Seq(
+        undefinedName.getId
+      )
+      invalidatedAll(ir, code, edit) should contain theSameElementsAs Seq(
+        UUID.fromString("b1c393b2-67be-488b-b46d-2adba21bca6d"),
+        UUID.fromString("17edd47d-b546-4d57-a453-0529036b393f"),
+        UUID.fromString("b95f644b-e877-4e33-b5da-11a65e01068e")
+      )
+    }
+
   }
 
   def invalidated(ir: IR, code: String, edits: TextEdit*): Set[IR.Identifier] =
     new ChangesetBuilder(Rope(code), ir).invalidated(edits).map(_.internalId)
+
+  def invalidatedAll(
+    ir: IR,
+    code: String,
+    edits: TextEdit*
+  ): Set[IR.ExternalId] =
+    new ChangesetBuilder(Rope(code), ir).compute(edits)
+
+  def freshModuleContext: ModuleContext =
+    buildModuleContext(freshNameSupply = Some(new FreshNameSupply))
+
+  def freshInlineContext: InlineContext =
+    buildInlineContext(
+      localScope       = Some(LocalScope.root),
+      freshNameSupply  = Some(new FreshNameSupply),
+      isInTailPosition = Some(false)
+    )
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
@@ -873,7 +873,7 @@ class DataflowAnalysisTest extends CompilerTest {
       depInfo.getDirect(undefinedNameId) shouldEqual Some(Set(bindingExprId))
     }
 
-    "propagate undefined variables in expressions" in {
+    "work properly for undefined variables in expressions" in {
       implicit val inlineContext: InlineContext = mkInlineContext
 
       val ir =

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/DataflowAnalysisTest.scala
@@ -855,19 +855,59 @@ class DataflowAnalysisTest extends CompilerTest {
 
       val depInfo = ir.getMetadata(DataflowAnalysis).get
 
-      val binding     = ir.asInstanceOf[IR.Expression.Binding]
-      val bindingName = binding.name.asInstanceOf[IR.Name.Literal]
-      val bindingExpr = binding.expression.asInstanceOf[IR.Error.Resolution]
+      val binding       = ir.asInstanceOf[IR.Expression.Binding]
+      val bindingName   = binding.name.asInstanceOf[IR.Name.Literal]
+      val bindingExpr   = binding.expression.asInstanceOf[IR.Error.Resolution]
+      val undefinedName = bindingExpr.originalName
 
       // The IDs
-      val bindingId     = mkStaticDep(binding.getId)
-      val bindingNameId = mkStaticDep(bindingName.getId)
-      val bindingExprId = mkStaticDep(bindingExpr.getId)
+      val bindingId       = mkStaticDep(binding.getId)
+      val bindingNameId   = mkStaticDep(bindingName.getId)
+      val bindingExprId   = mkStaticDep(bindingExpr.getId)
+      val undefinedNameId = mkDynamicDep(undefinedName.name)
 
       // The Test
       depInfo.getDirect(bindingId) should not be defined
       depInfo.getDirect(bindingNameId) shouldEqual Some(Set(bindingId))
       depInfo.getDirect(bindingExprId) shouldEqual Some(Set(bindingId))
+      depInfo.getDirect(undefinedNameId) shouldEqual Some(Set(bindingExprId))
+    }
+
+    "propagate undefined variables in expressions" in {
+      implicit val inlineContext: InlineContext = mkInlineContext
+
+      val ir =
+        """
+          |x = 1 + undefined
+          |""".stripMargin.preprocessExpression.get.analyse
+
+      val depInfo = ir.getMetadata(DataflowAnalysis).get
+
+      val binding     = ir.asInstanceOf[IR.Expression.Binding]
+      val bindingName = binding.name.asInstanceOf[IR.Name.Literal]
+      val bindingExpr = binding.expression.asInstanceOf[IR.Application.Prefix]
+      val undefinedArg =
+        bindingExpr
+          .arguments(1)
+          .asInstanceOf[IR.CallArgument.Specified]
+      val undefinedExpr = undefinedArg.value.asInstanceOf[IR.Error.Resolution]
+      val undefinedName = undefinedExpr.originalName
+
+      // The IDs
+      val bindingId       = mkStaticDep(binding.getId)
+      val bindingExprId   = mkStaticDep(bindingExpr.getId)
+      val bindingNameId   = mkStaticDep(bindingName.getId)
+      val undefinedArgId  = mkStaticDep(undefinedArg.getId)
+      val undefinedExprId = mkStaticDep(undefinedExpr.getId)
+      val undefinedNameId = mkDynamicDep(undefinedName.name)
+
+      // The Test
+      depInfo.getDirect(bindingId) should not be defined
+      depInfo.getDirect(bindingNameId) shouldEqual Some(Set(bindingId))
+      depInfo.getDirect(bindingExprId) shouldEqual Some(Set(bindingId))
+      depInfo.getDirect(undefinedArgId) shouldEqual Some(Set(bindingExprId))
+      depInfo.getDirect(undefinedExprId) shouldEqual Some(Set(undefinedArgId))
+      depInfo.getDirect(undefinedNameId) shouldEqual Some(Set(undefinedExprId))
     }
 
     "work properly for vector literals" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
@@ -622,8 +622,16 @@ class ExpressionErrorsTest
     )
     context.receive(5) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
-      TestMessages.update(contextId, xId, Constants.ERROR),
-      TestMessages.update(contextId, yId, Constants.ERROR),
+      TestMessages.error(
+        contextId,
+        xId,
+        Api.ExpressionUpdate.Payload.DataflowError(Seq())
+      ),
+      TestMessages.error(
+        contextId,
+        yId,
+        Api.ExpressionUpdate.Payload.DataflowError(Seq())
+      ),
       TestMessages.update(contextId, mainResId, Constants.NOTHING),
       context.executionComplete(contextId)
     )
@@ -664,9 +672,17 @@ class ExpressionErrorsTest
         )
       )
     )
-    context.receive(4) should contain theSameElementsAs Seq(
-      TestMessages.update(contextId, xId, Constants.ERROR),
-      TestMessages.update(contextId, yId, Constants.ERROR),
+    context.receive(3) should contain theSameElementsAs Seq(
+      TestMessages.error(
+        contextId,
+        xId,
+        Api.ExpressionUpdate.Payload.DataflowError(Seq())
+      ),
+      TestMessages.error(
+        contextId,
+        yId,
+        Api.ExpressionUpdate.Payload.DataflowError(Seq())
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
@@ -13,6 +13,7 @@ import org.enso.pkg.{Package, PackageManager}
 import org.enso.polyglot._
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.text.editing.model
+import org.enso.text.editing.model.TextEdit
 import org.enso.text.{ContentVersion, Sha3_224VersionCalculator}
 import org.graalvm.polyglot.Context
 import org.graalvm.polyglot.io.MessageEndpoint
@@ -220,7 +221,7 @@ class ExpressionErrorsTest
         )
       )
     )
-    context.receive(7) should contain theSameElementsAs Seq(
+    context.receive(8) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
         Api.ExecutionUpdate(
@@ -569,6 +570,343 @@ class ExpressionErrorsTest
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual Seq("42")
+  }
+
+  it should "continue execution after dataflow errors" in {
+    val contextId  = UUID.randomUUID()
+    val requestId  = UUID.randomUUID()
+    val moduleName = "Test.Main"
+    val metadata   = new Metadata
+    val xId        = metadata.addItem(55, 19)
+    val yId        = metadata.addItem(83, 5)
+    val mainResId  = metadata.addItem(93, 12)
+
+    val code =
+      """from Builtins import all
+        |
+        |type MyError
+        |
+        |main =
+        |    x = Error.throw MyError
+        |    y = x - 1
+        |    IO.println y
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // Open the new file
+    context.send(
+      Api.Request(Api.OpenFileNotification(mainFile, contents, true))
+    )
+    context.receiveNone shouldEqual None
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, "Test.Main", "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+    context.receive(5) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      TestMessages.update(contextId, xId, Constants.ERROR),
+      TestMessages.update(contextId, yId, Constants.ERROR),
+      TestMessages.update(contextId, mainResId, Constants.NOTHING),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual Seq("(Error: MyError)")
+
+    // Modify the file
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          mainFile,
+          Seq(
+            TextEdit(
+              model.Range(model.Position(5, 8), model.Position(5, 27)),
+              "1234567890123456789"
+            )
+          )
+        )
+      )
+    )
+    context.receive(3) should contain theSameElementsAs Seq(
+      TestMessages.update(contextId, xId, Constants.INTEGER),
+      TestMessages.update(contextId, yId, Constants.INTEGER),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual List("1234567890123456788")
+
+    // Modify the file
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          mainFile,
+          Seq(
+            TextEdit(
+              model.Range(model.Position(5, 8), model.Position(5, 27)),
+              "1000000000000.div 0"
+            )
+          )
+        )
+      )
+    )
+    context.receive(4) should contain theSameElementsAs Seq(
+      TestMessages.update(contextId, xId, Constants.ERROR),
+      TestMessages.update(contextId, yId, Constants.ERROR),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual List(
+      "(Error: (Arithmetic_Error 'Cannot divide by zero.'))"
+    )
+
+    // Modify the file
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          mainFile,
+          Seq(
+            TextEdit(
+              model.Range(model.Position(5, 8), model.Position(5, 27)),
+              "1000000000000.div 2"
+            )
+          )
+        )
+      )
+    )
+    context.receive(3) should contain theSameElementsAs Seq(
+      TestMessages.update(contextId, xId, Constants.INTEGER),
+      TestMessages.update(contextId, yId, Constants.INTEGER),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual List("499999999999")
+  }
+
+  it should "continue execution after thrown panics" in {
+    val contextId  = UUID.randomUUID()
+    val requestId  = UUID.randomUUID()
+    val moduleName = "Test.Main"
+    val metadata   = new Metadata
+    val xId        = metadata.addItem(55, 19)
+    val yId        = metadata.addItem(83, 5)
+    val mainResId  = metadata.addItem(93, 12)
+
+    val code =
+      """from Builtins import all
+        |
+        |type MyError
+        |
+        |main =
+        |    x = Panic.throw MyError
+        |    y = x - 1
+        |    IO.println y
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // Open the new file
+    context.send(
+      Api.Request(Api.OpenFileNotification(mainFile, contents, true))
+    )
+    context.receiveNone shouldEqual None
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, "Test.Main", "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+    context.receive(5) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      Update.panic(
+        contextId,
+        xId,
+        Api.ExpressionUpdate.Payload.Panic(
+          "MyError",
+          Seq(xId)
+        )
+      ),
+      Update.panic(
+        contextId,
+        yId,
+        Api.ExpressionUpdate.Payload.Panic(
+          "MyError",
+          Seq(xId)
+        )
+      ),
+      Update.panic(
+        contextId,
+        mainResId,
+        Api.ExpressionUpdate.Payload.Panic(
+          "MyError",
+          Seq(xId)
+        )
+      ),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual Seq()
+
+    // Modify the file
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          mainFile,
+          Seq(
+            TextEdit(
+              model.Range(model.Position(5, 8), model.Position(5, 27)),
+              "1234567890123456789"
+            )
+          )
+        )
+      )
+    )
+    context.receive(4) should contain theSameElementsAs Seq(
+      TestMessages.update(contextId, xId, Constants.INTEGER),
+      TestMessages.update(contextId, yId, Constants.INTEGER),
+      TestMessages.update(contextId, mainResId, Constants.NOTHING),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual List("1234567890123456788")
+  }
+
+  it should "continue execution after panics in expressions" in {
+    val contextId  = UUID.randomUUID()
+    val requestId  = UUID.randomUUID()
+    val moduleName = "Test.Main"
+    val metadata   = new Metadata
+    val xId        = metadata.addItem(41, 7)
+    val yId        = metadata.addItem(57, 5)
+    val mainResId  = metadata.addItem(67, 12)
+
+    val code =
+      """from Builtins import all
+        |
+        |main =
+        |    x = 1 + foo
+        |    y = x - 1
+        |    IO.println y
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // Open the new file
+    context.send(
+      Api.Request(Api.OpenFileNotification(mainFile, contents, true))
+    )
+    context.receiveNone shouldEqual None
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, "Test.Main", "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+    context.receive(6) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      Api.Response(
+        Api.ExecutionUpdate(
+          contextId,
+          Seq(
+            Api.ExecutionResult.Diagnostic.error(
+              "Variable `foo` is not defined.",
+              Some(mainFile),
+              Some(model.Range(model.Position(3, 12), model.Position(3, 15))),
+              None
+            )
+          )
+        )
+      ),
+      Update.panic(
+        contextId,
+        xId,
+        Api.ExpressionUpdate.Payload.Panic(
+          "Compile_Error Variable `foo` is not defined.",
+          Seq(xId)
+        )
+      ),
+      Update.panic(
+        contextId,
+        yId,
+        Api.ExpressionUpdate.Payload.Panic(
+          "Compile_Error Variable `foo` is not defined.",
+          Seq(xId)
+        )
+      ),
+      Update.panic(
+        contextId,
+        mainResId,
+        Api.ExpressionUpdate.Payload.Panic(
+          "Compile_Error Variable `foo` is not defined.",
+          Seq(xId)
+        )
+      ),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual Seq()
+
+    // Modify the file
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          mainFile,
+          Seq(
+            TextEdit(
+              model.Range(model.Position(3, 12), model.Position(3, 15)),
+              "101"
+            )
+          )
+        )
+      )
+    )
+    context.receive(4) should contain theSameElementsAs Seq(
+      TestMessages.update(contextId, xId, Constants.INTEGER),
+      TestMessages.update(contextId, yId, Constants.INTEGER),
+      TestMessages.update(contextId, mainResId, Constants.NOTHING),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual List("101")
+
   }
 
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1483 

PR fixes dependency analysis on `IR.Error` nodes.

Changelog:
- fix: dataflow analysis takes into account external node ids when building dynamic references.
- fix: ChangesetBuilder queries dependencies of dynamic symbols (in addition to stable identifiers)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
