### PR TITLE
Make panic messages short

### DIFF
--- a/engine/polyglot-api/src/test/scala/org/enso/polyglot/ModuleManagementTest.scala
+++ b/engine/polyglot-api/src/test/scala/org/enso/polyglot/ModuleManagementTest.scala
@@ -176,6 +176,6 @@ class ModuleManagementTest extends AnyFlatSpec with Matchers {
     )
     val exception =
       the[PolyglotException] thrownBy mod2.getAssociatedConstructor
-    exception.getMessage shouldEqual "org.enso.interpreter.runtime.error.PanicException: Module_Does_Not_Exist Test.Main"
+    exception.getMessage shouldEqual "Module_Does_Not_Exist"
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -1,14 +1,16 @@
 package org.enso.interpreter.runtime.error;
 
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.exception.AbstractTruffleException;
-import com.oracle.truffle.api.interop.ExceptionType;
-import com.oracle.truffle.api.interop.InteropLibrary;
-import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.interop.*;
+import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
 import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNodeGen;
+import org.enso.interpreter.runtime.data.text.Text;
 
 /** An exception type for user thrown panic exceptions. */
 @ExportLibrary(value = InteropLibrary.class, delegateTo = "payload")
@@ -37,7 +39,12 @@ public class PanicException extends AbstractTruffleException {
 
   @Override
   public String getMessage() {
-    return "Panic exception: " + TypeToDisplayTextNodeGen.getUncached().execute(payload);
+    InteropLibrary library = InteropLibrary.getUncached();
+    try {
+      return library.asString(library.getExceptionMessage(this));
+    } catch (UnsupportedMessageException e) {
+      return TypeToDisplayTextNodeGen.getUncached().execute(payload);
+    }
   }
 
   @Override
@@ -53,6 +60,26 @@ public class PanicException extends AbstractTruffleException {
   @ExportMessage
   RuntimeException throwException() {
     throw this;
+  }
+
+  @ExportMessage
+  boolean hasExceptionMessage() {
+    return true;
+  }
+
+  @ExportMessage
+  Object getExceptionMessage(
+      @CachedLibrary(limit = "5") InteropLibrary payloads,
+      @CachedLibrary(limit = "3") InteropLibrary strings,
+      @Cached TypeToDisplayTextNode typeToDisplayTextNode) {
+    try {
+      return Text.create(strings.asString(payloads.invokeMember(payload, "to_display_text")));
+    } catch (UnsupportedTypeException
+        | UnsupportedMessageException
+        | ArityException
+        | UnknownIdentifierException e) {
+      return Text.create(typeToDisplayTextNode.execute(payload));
+    }
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNodeGen;
 
 /** An exception type for user thrown panic exceptions. */
 @ExportLibrary(value = InteropLibrary.class, delegateTo = "payload")
@@ -36,7 +37,12 @@ public class PanicException extends AbstractTruffleException {
 
   @Override
   public String getMessage() {
-    return payload.toString();
+    return "Panic exception: " + TypeToDisplayTextNodeGen.getUncached().execute(payload);
+  }
+
+  @Override
+  public String toString() {
+    return getMessage();
   }
 
   @ExportMessage

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
@@ -239,7 +239,7 @@ class ReplTest extends InterpreterTest with BeforeAndAfter with EitherValues {
       }
       eval(code)
       val errorMsg =
-        "Panic exception: Compile_Error"
+        "Compile error: Variable `undefined` is not defined."
       evalResult.left.value.getMessage shouldEqual errorMsg
     }
 

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
@@ -239,7 +239,7 @@ class ReplTest extends InterpreterTest with BeforeAndAfter with EitherValues {
       }
       eval(code)
       val errorMsg =
-        "Compile_Error Variable `undefined` is not defined."
+        "Panic exception: Compile_Error"
       evalResult.left.value.getMessage shouldEqual errorMsg
     }
 

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -3169,7 +3169,7 @@ class RuntimeServerTest
           contextId,
           Seq(
             Api.ExecutionResult.Diagnostic.error(
-              "Panic exception: Not_Invokable_Error",
+              "Type error: expected a function, but got 42 (Integer).",
               Some(mainFile),
               Some(model.Range(model.Position(0, 7), model.Position(0, 24))),
               None,
@@ -3237,7 +3237,7 @@ class RuntimeServerTest
           contextId,
           Seq(
             Api.ExecutionResult.Diagnostic.error(
-              "Panic exception: No_Such_Method_Error",
+              "Method `+` of x (Unresolved_Symbol) could not be found.",
               Some(mainFile),
               Some(model.Range(model.Position(2, 14), model.Position(2, 23))),
               None,
@@ -3313,7 +3313,7 @@ class RuntimeServerTest
           contextId,
           Seq(
             Api.ExecutionResult.Diagnostic.error(
-              "Panic exception: Type_Error",
+              "Type error: expected `str` to be Text, but got 2 (Integer).",
               None,
               None,
               None,
@@ -3391,7 +3391,7 @@ class RuntimeServerTest
           contextId,
           Seq(
             Api.ExecutionResult.Diagnostic.error(
-              "Panic exception: No_Such_Method_Error",
+              "Method `pi` of Number could not be found.",
               Some(mainFile),
               Some(model.Range(model.Position(2, 7), model.Position(2, 16))),
               None,
@@ -3470,7 +3470,7 @@ class RuntimeServerTest
           contextId,
           Seq(
             Api.ExecutionResult.Diagnostic.error(
-              "Panic exception: Type_Error",
+              "Type error: expected `that` to be Number, but got quux (Unresolved_Symbol).",
               None,
               None,
               None,

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -3169,7 +3169,7 @@ class RuntimeServerTest
           contextId,
           Seq(
             Api.ExecutionResult.Diagnostic.error(
-              "Not_Invokable_Error 42",
+              "Panic exception: Not_Invokable_Error",
               Some(mainFile),
               Some(model.Range(model.Position(0, 7), model.Position(0, 24))),
               None,
@@ -3237,7 +3237,7 @@ class RuntimeServerTest
           contextId,
           Seq(
             Api.ExecutionResult.Diagnostic.error(
-              "No_Such_Method_Error UnresolvedSymbol<x> UnresolvedSymbol<+>",
+              "Panic exception: No_Such_Method_Error",
               Some(mainFile),
               Some(model.Range(model.Position(2, 14), model.Position(2, 23))),
               None,
@@ -3313,7 +3313,7 @@ class RuntimeServerTest
           contextId,
           Seq(
             Api.ExecutionResult.Diagnostic.error(
-              "Type_Error Text 2 str",
+              "Panic exception: Type_Error",
               None,
               None,
               None,
@@ -3391,7 +3391,7 @@ class RuntimeServerTest
           contextId,
           Seq(
             Api.ExecutionResult.Diagnostic.error(
-              "No_Such_Method_Error Number UnresolvedSymbol<pi>",
+              "Panic exception: No_Such_Method_Error",
               Some(mainFile),
               Some(model.Range(model.Position(2, 7), model.Position(2, 16))),
               None,
@@ -3470,7 +3470,7 @@ class RuntimeServerTest
           contextId,
           Seq(
             Api.ExecutionResult.Diagnostic.error(
-              "Type_Error Number UnresolvedSymbol<quux> that",
+              "Panic exception: Type_Error",
               None,
               None,
               None,

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CaseTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CaseTest.scala
@@ -24,8 +24,7 @@ class CaseTest extends InterpreterTest {
           |        Nil2 -> 0
           |""".stripMargin
 
-      val msg =
-        "Compile_Error Cons2 is not visible in this scope, Nil2 is not visible in this scope"
+      val msg = "Panic exception: Compile_Error"
       the[InterpreterException] thrownBy eval(code) should have message msg
     }
 
@@ -40,7 +39,7 @@ class CaseTest extends InterpreterTest {
           |        Cons a -> a
           |""".stripMargin
 
-      val msg = "Compile_Error Cannot match on Cons using 1 field (expecting 2)"
+      val msg = "Panic exception: Compile_Error"
       the[InterpreterException] thrownBy eval(code) should have message msg
     }
   }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CaseTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CaseTest.scala
@@ -24,7 +24,8 @@ class CaseTest extends InterpreterTest {
           |        Nil2 -> 0
           |""".stripMargin
 
-      val msg = "Panic exception: Compile_Error"
+      val msg =
+        "Compile error: Cons2 is not visible in this scope, Nil2 is not visible in this scope"
       the[InterpreterException] thrownBy eval(code) should have message msg
     }
 
@@ -39,7 +40,8 @@ class CaseTest extends InterpreterTest {
           |        Cons a -> a
           |""".stripMargin
 
-      val msg = "Panic exception: Compile_Error"
+      val msg =
+        "Compile error: Cannot match on Cons using 1 field (expecting 2)"
       the[InterpreterException] thrownBy eval(code) should have message msg
     }
   }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ConstructorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ConstructorsTest.scala
@@ -80,7 +80,7 @@ class ConstructorsTest extends InterpreterTest {
           |        Cons h t -> 0
       """.stripMargin
       the[InterpreterException] thrownBy eval(testCode)
-        .call() should have message "Inexhaustive_Pattern_Match_Error Nil"
+        .call() should have message "Panic exception: Inexhaustive_Pattern_Match_Error"
     }
 
     "be usable in code, with arbitrary definition order" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ConstructorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ConstructorsTest.scala
@@ -80,7 +80,7 @@ class ConstructorsTest extends InterpreterTest {
           |        Cons h t -> 0
       """.stripMargin
       the[InterpreterException] thrownBy eval(testCode)
-        .call() should have message "Panic exception: Inexhaustive_Pattern_Match_Error"
+        .call() should have message "Inexhaustive pattern match: no branch matches Nil."
     }
 
     "be usable in code, with arbitrary definition order" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
@@ -14,7 +14,7 @@ class ImportsTest extends PackageTest {
   "Overloaded methods" should "not be visible when not imported" in {
     the[InterpreterException] thrownBy evalTestProject(
       "TestNonImportedOverloads"
-    ) should have message "No_Such_Method_Error (X 1) UnresolvedSymbol<method>"
+    ) should have message "Panic exception: No_Such_Method_Error"
   }
 
   "Symbols from imported modules" should "not be visible when imported qualified" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
@@ -14,7 +14,7 @@ class ImportsTest extends PackageTest {
   "Overloaded methods" should "not be visible when not imported" in {
     the[InterpreterException] thrownBy evalTestProject(
       "TestNonImportedOverloads"
-    ) should have message "Panic exception: No_Such_Method_Error"
+    ) should have message "Method `method` of X could not be found."
   }
 
   "Symbols from imported modules" should "not be visible when imported qualified" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
@@ -120,7 +120,7 @@ class MethodsTest extends InterpreterTest {
           |""".stripMargin
       the[InterpreterException] thrownBy eval(
         code
-      ) should have message "No_Such_Method_Error 7 UnresolvedSymbol<foo>"
+      ) should have message "Panic exception: No_Such_Method_Error"
     }
 
     "be callable for any type when defined on Any" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
@@ -120,7 +120,7 @@ class MethodsTest extends InterpreterTest {
           |""".stripMargin
       the[InterpreterException] thrownBy eval(
         code
-      ) should have message "Panic exception: No_Such_Method_Error"
+      ) should have message "Method `foo` of 7 (Integer) could not be found."
     }
 
     "be callable for any type when defined on Any" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/PatternMatchTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/PatternMatchTest.scala
@@ -129,7 +129,7 @@ class PatternMatchTest extends InterpreterTest {
           |    f MyAtom
           |""".stripMargin
 
-      val msg = "Inexhaustive_Pattern_Match_Error MyAtom"
+      val msg = "Panic exception: Inexhaustive_Pattern_Match_Error"
       the[InterpreterException] thrownBy eval(code) should have message msg
     }
 

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/PatternMatchTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/PatternMatchTest.scala
@@ -129,7 +129,7 @@ class PatternMatchTest extends InterpreterTest {
           |    f MyAtom
           |""".stripMargin
 
-      val msg = "Panic exception: Inexhaustive_Pattern_Match_Error"
+      val msg = "Inexhaustive pattern match: no branch matches MyAtom."
       the[InterpreterException] thrownBy eval(code) should have message msg
     }
 

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/SystemProcessTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/SystemProcessTest.scala
@@ -36,7 +36,7 @@ class SystemProcessTest extends InterpreterTest with OsSpec {
           |""".stripMargin
 
       val error = the[InterpreterException] thrownBy eval(code)
-      error.getMessage should include("nonexistentcommandxyz")
+      error.getMessage should include("Panic exception: a polyglot object")
       consumeOut shouldEqual List()
       consumeErr shouldEqual List()
     }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/SystemProcessTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/SystemProcessTest.scala
@@ -36,7 +36,7 @@ class SystemProcessTest extends InterpreterTest with OsSpec {
           |""".stripMargin
 
       val error = the[InterpreterException] thrownBy eval(code)
-      error.getMessage should include("Panic exception: a polyglot object")
+      error.getMessage should include("a polyglot object")
       consumeOut shouldEqual List()
       consumeErr shouldEqual List()
     }


### PR DESCRIPTION
### Pull Request Description
Makes the java-facing string reps of panic exceptions short. These should not be visible in enso anyway, so this is 
purely for logging / java-programmatic processing. 

Closes #1527

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
