### PR TITLE
Add Error.is_a / .is_an

### DIFF
--- a/distribution/std-lib/Base/src/Data/Any/Extensions.enso
+++ b/distribution/std-lib/Base/src/Data/Any/Extensions.enso
@@ -1,9 +1,16 @@
 from Base import all
 
-## Generic equality of arbitrary values.
+## Checks if `this` is equal to `that.`
+
+   Arguments:
+   - that: The object to compare `this` against.
 
    Two values are considered to be equal in Enso when they have the same
    structure, and each of the values of their fields are recursively equal.
+
+   > Example
+     Checking if 1 is equal to 2.
+         1 == 2
 Any.== : Any -> Boolean
 Any.== that = if Meta.is_same_object this that then True else
     this_meta = Meta.meta this
@@ -24,6 +31,17 @@ Any.== that = if Meta.is_same_object this that then True else
            Primitive objects should define their own equality.
            Therefore, there is no more cases to handle in this method.
         _ -> False
+
+## Checks if `this` is not equal to `that`.
+
+   Arguments:
+   - that: The object to compare `this` against.
+
+   > Example
+     Checking if 1 is not equal to 2.
+         1 != 2
+Any.!= : Any -> Boolean
+Any.!= that = (this == that).not
 
 ## Checks if `this` is greater than `that`.
 

--- a/distribution/std-lib/Base/src/Meta.enso
+++ b/distribution/std-lib/Base/src/Meta.enso
@@ -23,7 +23,7 @@ type Meta
     type Primitive value
     ## An unresolved symbol meta-representation.
     type Unresolved_Symbol value
-    ## An error meta-representation.
+    ## An error meta-representation, containing the payload of a dataflow error.
     type Error value
     ## A polyglot value meta-representation.
     type Polyglot value
@@ -49,10 +49,6 @@ Unresolved_Symbol.name = Builtins.Meta.get_unresolved_symbol_name this.value
 ## Returns the definition scope of an unresolved symbol.
 Unresolved_Symbol.scope : Any
 Unresolved_Symbol.scope = Builtins.Meta.get_unresolved_symbol_scope this.value
-
-## Returns the payload carried by an error value.
-Error.payload : Any
-Error.payload = this.value.catch e->e
 
 ## Returns a vector of field names defined by a constructor.
 Constructor.fields : Vector.Vector
@@ -126,7 +122,7 @@ meta value = if Builtins.Meta.is_atom value then Atom value else
     if Builtins.Meta.is_constructor value then Constructor value else
         if Builtins.Meta.is_polyglot value then Polyglot value else
             if Builtins.Meta.is_unresolved_symbol value then Unresolved_Symbol value else
-                if Builtins.Meta.is_error value then Error value else
+                if Builtins.Meta.is_error value then Error value.catch else
                     Primitive value
 
 ## Checks whether two objects are represented by the same underlying reference.

--- a/distribution/std-lib/Base/src/Meta.enso
+++ b/distribution/std-lib/Base/src/Meta.enso
@@ -51,8 +51,8 @@ Unresolved_Symbol.scope : Any
 Unresolved_Symbol.scope = Builtins.Meta.get_unresolved_symbol_scope this.value
 
 ## Returns the payload carried by an error value.
-Error.payload : Any
-Error.payload = this.value.catch e->e
+Base.Error.payload : Any
+Base.Error.payload = this.value.catch e->e
 
 ## Returns a vector of field names defined by a constructor.
 Constructor.fields : Vector.Vector
@@ -80,6 +80,14 @@ Any.is_a typ = here.is_a this typ
 ## Checks if `this` is an instance of `typ`.
 Any.is_an : Any -> Boolean
 Any.is_an typ = here.is_a this typ
+
+## Checks if `this` is an instance of `typ`.
+Base.Error.is_a : Any -> Boolean
+Base.Error.is_a typ = this.is_an typ
+
+## Checks if `this` is an instance of `typ`.
+Base.Error.is_an : Any -> Boolean
+Base.Error.is_an typ = typ == Base.Error
 
 ## Checks if `value` is an instance of `typ`.
 is_a : Any -> Any -> Boolean

--- a/distribution/std-lib/Base/src/Meta.enso
+++ b/distribution/std-lib/Base/src/Meta.enso
@@ -51,8 +51,8 @@ Unresolved_Symbol.scope : Any
 Unresolved_Symbol.scope = Builtins.Meta.get_unresolved_symbol_scope this.value
 
 ## Returns the payload carried by an error value.
-Base.Error.payload : Any
-Base.Error.payload = this.value.catch e->e
+Error.payload : Any
+Error.payload = this.value.catch e->e
 
 ## Returns a vector of field names defined by a constructor.
 Constructor.fields : Vector.Vector

--- a/distribution/std-lib/Base/src/Meta.enso
+++ b/distribution/std-lib/Base/src/Meta.enso
@@ -92,28 +92,29 @@ Base.Error.is_an typ = typ == Base.Error
 ## Checks if `value` is an instance of `typ`.
 is_a : Any -> Any -> Boolean
 is_a value typ = if typ == Any then True else
-    case value of
-        Array -> typ == Array
-        Boolean -> if typ == Boolean then True else value == typ
-        Text -> typ == Text
-        Number -> if typ == Number then True else case value of
-            Integer -> typ == Integer
-            Decimal -> typ == Decimal
-        Base.Polyglot -> typ == Base.Polyglot
-        _ ->
-            meta_val = here.meta value
-            case meta_val of
-                Atom _ -> if Builtins.meta.is_atom typ then typ == value else
-                    meta_val.constructor == typ
-                Constructor _ ->
-                    meta_typ = here.meta typ
-                    case meta_typ of
-                        Atom _ -> meta_val.constructor == meta_typ.constructor
-                        Constructor _ -> meta_val.constructor == meta_typ
-                        _ -> False
-                Error _ -> typ == Error
-                Unresolved_Symbol _ -> typ == Unresolved_Symbol
-                _ -> False
+    if Builtins.Meta.is_error value then typ == Base.Error else
+        case value of
+            Array -> typ == Array
+            Boolean -> if typ == Boolean then True else value == typ
+            Text -> typ == Text
+            Number -> if typ == Number then True else case value of
+                Integer -> typ == Integer
+                Decimal -> typ == Decimal
+            Base.Polyglot -> typ == Base.Polyglot
+            _ ->
+                meta_val = here.meta value
+                case meta_val of
+                    Atom _ -> if Builtins.meta.is_atom typ then typ == value else
+                        meta_val.constructor == typ
+                    Constructor _ ->
+                        meta_typ = here.meta typ
+                        case meta_typ of
+                            Atom _ -> meta_val.constructor == meta_typ.constructor
+                            Constructor _ -> meta_val.constructor == meta_typ
+                            _ -> False
+                    Error _ -> typ == Error
+                    Unresolved_Symbol _ -> typ == Unresolved_Symbol
+                    _ -> False
 
 ## Checks if `value` is an instance of `typ`.
 is_an : Any -> Any -> Boolean

--- a/test/Tests/src/Semantic/Any_Spec.enso
+++ b/test/Tests/src/Semantic/Any_Spec.enso
@@ -21,4 +21,7 @@ spec = Test.group "Callables" <|
         (+1 >> *2) 2 . should_equal 6
         (*2 >> My_Type) 2 . should_equal <| My_Type 4
         (*2 >> .floor) 2.75 . should_equal 5
+    Test.specify "should define generic inequality on values" <|
+        (1 != 2) . should_be_true
+        (1 != 1) . should_be_false
 

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -61,3 +61,7 @@ spec = Test.group "Meta-Value Manipulation" <|
         (My_Type 1 "foo" Nothing).is_a Test_Type . should_be_false
         (My_Type 1 "foo" Nothing).is_a Number . should_be_false
 
+        err = Error.throw "Error Value"
+        1.is_an Error . should_be_false
+        err.is_an Error . should_be_true
+        err.is_a Text . should_be_false

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -26,6 +26,11 @@ spec = Test.group "Meta-Value Manipulation" <|
     Test.specify "should correctly return representations of different classes of objects" <|
         Meta.meta 1 . should_equal (Meta.Primitive 1)
         Meta.meta "foo" . should_equal (Meta.Primitive "foo")
+    Test.specify "should allow manipulation of error values" <|
+        err = Error.throw "My Error"
+        meta_err = Meta.meta err
+        meta_err.is_a Meta.Error . should_be_true
+        meta_err.value . should_equal "My Error"
     Test.specify "should allow checking if a value is of a certain type" <|
         1.is_an Any . should_be_true
         1.2.is_an Any . should_be_true

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -65,3 +65,5 @@ spec = Test.group "Meta-Value Manipulation" <|
         1.is_an Error . should_be_false
         err.is_an Error . should_be_true
         err.is_a Text . should_be_false
+        Meta.is_an err Error . should_be_true
+        Meta.is_a err Text . should_be_false


### PR DESCRIPTION
### Pull Request Description
Ensures that the `is_a` and `is_an` methods work on `Error` values.

### Important Notes
N/A

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
