### PR TITLE
Analyze compiled modules

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -72,14 +72,8 @@ class EnsureCompiledJob(protected val files: Iterable[File])
     val modules = files.flatMap { file =>
       ctx.executionService.getContext.getModuleForFile(file).toScala
     }
-    val moduleCompilationStatus = modules.flatMap { module =>
-      val importedModules =
-        ctx.executionService.getContext.getCompiler
-          .runImportsResolution(module)
-          .filter(_.getName != module.getName)
-      ensureCompiledModule(module) +: ensureCompiledImports(importedModules)
-    }
-    val scopeCompilationStatus = ensureCompiledScope()
+    val moduleCompilationStatus = modules.map(ensureCompiledModule)
+    val scopeCompilationStatus  = ensureCompiledScope()
     (moduleCompilationStatus ++ scopeCompilationStatus).maxOption
       .getOrElse(CompilationStatus.Success)
   }
@@ -96,30 +90,14 @@ class EnsureCompiledJob(protected val files: Iterable[File])
     compile(module)
     val changeset = applyEdits(new File(module.getPath))
     compile(module)
-      .map {
-        case Some(module) =>
-          val cacheInvalidationCommands =
-            buildCacheInvalidationCommands(changeset, module.getLiteralSource)
-          runInvalidationCommands(cacheInvalidationCommands)
-          analyzeModule(module, changeset)
-          runCompilationDiagnostics(module)
-        case None =>
-          CompilationStatus.Success
+      .map { module =>
+        val cacheInvalidationCommands =
+          buildCacheInvalidationCommands(changeset, module.getLiteralSource)
+        runInvalidationCommands(cacheInvalidationCommands)
+        analyzeModule(module, changeset)
+        runCompilationDiagnostics(module)
       }
       .getOrElse(CompilationStatus.Failure)
-  }
-
-  /** Compile the imported modules and send the suggestion updates.
-    *
-    * @param importedModules the imported modules to analyze.
-    * @param ctx the runtime context
-    */
-
-  private def ensureCompiledImports(importedModules: Seq[Module])(implicit
-    ctx: RuntimeContext
-  ): Seq[CompilationStatus] = {
-    importedModules.foreach(analyzeImport)
-    importedModules.map(runCompilationDiagnostics)
   }
 
   /** Compile all modules in the scope and send the extracted suggestions.
@@ -132,7 +110,7 @@ class EnsureCompiledJob(protected val files: Iterable[File])
     val modulesInScope =
       ctx.executionService.getContext.getTopScope.getModules.asScala
     ctx.executionService.getLogger
-      .finest(s"Modules in scope: ${modulesInScope.map(_.getName)}")
+      .log(Level.FINEST, s"Modules in scope: ${modulesInScope.map(_.getName)}")
     modulesInScope
       .map { module =>
         compile(module) match {
@@ -146,39 +124,11 @@ class EnsureCompiledJob(protected val files: Iterable[File])
               )
             )
             CompilationStatus.Failure
-          case Right(Some(module)) =>
+          case Right(module) =>
             analyzeModuleInScope(module)
             runCompilationDiagnostics(module)
-          case Right(None) =>
-            CompilationStatus.Success
         }
       }
-  }
-
-  private def analyzeImport(
-    module: Module
-  )(implicit ctx: RuntimeContext): Unit = {
-    if (
-      !module.isIndexed &&
-      module.getLiteralSource != null &&
-      module.getPath != null
-    ) {
-      ctx.executionService.getLogger
-        .finest(s"Analyzing imported ${module.getName}")
-      val moduleName = module.getName.toString
-      val addedSuggestions = SuggestionBuilder(module.getLiteralSource)
-        .build(module.getName, module.getIr)
-        .filter(isSuggestionGlobal)
-      val version = ctx.versioning.evalVersion(module.getLiteralSource.toString)
-      val notification = Api.SuggestionsDatabaseModuleUpdateNotification(
-        file    = new File(module.getPath),
-        version = version,
-        actions = Vector(Api.SuggestionsDatabaseAction.Clean(moduleName)),
-        updates = SuggestionDiff.compute(Tree.empty, addedSuggestions)
-      )
-      sendModuleUpdate(notification)
-      module.setIndexed(true)
-    }
   }
 
   private def analyzeModuleInScope(module: Module)(implicit
@@ -199,7 +149,7 @@ class EnsureCompiledJob(protected val files: Iterable[File])
       module.getPath != null
     ) {
       ctx.executionService.getLogger
-        .finest(s"Analyzing module in scope ${module.getName}")
+        .log(Level.FINEST, s"Analyzing module in scope ${module.getName}")
       val moduleName = module.getName
       val newSuggestions = SuggestionBuilder(module.getLiteralSource)
         .build(moduleName, module.getIr)
@@ -225,7 +175,7 @@ class EnsureCompiledJob(protected val files: Iterable[File])
     val version    = ctx.versioning.evalVersion(module.getLiteralSource.toString)
     if (module.isIndexed) {
       ctx.executionService.getLogger
-        .finest(s"Analyzing indexed module $moduleName")
+        .log(Level.FINEST, s"Analyzing indexed module $moduleName")
       val prevSuggestions = SuggestionBuilder(changeset.source)
         .build(moduleName, changeset.ir)
       val newSuggestions =
@@ -242,7 +192,7 @@ class EnsureCompiledJob(protected val files: Iterable[File])
       sendModuleUpdate(notification)
     } else {
       ctx.executionService.getLogger
-        .finest(s"Analyzing not-indexed module ${module.getName}")
+        .log(Level.FINEST, s"Analyzing not-indexed module ${module.getName}")
       val newSuggestions =
         SuggestionBuilder(module.getLiteralSource)
           .build(moduleName, module.getIr)
@@ -321,20 +271,17 @@ class EnsureCompiledJob(protected val files: Iterable[File])
     */
   private def compile(
     module: Module
-  )(implicit ctx: RuntimeContext): Either[Throwable, Option[Module]] = {
+  )(implicit ctx: RuntimeContext): Either[Throwable, Module] = {
     val prevStage = module.getCompilationStage
     val compilationResult = Either.catchNonFatal {
       module.compileScope(ctx.executionService.getContext).getModule
     }
-    compilationResult.map { compiledModule =>
-      if (prevStage != compiledModule.getCompilationStage) {
-        ctx.executionService.getLogger.log(
-          Level.FINEST,
-          s"Compiled ${module.getName} $prevStage->${module.getCompilationStage}"
-        )
-        Some(compiledModule)
-      } else None
-    }
+    ctx.executionService.getLogger
+      .log(
+        Level.FINEST,
+        s"Compiled ${module.getName} $prevStage->${module.getCompilationStage}"
+      )
+    compilationResult
   }
 
   /** Apply pending edits to the file.

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -405,7 +405,7 @@ class RuntimeServerTest
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
     context.receive(3) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PopContextResponse(contextId)),
-      context.Main.Update.mainY(contextId, fromCache    = true),
+      context.Main.Update.mainY(contextId, fromCache = true),
       context.executionComplete(contextId)
     )
 
@@ -1358,7 +1358,7 @@ class RuntimeServerTest
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
     context.receive(3) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PopContextResponse(contextId)),
-      context.Main.Update.mainY(contextId, fromCache    = true),
+      context.Main.Update.mainY(contextId, fromCache = true),
       context.executionComplete(contextId)
     )
 
@@ -2507,7 +2507,7 @@ class RuntimeServerTest
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
     context.receive(3) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PopContextResponse(contextId)),
-      context.Main.Update.mainY(contextId, fromCache    = true),
+      context.Main.Update.mainY(contextId, fromCache = true),
       context.executionComplete(contextId)
     )
 
@@ -3590,7 +3590,9 @@ class RuntimeServerTest
       ),
       context.executionComplete(contextId)
     )
-    context.consumeOut shouldEqual List("(Error: (Syntax_Error 'Unrecognized token.'))")
+    context.consumeOut shouldEqual List(
+      "(Error: (Syntax_Error 'Unrecognized token.'))"
+    )
   }
 
   it should "return compiler error syntax error" in {


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

When requesting to compile a module the compiler builds all its dependencies as well.
PR changes the logic of `EnsureCompiledJob` to analyze all compiled modules, disregarding its previous compilation stage.

Changelog:
- fix: analyze all compiled modules
- refactor: remove redundant `analyzaImports` logic

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
