### PR TITLE
Fix Locations in Desugared Lambdas

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -4249,7 +4249,7 @@ object IR {
 
           override def toString: String =
             s"""
-            |IR.Application.Operator.Section.Centre(
+            |IR.Application.Operator.Section.Sides(
             |operator =  $operator,
             |location = $location,
             |passData = ${this.showPassData},

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
@@ -138,15 +138,15 @@ case object LambdaShorthandToLambda extends IRPass {
         IR.Function.Lambda(
           List(
             IR.DefinitionArgument.Specified(
-              IR.Name.Literal(
+              name = IR.Name.Literal(
                 newName.name,
                 isReferent = false,
                 isMethod   = false,
                 None
               ),
-              None,
-              suspended = false,
-              None
+              defaultValue = None,
+              suspended    = false,
+              location     = None
             )
           ),
           newName,
@@ -218,7 +218,7 @@ case object LambdaShorthandToLambda extends IRPass {
           )
 
         // If the function is shorthand, do the same
-        if (functionIsShorthand) {
+        val resultExpr = if (functionIsShorthand) {
           IR.Function.Lambda(
             List(
               IR.DefinitionArgument.Specified(
@@ -238,6 +238,11 @@ case object LambdaShorthandToLambda extends IRPass {
             None
           )
         } else appResult
+
+        resultExpr match {
+          case lam: IR.Function.Lambda => lam.copy(location = p.location)
+          case result                  => result
+        }
       case f @ IR.Application.Force(tgt, _, _, _) =>
         f.copy(target = desugarExpression(tgt, freshNameSupply))
       case vector @ IR.Application.Literal.Sequence(items, _, _, _) =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/SectionsToBinOp.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/SectionsToBinOp.scala
@@ -115,10 +115,10 @@ case object SectionsToBinOp extends IRPass {
             None
           )
           val opCall = IR.Application.Prefix(
-            op,
-            List(leftCallArg, rightCallArg),
+            function             = op,
+            arguments            = List(leftCallArg, rightCallArg),
             hasDefaultsSuspended = false,
-            loc,
+            location             = None,
             passData,
             diagnostics
           )
@@ -132,15 +132,15 @@ case object SectionsToBinOp extends IRPass {
           IR.Function.Lambda(
             List(leftDefArg),
             rightLam,
-            None
+            loc
           )
 
         } else {
           val opCall = IR.Application.Prefix(
-            op,
-            List(arg, rightCallArg),
+            function             = op,
+            arguments            = List(arg, rightCallArg),
             hasDefaultsSuspended = false,
-            loc,
+            location             = None,
             passData,
             diagnostics
           )
@@ -148,7 +148,7 @@ case object SectionsToBinOp extends IRPass {
           IR.Function.Lambda(
             List(rightDefArg),
             opCall,
-            None
+            loc
           )
         }
       case Section.Sides(op, loc, passData, diagnostics) =>
@@ -173,10 +173,10 @@ case object SectionsToBinOp extends IRPass {
         )
 
         val opCall = IR.Application.Prefix(
-          op,
-          List(leftCallArg, rightCallArg),
+          function             = op,
+          arguments            = List(leftCallArg, rightCallArg),
           hasDefaultsSuspended = false,
-          loc,
+          location             = None,
           passData,
           diagnostics
         )
@@ -190,7 +190,7 @@ case object SectionsToBinOp extends IRPass {
         IR.Function.Lambda(
           List(leftDefArg),
           rightLambda,
-          None
+          loc
         )
 
       /* Note [Blanks in Sections]
@@ -237,10 +237,10 @@ case object SectionsToBinOp extends IRPass {
           )
 
           val opCall = IR.Application.Prefix(
-            op,
-            List(leftCallArg, rightCallArg),
+            function             = op,
+            arguments            = List(leftCallArg, rightCallArg),
             hasDefaultsSuspended = false,
-            loc,
+            location             = None,
             passData,
             diagnostics
           )
@@ -254,14 +254,14 @@ case object SectionsToBinOp extends IRPass {
           IR.Function.Lambda(
             List(rightDefArg),
             leftLam,
-            None
+            loc
           )
         } else {
           val opCall = IR.Application.Prefix(
-            op,
-            List(leftCallArg, arg),
+            function             = op,
+            arguments            = List(leftCallArg, arg),
             hasDefaultsSuspended = false,
-            loc,
+            location             = None,
             passData,
             diagnostics
           )
@@ -269,7 +269,7 @@ case object SectionsToBinOp extends IRPass {
           IR.Function.Lambda(
             List(leftDefArg),
             opCall,
-            None
+            loc
           )
         }
     }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
@@ -55,6 +55,7 @@ class AstToIrTest extends CompilerTest with Inside {
           |""".stripMargin.toIrExpression.get
 
       ir shouldBe an[IR.Application.Operator.Section.Left]
+      ir.location shouldBe defined
     }
 
     "work properly for sides sections" in {
@@ -64,6 +65,8 @@ class AstToIrTest extends CompilerTest with Inside {
           |""".stripMargin.toIrExpression.get
 
       ir shouldBe an[IR.Application.Operator.Section.Sides]
+      // TODO[DB] Section.Sides location is not parsed
+      //ir.location shouldBe defined
     }
 
     "work properly for right sections" in {
@@ -73,6 +76,7 @@ class AstToIrTest extends CompilerTest with Inside {
           |""".stripMargin.toIrExpression.get
 
       ir shouldBe an[IR.Application.Operator.Section.Right]
+      ir.location shouldBe defined
     }
 
     "disallow sections with named arguments" in {

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaTest.scala
@@ -58,6 +58,7 @@ class LambdaShorthandToLambdaTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
       val irFn = ir.asInstanceOf[IR.Function.Lambda]
       val irFnArgName =
         irFn.arguments.head.asInstanceOf[IR.DefinitionArgument.Specified].name
@@ -98,6 +99,7 @@ class LambdaShorthandToLambdaTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
       val irFn = ir.asInstanceOf[IR.Function.Lambda]
       val irFnArgName =
         irFn.arguments.head.asInstanceOf[IR.DefinitionArgument.Specified].name
@@ -136,6 +138,7 @@ class LambdaShorthandToLambdaTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
       val irFn = ir.asInstanceOf[IR.Function.Lambda]
       val irFnArgName =
         irFn.arguments.head.asInstanceOf[IR.DefinitionArgument.Specified].name
@@ -157,6 +160,7 @@ class LambdaShorthandToLambdaTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
       val irFn = ir.asInstanceOf[IR.Function.Lambda]
       val irFnArgName =
         irFn.arguments.head.asInstanceOf[IR.DefinitionArgument.Specified].name
@@ -181,6 +185,7 @@ class LambdaShorthandToLambdaTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
 
       val irLam = ir.asInstanceOf[IR.Function.Lambda]
       irLam.arguments.length shouldEqual 1
@@ -205,6 +210,7 @@ class LambdaShorthandToLambdaTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
       val irFn = ir.asInstanceOf[IR.Function.Lambda]
 
       val argName =
@@ -225,6 +231,7 @@ class LambdaShorthandToLambdaTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
       val underscoreFn      = ir.asInstanceOf[IR.Function.Lambda]
       val underscoreArgName = underscoreFn.arguments.head.name
 
@@ -253,6 +260,7 @@ class LambdaShorthandToLambdaTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
       val irFn     = ir.asInstanceOf[IR.Function.Lambda]
       val arg1Name = irFn.arguments.head.name
 
@@ -278,6 +286,7 @@ class LambdaShorthandToLambdaTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
       val irFn         = ir.asInstanceOf[IR.Function.Lambda]
       val rightArgName = irFn.arguments.head.name
 

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/SectionsToBinOpTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/SectionsToBinOpTest.scala
@@ -57,6 +57,7 @@ class SectionsToBinOpTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
 
       val irLam = ir.asInstanceOf[IR.Function.Lambda]
       irLam.arguments.length shouldEqual 1
@@ -86,6 +87,8 @@ class SectionsToBinOpTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      // TODO[DB] Section.Sides location is not parsed
+      //ir.location shouldBe defined
 
       val leftLam = ir.asInstanceOf[IR.Function.Lambda]
       leftLam.arguments.length shouldEqual 1
@@ -127,6 +130,7 @@ class SectionsToBinOpTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
 
       val irLam = ir.asInstanceOf[IR.Function.Lambda]
       irLam.arguments.length shouldEqual 1
@@ -175,6 +179,7 @@ class SectionsToBinOpTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.desugar
 
       ir shouldBe an[IR.Function.Lambda]
+      ir.location shouldBe defined
       val irFn = ir.asInstanceOf[IR.Function.Lambda]
 
       val rightArgName =


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1511

Fixes points 1-5 in #1511. The issue happened because the runtime did not send the updates for lambda expressions. 
This was because the locations in lambdas were missing and therefore the lambdas were invisible to the runtime instrumentation.

This PR only fixes the lambda expressions, but there is a similar issue with the operator sections #1521


Changelog
- fix: reattach original locations during the lambda desugaring

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
