### PR TITLE
Fix Invalidation of Dynamic Dependencies

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/context/ChangesetBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/ChangesetBuilder.scala
@@ -71,10 +71,10 @@ final class ChangesetBuilder[A: TextEditor: IndexedSource](
         val transitive = metadata.get(elem).getOrElse(Set())
         val dynamic = transitive
           .flatMap {
-            case DataflowAnalysis.DependencyInfo.Type.Static(int, ext) =>
+            case DataflowAnalysis.DependencyInfo.Type.Static(int, _) =>
               ChangesetBuilder
                 .getExpressionName(ir, int)
-                .map(DataflowAnalysis.DependencyInfo.Type.Dynamic(_, ext))
+                .map(DataflowAnalysis.DependencyInfo.Type.Dynamic(_, None))
             case dyn: DataflowAnalysis.DependencyInfo.Type.Dynamic =>
               Some(dyn)
             case _ =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
@@ -6,10 +6,7 @@ import org.enso.compiler.core.IR.{ExternalId, Pattern}
 import org.enso.compiler.core.ir.MetadataStorage._
 import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.IRPass
-import org.enso.compiler.pass.analyse.DataflowAnalysis.DependencyInfo.Type.{
-  asDynamic,
-  asStatic
-}
+import org.enso.compiler.pass.analyse.DataflowAnalysis.DependencyInfo.Type.asStatic
 
 import scala.collection.mutable
 
@@ -106,9 +103,7 @@ case object DataflowAnalysis extends IRPass {
         info.updateAt(asStatic(body), Set(asStatic(method)))
 
         method
-          .copy(
-            body = analyseExpression(body, info)
-          )
+          .copy(body = analyseExpression(body, info))
           .updateMetadata(this -->> info)
       case _: IR.Module.Scope.Definition.Method.Binding =>
         throw new CompilerError(
@@ -415,11 +410,11 @@ case object DataflowAnalysis extends IRPass {
               case Some(AliasAnalysis.Graph.Occurrence.Def(_, _, id, ext, _)) =>
                 DependencyInfo.Type.Static(id, ext)
               case _ =>
-                asDynamic(name)
+                DependencyInfo.Type.Dynamic(name.name, None)
             }
 
           case None =>
-            asDynamic(name)
+            DependencyInfo.Type.Dynamic(name.name, None)
         }
 
         info.updateAt(key, Set(asStatic(name)))

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -1163,6 +1163,10 @@ class RuntimeServerTest
     val moduleName = "Test.Main"
     val metadata   = new Metadata
 
+    @scala.annotation.unused
+    val fooDefinition = metadata.addItem(26, 22)
+    @scala.annotation.unused
+    val fooName = metadata.addItem(26, 3)
     val fooX    = metadata.addItem(40, 1)
     val fooRes  = metadata.addItem(46, 1)
     val mainFoo = metadata.addItem(64, 8)

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -1163,10 +1163,10 @@ class RuntimeServerTest
     val moduleName = "Test.Main"
     val metadata   = new Metadata
 
-    @scala.annotation.unused
-    val fooDefinition = metadata.addItem(26, 22)
-    @scala.annotation.unused
-    val fooName = metadata.addItem(26, 3)
+    // foo definition
+    metadata.addItem(26, 22)
+    // foo name
+    metadata.addItem(26, 3)
     val fooX    = metadata.addItem(40, 1)
     val fooRes  = metadata.addItem(46, 1)
     val mainFoo = metadata.addItem(64, 8)


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1510 

IDE attaches external id to the method definition, and ChangesetBuilder was using this id to search for dynamic dependencies. It occurred that dependency analysis doesn't work this way. The fix is to revert the change from #1495 and do not index dynamic symbols with their external ids, and then query dependencies using only the symbol.

Changelog:
- revert: change from #1495, where dynamic dependencies come with external ids.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
