### PR TITLE
Error message representations

### DIFF
--- a/distribution/std-lib/Base/src/Data/Any/Extensions.enso
+++ b/distribution/std-lib/Base/src/Data/Any/Extensions.enso
@@ -127,5 +127,5 @@ Any.>> that = x -> that (this x)
 
    Types defining their own versions of this method should ensure that the
    result is reasonably small and the operation is quick to compute.
-Any.to_display : Text
-Any.to_display = this.to_json.to_text
+Any.to_default_visualization_data : Text
+Any.to_default_visualization_data = this.to_json.to_text

--- a/distribution/std-lib/Base/src/Error/Extensions.enso
+++ b/distribution/std-lib/Base/src/Error/Extensions.enso
@@ -30,9 +30,9 @@ Error.catch (handler = x->x) = this.catch_primitive handler
 
    > Example
      Displaying a dataflow error.
-         (Error.throw "oops!").to_display
-Error.to_display : Text
-Error.to_display = this.catch .to_display
+         (Error.throw "oops!").to_default_visualization_data
+Error.to_default_visualization_data : Text
+Error.to_default_visualization_data = this.catch .to_default_visualization_data
 
 ## Takes any value, and if it is a dataflow error, throws it as a Panic.
    Otherwise, returns the original value unchanged.

--- a/distribution/std-lib/Base/src/Error/Extensions.enso
+++ b/distribution/std-lib/Base/src/Error/Extensions.enso
@@ -34,6 +34,10 @@ Error.catch (handler = x->x) = this.catch_primitive handler
 Error.to_default_visualization_data : Text
 Error.to_default_visualization_data = this.catch .to_default_visualization_data
 
+## Returns a human-readable text representing this error.
+Error.to_display_text : Text
+Error.to_display_text  = "Error: " + (this.catch .to_display_text)
+
 ## Takes any value, and if it is a dataflow error, throws it as a Panic.
    Otherwise, returns the original value unchanged.
 Panic.rethrow : (Any ! Any) -> Any

--- a/distribution/std-lib/Table/src/Data/Column.enso
+++ b/distribution/std-lib/Table/src/Data/Column.enso
@@ -307,8 +307,8 @@ type Column
 
        Shows a JSON serialization of a truncated version of this column, for the
        benefit of visualization in the IDE.
-    to_display : Text
-    to_display =
+    to_default_visualization_data : Text
+    to_default_visualization_data =
         size = ['length', this.length]
         name = ['name', this.name]
         max_data = 100

--- a/distribution/std-lib/Table/src/Data/Table.enso
+++ b/distribution/std-lib/Table/src/Data/Table.enso
@@ -58,7 +58,8 @@ type Table
        Returns a Text used to display this table in the IDE by default.
        Returns a JSON object containing useful metadata and previews of column
        values.
-    to_display =
+    to_default_visualization_data : Text
+    to_default_visualization_data =
         max_size = 10
         nrows = ['number_of_rows', this.nrows]
         cols = this.columns.map c->

--- a/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
@@ -42,6 +42,7 @@ class ContextFactory {
       .option(RuntimeOptions.PACKAGES_PATH, packagesPath)
       .option(RuntimeOptions.STRICT_ERRORS, strictErrors.toString)
       .option(DebugServerInfo.ENABLE_OPTION, "true")
+      .option("js.foreign-object-prototype", "true")
       .out(out)
       .in(in)
       .serverTransport { (uri, peer) =>

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArithmeticErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArithmeticErrorToDisplayTextNode.java
@@ -1,0 +1,33 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@BuiltinMethod(type = "Compile_Error", name = "to_display_text")
+public abstract class ArithmeticErrorToDisplayTextNode extends Node {
+  static ArithmeticErrorToDisplayTextNode build() {
+    return ArithmeticErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this) {
+    try {
+      return Text.create("Arithmetic error: ", TypesGen.expectText(_this.getFields()[0]));
+    } catch (UnexpectedResultException e) {
+      return Text.create("Arithmetic error.");
+    }
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Arithmetic error.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArithmeticErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArithmeticErrorToDisplayTextNode.java
@@ -9,7 +9,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-@BuiltinMethod(type = "Compile_Error", name = "to_display_text")
+@BuiltinMethod(type = "Arithmetic_Error", name = "to_display_text")
 public abstract class ArithmeticErrorToDisplayTextNode extends Node {
   static ArithmeticErrorToDisplayTextNode build() {
     return ArithmeticErrorToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArityErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArityErrorToDisplayTextNode.java
@@ -1,0 +1,31 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+
+@BuiltinMethod(type = "Compile_Error", name = "to_display_text")
+public abstract class ArityErrorToDisplayTextNode extends Node {
+  static ArityErrorToDisplayTextNode build() {
+    return ArityErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this) {
+    return Text.create("Wrong number of arguments. Expected ")
+        .add(String.valueOf(_this.getFields()[0]))
+        .add(", but got ")
+        .add(String.valueOf(_this.getFields()[1]))
+        .add(".");
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Wrong number of arguments.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArityErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArityErrorToDisplayTextNode.java
@@ -7,7 +7,7 @@ import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.text.Text;
 
-@BuiltinMethod(type = "Compile_Error", name = "to_display_text")
+@BuiltinMethod(type = "Arity_Error", name = "to_display_text")
 public abstract class ArityErrorToDisplayTextNode extends Node {
   static ArityErrorToDisplayTextNode build() {
     return ArityErrorToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/CompileErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/CompileErrorToDisplayTextNode.java
@@ -1,0 +1,33 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@BuiltinMethod(type = "Compile_Error", name = "to_display_text")
+public abstract class CompileErrorToDisplayTextNode extends Node {
+  static CompileErrorToDisplayTextNode build() {
+    return CompileErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this) {
+    try {
+      return Text.create("Compile error: ", TypesGen.expectText(_this.getFields()[0]));
+    } catch (UnexpectedResultException e) {
+      return Text.create("Compile error.");
+    }
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Compile error.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/InexhaustivePatternMatchErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/InexhaustivePatternMatchErrorToDisplayTextNode.java
@@ -11,7 +11,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+@BuiltinMethod(type = "Inexhaustive_Pattern_Match_Error", name = "to_display_text")
 public abstract class InexhaustivePatternMatchErrorToDisplayTextNode extends Node {
   static InexhaustivePatternMatchErrorToDisplayTextNode build() {
     return InexhaustivePatternMatchErrorToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/InexhaustivePatternMatchErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/InexhaustivePatternMatchErrorToDisplayTextNode.java
@@ -1,0 +1,33 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+public abstract class InexhaustivePatternMatchErrorToDisplayTextNode extends Node {
+  static InexhaustivePatternMatchErrorToDisplayTextNode build() {
+    return InexhaustivePatternMatchErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this, @Cached TypeToDisplayTextNode displayTypeNode) {
+    return Text.create("Inexhaustive pattern match: no branch matches ")
+        .add(displayTypeNode.execute(_this.getFields()[0]))
+        .add(".");
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Inexhaustive pattern match.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/InvalidArrayIndexErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/InvalidArrayIndexErrorToDisplayTextNode.java
@@ -1,0 +1,29 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@BuiltinMethod(type = "Compile_Error", name = "to_display_text")
+public abstract class InvalidArrayIndexErrorToDisplayTextNode extends Node {
+  static InvalidArrayIndexErrorToDisplayTextNode build() {
+    return InvalidArrayIndexErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this) {
+    return Text.create("Invalid array index: ", String.valueOf(_this.getFields()[1]));
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Invalid array index.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/InvalidArrayIndexErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/InvalidArrayIndexErrorToDisplayTextNode.java
@@ -9,7 +9,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-@BuiltinMethod(type = "Compile_Error", name = "to_display_text")
+@BuiltinMethod(type = "Invalid_Array_Index_Error", name = "to_display_text")
 public abstract class InvalidArrayIndexErrorToDisplayTextNode extends Node {
   static InvalidArrayIndexErrorToDisplayTextNode build() {
     return InvalidArrayIndexErrorToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ModuleDoesNotExistErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ModuleDoesNotExistErrorToDisplayTextNode.java
@@ -9,7 +9,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-@BuiltinMethod(type = "Syntax_Error", name = "to_display_text")
+@BuiltinMethod(type = "Module_Does_Not_Exist_Error", name = "to_display_text")
 public abstract class ModuleDoesNotExistErrorToDisplayTextNode extends Node {
   static ModuleDoesNotExistErrorToDisplayTextNode build() {
     return ModuleDoesNotExistErrorToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ModuleDoesNotExistErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ModuleDoesNotExistErrorToDisplayTextNode.java
@@ -1,0 +1,35 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@BuiltinMethod(type = "Syntax_Error", name = "to_display_text")
+public abstract class ModuleDoesNotExistErrorToDisplayTextNode extends Node {
+  static ModuleDoesNotExistErrorToDisplayTextNode build() {
+    return ModuleDoesNotExistErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this) {
+    try {
+      return Text.create("Module ")
+          .add(TypesGen.expectText(_this.getFields()[0]))
+          .add(" does not exist.");
+    } catch (UnexpectedResultException e) {
+      return Text.create("Module does not exist.");
+    }
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Module does not exist.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ModuleNotInPackageErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ModuleNotInPackageErrorToDisplayTextNode.java
@@ -1,0 +1,21 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+
+@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+public class ModuleNotInPackageErrorToDisplayTextNode extends Node {
+
+  Text execute(Object _this) {
+    return Text.create("Module is not a part of a package.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ModuleNotInPackageErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ModuleNotInPackageErrorToDisplayTextNode.java
@@ -12,7 +12,7 @@ import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.text.Text;
 
-@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+@BuiltinMethod(type = "Module_Not_In_Package_Error", name = "to_display_text")
 public class ModuleNotInPackageErrorToDisplayTextNode extends Node {
 
   Text execute(Object _this) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/NoSuchMethodErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/NoSuchMethodErrorToDisplayTextNode.java
@@ -11,7 +11,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+@BuiltinMethod(type = "No_Such_Method_Error", name = "to_display_text")
 public abstract class NoSuchMethodErrorToDisplayTextNode extends Node {
   static NoSuchMethodErrorToDisplayTextNode build() {
     return NoSuchMethodErrorToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/NoSuchMethodErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/NoSuchMethodErrorToDisplayTextNode.java
@@ -1,0 +1,39 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+public abstract class NoSuchMethodErrorToDisplayTextNode extends Node {
+  static NoSuchMethodErrorToDisplayTextNode build() {
+    return NoSuchMethodErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this, @Cached TypeToDisplayTextNode displayTypeNode) {
+    try {
+      return Text.create("Method `")
+          .add(TypesGen.expectUnresolvedSymbol(_this.getFields()[1]).getName())
+          .add("` of ")
+          .add(displayTypeNode.execute(_this.getFields()[0]))
+          .add(" could not be found.");
+    } catch (UnexpectedResultException e) {
+      return Text.create("Method could not be found.");
+    }
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Method could not be found.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/NotInvokableErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/NotInvokableErrorToDisplayTextNode.java
@@ -11,7 +11,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+@BuiltinMethod(type = "Not_Invokable_Error", name = "to_display_text")
 public abstract class NotInvokableErrorToDisplayTextNode extends Node {
   static NotInvokableErrorToDisplayTextNode build() {
     return NotInvokableErrorToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/NotInvokableErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/NotInvokableErrorToDisplayTextNode.java
@@ -1,0 +1,32 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+public abstract class NotInvokableErrorToDisplayTextNode extends Node {
+  static NotInvokableErrorToDisplayTextNode build() {
+    return NotInvokableErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this, @Cached TypeToDisplayTextNode displayTypeNode) {
+    return Text.create("Type error: expected a function, but got ")
+        .add(displayTypeNode.execute(_this.getFields()[0]));
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Type error.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/PolyglotErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/PolyglotErrorToDisplayTextNode.java
@@ -1,0 +1,49 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+public abstract class PolyglotErrorToDisplayTextNode extends Node {
+  static PolyglotErrorToDisplayTextNode build() {
+    return PolyglotErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(
+      Atom _this,
+      @Cached TypeToDisplayTextNode displayTypeNode,
+      @CachedLibrary(limit = "5") InteropLibrary exceptions,
+      @CachedLibrary(limit = "5") InteropLibrary strings) {
+    try {
+      Object cause = _this.getFields()[0];
+      String rep;
+      if (exceptions.hasExceptionMessage(cause)) {
+        rep = strings.asString(exceptions.getExceptionCause(cause));
+      } else {
+        rep = displayTypeNode.execute(cause);
+      }
+      return Text.create("Polyglot error: ").add(rep);
+    } catch (UnsupportedMessageException e) {
+      return Text.create("Polyglot error.");
+    }
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Polyglot error.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/PolyglotErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/PolyglotErrorToDisplayTextNode.java
@@ -14,7 +14,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+@BuiltinMethod(type = "Polyglot_Error", name = "to_display_text")
 public abstract class PolyglotErrorToDisplayTextNode extends Node {
   static PolyglotErrorToDisplayTextNode build() {
     return PolyglotErrorToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/SyntaxErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/SyntaxErrorToDisplayTextNode.java
@@ -1,0 +1,33 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@BuiltinMethod(type = "Syntax_Error", name = "to_display_text")
+public abstract class SyntaxErrorToDisplayTextNode extends Node {
+  static SyntaxErrorToDisplayTextNode build() {
+    return SyntaxErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this) {
+    try {
+      return Text.create("Syntax error: ", TypesGen.expectText(_this.getFields()[0]));
+    } catch (UnexpectedResultException e) {
+      return Text.create("Syntax error.");
+    }
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Syntax error.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/TypeErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/TypeErrorToDisplayTextNode.java
@@ -1,0 +1,41 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+public abstract class TypeErrorToDisplayTextNode extends Node {
+  static TypeErrorToDisplayTextNode build() {
+    return TypeErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this, @Cached TypeToDisplayTextNode displayTypeNode) {
+    try {
+      return Text.create("Type error: expected ")
+          .add(TypesGen.expectText(_this.getFields()[2]))
+          .add(" to be ")
+          .add(displayTypeNode.execute(_this.getFields()[0]))
+          .add(", but got ")
+          .add(displayTypeNode.execute(_this.getFields()[1]))
+          .add(".");
+    } catch (UnexpectedResultException e) {
+      return Text.create("Type error.");
+    }
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Type error.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/UninitializedStateErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/UninitializedStateErrorToDisplayTextNode.java
@@ -1,0 +1,31 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+
+@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+public abstract class UninitializedStateErrorToDisplayTextNode extends Node {
+  static UninitializedStateErrorToDisplayTextNode build() {
+    return UninitializedStateErrorToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this, @Cached TypeToDisplayTextNode displayTypeNode) {
+    return Text.create("State is not initialized for type ")
+        .add(displayTypeNode.execute(_this.getFields()[0]))
+        .add(".");
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Uninitialized state error.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/UninitializedStateErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/UninitializedStateErrorToDisplayTextNode.java
@@ -9,7 +9,7 @@ import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.text.Text;
 
-@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+@BuiltinMethod(type = "Uninitialized_State_Error", name = "to_display_text")
 public abstract class UninitializedStateErrorToDisplayTextNode extends Node {
   static UninitializedStateErrorToDisplayTextNode build() {
     return UninitializedStateErrorToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/UnsupportedArgumentTypesToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/UnsupportedArgumentTypesToDisplayTextNode.java
@@ -1,0 +1,32 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.UnexpectedResultException;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+public abstract class UnsupportedArgumentTypesToDisplayTextNode extends Node {
+  static UnsupportedArgumentTypesToDisplayTextNode build() {
+    return UnsupportedArgumentTypesToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doAtom(Atom _this, @Cached TypeToDisplayTextNode displayTypeNode) {
+    return Text.create("Unsupported argument types: ")
+        .add(displayTypeNode.execute(_this.getFields()[0]));
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor _this) {
+    return Text.create("Unsupported argument types.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/UnsupportedArgumentTypesToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/UnsupportedArgumentTypesToDisplayTextNode.java
@@ -11,7 +11,7 @@ import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.type.TypesGen;
 
-@BuiltinMethod(type = "Type_Error", name = "to_display_text")
+@BuiltinMethod(type = "Unsupported_Argument_Types", name = "to_display_text")
 public abstract class UnsupportedArgumentTypesToDisplayTextNode extends Node {
   static UnsupportedArgumentTypesToDisplayTextNode build() {
     return UnsupportedArgumentTypesToDisplayTextNodeGen.create();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToDisplayTextNode.java
@@ -1,0 +1,27 @@
+package org.enso.interpreter.node.expression.builtin.text;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Fallback;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.data.text.Text;
+
+@BuiltinMethod(type = "Any", name = "to_display_text")
+public abstract class AnyToDisplayTextNode extends Node {
+  static AnyToDisplayTextNode build() {
+    return AnyToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object _this);
+
+  @Specialization
+  Text doShowType(Object _this, @Cached TypeToDisplayTextNode typeToDisplayTextNode) {
+    return Text.create(typeToDisplayTextNode.execute(_this));
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/util/TypeToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/util/TypeToDisplayTextNode.java
@@ -1,0 +1,60 @@
+package org.enso.interpreter.node.expression.builtin.text.util;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.runtime.type.TypesGen;
+
+@GenerateUncached
+public abstract class TypeToDisplayTextNode extends Node {
+  public abstract String execute(Object o);
+
+  @Specialization
+  @CompilerDirectives.TruffleBoundary
+  String doDisplay(
+      Object value,
+      @CachedLibrary(limit = "5") InteropLibrary objects,
+      @CachedLibrary(limit = "5") InteropLibrary displays,
+      @CachedLibrary(limit = "5") InteropLibrary strings) {
+    if (TypesGen.isLong(value)) {
+      return value + " (Integer)";
+    } else if (TypesGen.isEnsoBigInteger(value)) {
+      return "Integer";
+    } else if (TypesGen.isDouble(value)) {
+      return value + " (Decimal)";
+    } else if (TypesGen.isBoolean(value)) {
+      return (TypesGen.asBoolean(value) ? "True" : "False");
+    } else if (TypesGen.isText(value)) {
+      return "Text";
+    } else if (TypesGen.isFunction(value)) {
+      return "Function";
+    } else if (TypesGen.isAtom(value)) {
+      return TypesGen.asAtom(value).getConstructor().getName();
+    } else if (TypesGen.isAtomConstructor(value)) {
+      return TypesGen.asAtomConstructor(value).getName();
+    } else if (TypesGen.isDataflowError(value)) {
+      return "Error";
+    } else if (TypesGen.isUnresolvedSymbol(value)) {
+      return TypesGen.asUnresolvedSymbol(value).getName() + " (Unresolved_Symbol)";
+    } else if (TypesGen.isManagedResource(value)) {
+      return "Managed_Resource";
+    } else if (TypesGen.isArray(value)) {
+      return "Array";
+    } else if (TypesGen.isRef(value)) {
+      return "Ref";
+    } else if (objects.hasMetaObject(value)) {
+      try {
+        return strings.asString(displays.toDisplayString(objects.getMetaObject(value)));
+      } catch (UnsupportedMessageException e) {
+        throw new IllegalStateException(
+            "Receiver declares a meta object, but does not it return it.");
+      }
+    } else {
+      return "a polyglot object";
+    }
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -28,6 +28,7 @@ import org.enso.interpreter.node.expression.builtin.runtime.NoInlineMethodGen;
 import org.enso.interpreter.node.expression.builtin.state.GetStateMethodGen;
 import org.enso.interpreter.node.expression.builtin.state.PutStateMethodGen;
 import org.enso.interpreter.node.expression.builtin.state.RunStateMethodGen;
+import org.enso.interpreter.node.expression.builtin.text.AnyToDisplayTextMethodGen;
 import org.enso.interpreter.node.expression.builtin.text.AnyToTextMethodGen;
 import org.enso.interpreter.node.expression.builtin.thread.WithInterruptHandlerMethodGen;
 import org.enso.interpreter.node.expression.builtin.unsafe.SetAtomFieldMethodGen;
@@ -163,6 +164,7 @@ public class Builtins {
     scope.registerMethod(function, "call", ExplicitCallFunctionMethodGen.makeFunction(language));
 
     scope.registerMethod(any, "to_text", AnyToTextMethodGen.makeFunction(language));
+    scope.registerMethod(any, "to_display_text", AnyToDisplayTextMethodGen.makeFunction(language));
 
     scope.registerMethod(java, "add_to_class_path", AddToClassPathMethodGen.makeFunction(language));
     scope.registerMethod(java, "lookup_class", LookupClassMethodGen.makeFunction(language));

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.runtime.builtin;
 
 import org.enso.interpreter.Language;
+import org.enso.interpreter.node.expression.builtin.error.displaytext.*;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.ArgumentDefinition;
 import org.enso.interpreter.runtime.callable.atom.Atom;
@@ -24,7 +25,6 @@ public class Error {
   private final AtomConstructor arityError;
   private final AtomConstructor unsupportedArgumentsError;
   private final AtomConstructor moduleDoesNotExistError;
-  private final AtomConstructor duplicateArgumentNameError;
   private final AtomConstructor notInvokableError;
 
   private final Atom arithmeticErrorShiftTooBig;
@@ -88,7 +88,7 @@ public class Error {
         new AtomConstructor("Arity_Error", scope)
             .initializeFields(
                 new ArgumentDefinition(0, "expected", ArgumentDefinition.ExecutionMode.EXECUTE),
-                new ArgumentDefinition(0, "actual", ArgumentDefinition.ExecutionMode.EXECUTE));
+                new ArgumentDefinition(1, "actual", ArgumentDefinition.ExecutionMode.EXECUTE));
 
     unsupportedArgumentsError =
         new AtomConstructor("Unsupported_Argument_Types", scope)
@@ -98,28 +98,63 @@ public class Error {
         new AtomConstructor("Module_Does_Not_Exist", scope)
             .initializeFields(
                 new ArgumentDefinition(0, "name", ArgumentDefinition.ExecutionMode.EXECUTE));
-    duplicateArgumentNameError =
-        new AtomConstructor("Duplicate_Argument_Name", scope)
-            .initializeFields(
-                new ArgumentDefinition(0, "name", ArgumentDefinition.ExecutionMode.EXECUTE));
     notInvokableError =
         new AtomConstructor("Not_Invokable", scope)
             .initializeFields(
                 new ArgumentDefinition(0, "target", ArgumentDefinition.ExecutionMode.EXECUTE));
 
-    scope.registerConstructor(syntaxError);
-    scope.registerConstructor(typeError);
-    scope.registerConstructor(compileError);
-    scope.registerConstructor(inexhaustivePatternMatchError);
-    scope.registerConstructor(uninitializedState);
-    scope.registerConstructor(noSuchMethodError);
-    scope.registerConstructor(polyglotError);
-    scope.registerConstructor(moduleNotInPackageError);
-    scope.registerConstructor(arithmeticError);
-    scope.registerConstructor(invalidArrayIndexError);
-    scope.registerConstructor(typeError);
     scope.registerConstructor(arityError);
+    scope.registerMethod(
+        arityError, "to_display_text", ArityErrorToDisplayTextMethodGen.makeFunction(language));
+    scope.registerConstructor(syntaxError);
+    scope.registerMethod(
+        syntaxError, "to_display_text", SyntaxErrorToDisplayTextMethodGen.makeFunction(language));
+    scope.registerConstructor(typeError);
+    scope.registerMethod(
+        typeError, "to_display_text", TypeErrorToDisplayTextMethodGen.makeFunction(language));
+    scope.registerConstructor(compileError);
+    scope.registerMethod(
+        compileError, "to_display_text", CompileErrorToDisplayTextMethodGen.makeFunction(language));
+    scope.registerConstructor(inexhaustivePatternMatchError);
+    scope.registerMethod(
+        inexhaustivePatternMatchError,
+        "to_display_text",
+        InexhaustivePatternMatchErrorToDisplayTextMethodGen.makeFunction(language));
+    scope.registerConstructor(uninitializedState);
+    scope.registerMethod(
+        uninitializedState,
+        "to_display_text",
+        UninitializedStateErrorToDisplayTextMethodGen.makeFunction(language));
+    scope.registerConstructor(noSuchMethodError);
+    scope.registerMethod(
+        noSuchMethodError,
+        "to_display_text",
+        NoSuchMethodErrorToDisplayTextMethodGen.makeFunction(language));
+    scope.registerConstructor(polyglotError);
+    scope.registerMethod(
+        polyglotError,
+        "to_display_text",
+        PolyglotErrorToDisplayTextMethodGen.makeFunction(language));
+    scope.registerConstructor(moduleNotInPackageError);
+    scope.registerMethod(
+        moduleNotInPackageError,
+        "to_display_text",
+        ModuleNotInPackageErrorToDisplayTextMethodGen.makeFunction(language));
+    scope.registerConstructor(arithmeticError);
+    scope.registerMethod(
+        arithmeticError,
+        "to_display_text",
+        ArithmeticErrorToDisplayTextMethodGen.makeFunction(language));
+    scope.registerConstructor(invalidArrayIndexError);
+    scope.registerMethod(
+        invalidArrayIndexError,
+        "to_display_text",
+        InvalidArrayIndexErrorToDisplayTextMethodGen.makeFunction(language));
     scope.registerConstructor(unsupportedArgumentsError);
+    scope.registerMethod(
+        unsupportedArgumentsError,
+        "to_display_text",
+        UnsupportedArgumentTypesToDisplayTextMethodGen.makeFunction(language));
   }
 
   /** @return the builtin {@code Syntax_Error} atom constructor. */
@@ -237,15 +272,7 @@ public class Error {
    * @return a module does not exist error
    */
   public Atom makeModuleDoesNotExistError(String name) {
-    return moduleDoesNotExistError.newInstance(name);
-  }
-
-  /**
-   * @param name the name of the duplicated argument
-   * @return a duplicate argument name error
-   */
-  public Atom makeDuplicateArgumentNameError(String name) {
-    return duplicateArgumentNameError.newInstance(name);
+    return moduleDoesNotExistError.newInstance(Text.create(name));
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
@@ -91,10 +91,20 @@ public class Text implements TruffleObject {
     return new Text(new ConcatRope(t1, t2));
   }
 
+  /**
+   * Adds a string to this text.
+   * @param other the string add.
+   * @return the concatenation of this and the requested string.
+   */
   public Text add(String other) {
     return new Text(new ConcatRope(this.contents, other));
   }
 
+  /**
+   * Adds a text to this text.
+   * @param other the text add.
+   * @return the concatenation of this and the requested text.
+   */
   public Text add(Text other) {
     return new Text(new ConcatRope(this.contents, other.contents));
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
@@ -69,6 +69,36 @@ public class Text implements TruffleObject {
     return new Text(new ConcatRope(t1.contents, t2));
   }
 
+  /**
+   * Creates a new Text by concatenating a text and a string.
+   *
+   * @param t1 the left operand.
+   * @param t2 the right operand.
+   * @return a Text representing concatenation of t1 and t2.
+   */
+  public static Text create(String t1, Text t2) {
+    return new Text(new ConcatRope(t1, t2.contents));
+  }
+
+  /**
+   * Creates a new Text by concatenating two strings.
+   *
+   * @param t1 the left operand.
+   * @param t2 the right operand.
+   * @return a Text representing concatenation of t1 and t2.
+   */
+  public static Text create(String t1, String t2) {
+    return new Text(new ConcatRope(t1, t2));
+  }
+
+  public Text add(String other) {
+    return new Text(new ConcatRope(this.contents, other));
+  }
+
+  public Text add(Text other) {
+    return new Text(new ConcatRope(this.contents, other.contents));
+  }
+
   @ExportMessage
   boolean isString() {
     return true;

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -314,6 +314,12 @@ public class ExecutionService {
     return null;
   }
 
+  /**
+   * Returns a human-readable message for a panic exception.
+   *
+   * @param panic the panic to display.
+   * @return a human-readable version of its contents.
+   */
   public String getExceptionMessage(PanicException panic) {
     try {
       return interopLibrary.asString(

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -11,10 +11,12 @@ import org.enso.interpreter.instrument.IdExecutionInstrument;
 import org.enso.interpreter.instrument.MethodCallsCache;
 import org.enso.interpreter.instrument.RuntimeCache;
 import org.enso.interpreter.node.callable.FunctionCallInstrumentationNode;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNodeGen;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.interpreter.runtime.state.data.EmptyMap;
 import org.enso.interpreter.service.error.*;
@@ -310,5 +312,23 @@ public class ExecutionService {
       }
     }
     return null;
+  }
+
+  public String getExceptionMessage(PanicException panic) {
+    try {
+      return interopLibrary.asString(
+          interopLibrary.invokeMember(panic.getPayload(), "to_display_text"));
+    } catch (UnsupportedMessageException
+        | ArityException
+        | UnknownIdentifierException
+        | UnsupportedTypeException e) {
+      return TypeToDisplayTextNodeGen.getUncached().execute(panic.getPayload());
+    } catch (Throwable e) {
+      if (interopLibrary.isException(e)) {
+        return TypeToDisplayTextNodeGen.getUncached().execute(panic.getPayload());
+      } else {
+        throw e;
+      }
+    }
   }
 }

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -264,6 +264,15 @@ type Compile_Error message
 @Builtin_Type
 type Inexhaustive_Pattern_Match_Error scrutinee
 
+## The error thrown when the number of arguments provided to an operation
+   does not match the expected number of arguments.
+
+   Arguments:
+     - expected: the expected number of arguments.
+     - actual: the actual number of arguments passed.
+@Builtin_Type
+type Arity_Error expected actual
+
 ## The error thrown when the program attempts to read from a state slot that has
    not yet been initialized.
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -1052,7 +1052,7 @@ class IrToTruffle(
 
           if (seenArgNames contains argName) {
             throw new IllegalStateException(
-              "A duplicate argument name found during codegen."
+              s"A duplicate argument name, $argName, was found during codegen."
             )
           } else seenArgNames.add(argName)
           slot

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -63,7 +63,6 @@ import org.enso.interpreter.runtime.callable.function.{
   Function => RuntimeFunction
 }
 import org.enso.interpreter.runtime.data.text.Text
-import org.enso.interpreter.runtime.error.PanicException
 import org.enso.interpreter.runtime.scope.{
   FramePointer,
   LocalScope,
@@ -1052,9 +1051,9 @@ class IrToTruffle(
           val argName = arg.getName
 
           if (seenArgNames contains argName) {
-            val err =
-              context.getBuiltins.error.makeDuplicateArgumentNameError(argName)
-            throw new PanicException(err, null)
+            throw new IllegalStateException(
+              "A duplicate argument name found during codegen."
+            )
           } else seenArgNames.add(argName)
           slot
         }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -328,7 +328,7 @@ trait ProgramExecutionSupport {
         case sentinel: PanicSentinel =>
           Api.ExpressionUpdate.Payload
             .Panic(
-              sentinel.getPanic.getMessage,
+              ctx.executionService.getExceptionMessage(sentinel.getPanic),
               ErrorResolver.getStackTrace(sentinel).flatMap(_.expressionId)
             )
         case error: DataflowError =>

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
@@ -240,7 +240,7 @@ class ExpressionErrorsTest
         contextId,
         xId,
         Api.ExpressionUpdate.Payload.Panic(
-          "Compile_Error Variable `undefined` is not defined.",
+          "Compile error: Variable `undefined` is not defined.",
           Seq(xId)
         )
       ),
@@ -248,7 +248,7 @@ class ExpressionErrorsTest
         contextId,
         fooBodyId,
         Api.ExpressionUpdate.Payload.Panic(
-          "Compile_Error Variable `undefined` is not defined.",
+          "Compile error: Variable `undefined` is not defined.",
           Seq(xId)
         )
       ),
@@ -256,7 +256,7 @@ class ExpressionErrorsTest
         contextId,
         yId,
         Api.ExpressionUpdate.Payload.Panic(
-          "Compile_Error Variable `undefined` is not defined.",
+          "Compile error: Variable `undefined` is not defined.",
           Seq(xId)
         )
       ),
@@ -264,7 +264,7 @@ class ExpressionErrorsTest
         contextId,
         mainResId,
         Api.ExpressionUpdate.Payload.Panic(
-          "Compile_Error Variable `undefined` is not defined.",
+          "Compile error: Variable `undefined` is not defined.",
           Seq(xId)
         )
       ),
@@ -333,7 +333,7 @@ class ExpressionErrorsTest
         mainBodyId,
         Api.MethodPointer("Test.Main", "Test.Main", "foo"),
         Api.ExpressionUpdate.Payload.Panic(
-          "Compile_Error Variable `x` is not defined.",
+          "Compile error: Variable `x` is not defined.",
           Seq(mainBodyId)
         )
       ),
@@ -487,7 +487,7 @@ class ExpressionErrorsTest
         contextId,
         xId,
         Api.ExpressionUpdate.Payload.Panic(
-          "Compile_Error Variable `undefined` is not defined.",
+          "Compile error: Variable `undefined` is not defined.",
           Seq(xId)
         )
       ),

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ExpressionErrorsTest.scala
@@ -877,7 +877,7 @@ class ExpressionErrorsTest
         contextId,
         xId,
         Api.ExpressionUpdate.Payload.Panic(
-          "Compile_Error Variable `foo` is not defined.",
+          "Compile error: Variable `foo` is not defined.",
           Seq(xId)
         )
       ),
@@ -885,7 +885,7 @@ class ExpressionErrorsTest
         contextId,
         yId,
         Api.ExpressionUpdate.Payload.Panic(
-          "Compile_Error Variable `foo` is not defined.",
+          "Compile error: Variable `foo` is not defined.",
           Seq(xId)
         )
       ),
@@ -893,7 +893,7 @@ class ExpressionErrorsTest
         contextId,
         mainResId,
         Api.ExpressionUpdate.Payload.Panic(
-          "Compile_Error Variable `foo` is not defined.",
+          "Compile error: Variable `foo` is not defined.",
           Seq(xId)
         )
       ),

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
@@ -101,5 +101,31 @@ class TextTest extends InterpreterTest {
 
       eval(code) shouldEqual "foobarbaz yay!"
     }
+
+    "support converting values to display texts" in {
+      val code =
+        """
+          |from Builtins import all
+          |
+          |main =
+          |    IO.println (Cons Nothing Nothing).to_display_text
+          |    IO.println (Syntax_Error "foo").to_display_text
+          |    IO.println (Type_Error Nothing Text "myvar").to_display_text
+          |    IO.println (Compile_Error "error :(").to_display_text
+          |    IO.println (Inexhaustive_Pattern_Match_Error 32).to_display_text
+          |    IO.println (Arithmetic_Error "cannot frobnicate quaternions").to_display_text
+          |    IO.println (Arity_Error 10 20).to_display_text
+          |""".stripMargin
+      eval(code)
+      consumeOut shouldEqual List(
+        "Cons",
+        "Syntax error: foo",
+        "Type error: expected myvar to be Nothing, but got Text.",
+        "Compile error: error :(",
+        "Inexhaustive pattern match: no branch matches 32 (Integer).",
+        "Arithmetic error: cannot frobnicate quaternions",
+        "Wrong number of arguments. Expected 10, but got 20."
+      )
+    }
   }
 }

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/BuiltinMethod.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/BuiltinMethod.java
@@ -16,5 +16,5 @@ public @interface BuiltinMethod {
   String name();
 
   /** @return a short description of this method. */
-  String description();
+  String description() default "";
 }

--- a/test/Tests/src/Semantic/Error_Spec.enso
+++ b/test/Tests/src/Semantic/Error_Spec.enso
@@ -19,6 +19,6 @@ spec =
             err_3.target.to_text.should_equal "(My_Type False)"
             err_3.method_name.should_equal "nope"
     Test.group "Dataflow Errors" <|
-        Test.specify "should be able to be displayed" <|
-            json = (Error.throw <| My_Type "aaa").to_display
+        Test.specify "should be able to be shown in the default visualization" <|
+            json = (Error.throw <| My_Type "aaa").to_default_visualization_data
             json . should_equal <| (Json.from_pairs [["foo", "aaa"], ["type", "My_Type"]]).to_text

--- a/test/Tests/src/Semantic/Error_Spec.enso
+++ b/test/Tests/src/Semantic/Error_Spec.enso
@@ -22,3 +22,5 @@ spec =
         Test.specify "should be able to be shown in the default visualization" <|
             json = (Error.throw <| My_Type "aaa").to_default_visualization_data
             json . should_equal <| (Json.from_pairs [["foo", "aaa"], ["type", "My_Type"]]).to_text
+        Test.specify "should implement to_display_text" <|
+            Error.throw Nothing . to_display_text . should_equal "Error: Nothing"


### PR DESCRIPTION
### Pull Request Description
Introduces `to_display_text` for any object for short & sweet representations and implements it meaningfully for the common errors in Enso.
Renames `to_display` to `to_default_visualization_data`.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
