### PR TITLE
Initialize Language Server on Client Connection

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -212,7 +212,7 @@ branches:
         strict: true
         contexts:
           - "Build and Test (macOS-latest)"
-          - "Build and Test (ubuntu-latest)"
+          - "Build and Test (ubuntu-18.04)"
           - "Build and Test (windows-latest)"
           - "Docs Check"
           - "Rust Check"

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -238,7 +238,7 @@ branches:
         strict: true
         contexts:
           - "Build and Test (macOS-latest)"
-          - "Build and Test (ubuntu-latest)"
+          - "Build and Test (ubuntu-18.04)"
           - "Build and Test (windows-latest)"
           - "Docs Check"
           - "Build Engine"

--- a/.github/workflows/legal-review.yml
+++ b/.github/workflows/legal-review.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   verify-review:
     name: Verify Notice Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/release-update-broken.yml
+++ b/.github/workflows/release-update-broken.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-s3:
     name: Update S3
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        os: [macOS-latest, ubuntu-18.04, windows-latest]
       fail-fast: true
     steps:
       - name: Checkout
@@ -230,7 +230,7 @@ jobs:
 
   create-release:
     name: Prepare Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: build
     steps:
       - name: Checkout code

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-18.03, windows-latest]
+        os: [macOS-latest, ubuntu-18.04, windows-latest]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        os: [macOS-latest, ubuntu-18.03, windows-latest]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -161,6 +161,7 @@ transport formats, please look [here](./protocol-architecture).
   - [`CapabilityNotAcquired`](#capabilitynotacquired)
   - [`SessionNotInitialisedError`](#sessionnotinitialisederror)
   - [`SessionAlreadyInitialisedError`](#sessionalreadyinitialisederror)
+  - [`ResourcesInitializationError`](#resourcesinitializationerror)
   - [`SuggestionsDatabaseError`](#suggestionsdatabaseerror)
   - [`ProjectNotFoundError`](#projectnotfounderror)
   - [`ModuleNameNotResolvedError`](#modulenamenotresolvederror)
@@ -1079,6 +1080,8 @@ be correlated between the textual and data connections.
 
 - [`SessionAlreadyInitialisedError`](#sessionalreadyinitialisederror) to signal
   that session is already initialised.
+- [`ResourcesInitializationError`](#resourcesinitializationerror) to signal
+  about the error during the initialization of Language Server resources.
 
 ### `session/initBinaryConnection`
 
@@ -3735,6 +3738,17 @@ Signals that session is already initialised.
 "error" : {
   "code" : 6002,
   "message" : "Session already initialised"
+}
+```
+
+### `ResourcesInitializationError`
+
+Signals about the failure in the Language Server initialization process.
+
+```typescript
+"error" : {
+  "code" : 6003,
+  "message" : "Failed to initialize the Language Server resources"
 }
 ```
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/InitializationComponent.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/InitializationComponent.scala
@@ -1,0 +1,15 @@
+package org.enso.languageserver.boot
+
+import scala.concurrent.Future
+
+/** A component that should be initialized. */
+trait InitializationComponent {
+
+  /** Initialize the component. */
+  def init(): Future[InitializationComponent.Initialized.type]
+}
+
+object InitializationComponent {
+
+  case object Initialized
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/LanguageServerComponent.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/LanguageServerComponent.scala
@@ -37,11 +37,6 @@ class LanguageServerComponent(config: LanguageServerConfig, logLevel: LogLevel)
   override def start(): Future[ComponentStarted.type] = {
     logger.info("Starting Language Server...")
     val module = new MainModule(config, logLevel)
-    val initMainModule =
-      for {
-        _ <- module.init
-        _ <- Future { logger.debug("Main module initialized") }
-      } yield ()
     val bindJsonServer =
       for {
         binding <- module.jsonRpcServer.bind(config.interface, config.rpcPort)
@@ -58,7 +53,6 @@ class LanguageServerComponent(config: LanguageServerConfig, logLevel: LogLevel)
       _ <- Future {
         maybeServerCtx = Some(ServerContext(module, jsonBinding, binaryBinding))
       }
-      _ <- initMainModule
       _ <- Future {
         logger.info(
           s"Started server at json:${config.interface}:${config.rpcPort}, " +

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -163,7 +163,6 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
   val stdInSink = new ObservableOutputStream
   val stdIn     = new ObservablePipedInputStream(stdInSink)
 
-  log.trace("Initializing Runtime context...")
   val context = Context
     .newBuilder(LanguageInfo.ID)
     .allowAllAccess(true)
@@ -195,8 +194,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
       } else null
     })
     .build()
-  context.initialize(LanguageInfo.ID)
-  log.trace("Runtime context initialized")
+  log.trace("Runtime context created")
 
   system.eventStream.setLogLevel(LogLevel.toAkka(logLevel))
   log.trace(s"Set akka log level to $logLevel")
@@ -227,11 +225,12 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
       "std-in-controller"
     )
 
-  val initializationComponent = new ResourcesInitialization(
+  val initializationComponent = ResourcesInitialization(
     system.eventStream,
     directoriesConfig,
     suggestionsRepo,
-    versionsRepo
+    versionsRepo,
+    context
   )(system.dispatcher)
 
   val jsonRpcControllerFactory = new JsonConnectionControllerFactory(

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/ResourcesInitialization.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/ResourcesInitialization.scala
@@ -1,0 +1,72 @@
+package org.enso.languageserver.boot
+
+import akka.event.EventStream
+import org.enso.languageserver.data.DirectoriesConfig
+import org.enso.languageserver.event.InitializedEvent
+import org.enso.searcher.{FileVersionsRepo, SuggestionsRepo}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/** Initialization of the Language Server resources. Creates the directories and
+  * initializes the databases.
+  *
+  * @param eventStream system event stream
+  * @param directoriesConfig configuration of directories that should be created
+  * @param suggestionsRepo the suggestions repo
+  * @param versionsRepo the file versions repo
+  */
+class ResourcesInitialization(
+  eventStream: EventStream,
+  directoriesConfig: DirectoriesConfig,
+  suggestionsRepo: SuggestionsRepo[Future],
+  versionsRepo: FileVersionsRepo[Future]
+)(implicit ec: ExecutionContext)
+    extends InitializationComponent {
+
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  /** @inheritdoc */
+  override def init(): Future[InitializationComponent.Initialized.type] = {
+    val directoriesInit: Future[Unit] = Future {
+      directoriesConfig.createDirectories()
+    }
+
+    val initialization = for {
+      _ <- directoriesInit
+      _ <- Future.sequence(Seq(suggestionsRepoInit, versionsRepoInit))
+    } yield InitializationComponent.Initialized
+
+    initialization.onComplete {
+      case Success(_) =>
+        eventStream.publish(InitializedEvent.InitializationFinished)
+      case _ =>
+        eventStream.publish(InitializedEvent.InitializationFailed)
+    }
+    initialization
+  }
+
+  private def suggestionsRepoInit: Future[Unit] = {
+    val initAction = suggestionsRepo.init
+    initAction.onComplete {
+      case Success(()) =>
+        eventStream.publish(InitializedEvent.SuggestionsRepoInitialized)
+      case Failure(ex) =>
+        log.error("Failed to initialize SQL suggestions repo", ex)
+    }
+    initAction
+  }
+
+  private def versionsRepoInit: Future[Unit] = {
+    val initAction = versionsRepo.init
+    initAction.onComplete {
+      case Success(()) =>
+        eventStream.publish(InitializedEvent.FileVersionsRepoInitialized)
+      case Failure(ex) =>
+        log.error("Failed to initialize versions repo", ex)
+    }
+    initAction
+  }
+
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/DirectoriesInitialization.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/DirectoriesInitialization.scala
@@ -1,0 +1,25 @@
+package org.enso.languageserver.boot.resource
+
+import org.enso.languageserver.data.DirectoriesConfig
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Directories initialization.
+  *
+  * @param directoriesConfig the directories config
+  */
+class DirectoriesInitialization(directoriesConfig: DirectoriesConfig)(implicit
+  ec: ExecutionContext
+) extends InitializationComponent {
+
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  /** @inheritdoc */
+  override def init(): Future[InitializationComponent.Initialized.type] =
+    Future {
+      directoriesConfig.createDirectories()
+      log.info("Initialized directories.")
+      InitializationComponent.Initialized
+    }
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/InitializationComponent.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/InitializationComponent.scala
@@ -1,4 +1,4 @@
-package org.enso.languageserver.boot
+package org.enso.languageserver.boot.resource
 
 import scala.concurrent.Future
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/RepoInitialization.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/RepoInitialization.scala
@@ -1,0 +1,56 @@
+package org.enso.languageserver.boot.resource
+
+import akka.event.EventStream
+import org.enso.languageserver.event.InitializedEvent
+import org.enso.searcher.{FileVersionsRepo, SuggestionsRepo}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/** Initialization of the Language Server repositories.
+  *
+  * @param eventStream akka events stream
+  * @param suggestionsRepo the suggestions repo
+  * @param versionsRepo the versions repo
+  */
+class RepoInitialization(
+  eventStream: EventStream,
+  suggestionsRepo: SuggestionsRepo[Future],
+  versionsRepo: FileVersionsRepo[Future]
+)(implicit ec: ExecutionContext)
+    extends InitializationComponent {
+
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  /** @inheritdoc */
+  override def init(): Future[InitializationComponent.Initialized.type] =
+    for {
+      _ <- Future.sequence(Seq(suggestionsRepoInit, versionsRepoInit))
+    } yield InitializationComponent.Initialized
+
+  private def suggestionsRepoInit: Future[Unit] = {
+    val initAction = suggestionsRepo.init
+    initAction.onComplete {
+      case Success(()) =>
+        eventStream.publish(InitializedEvent.SuggestionsRepoInitialized)
+      case Failure(ex) =>
+        log.error("Failed to initialize SQL suggestions repo", ex)
+    }
+    log.info("Initialized Suggestions repo.")
+    initAction
+  }
+
+  private def versionsRepoInit: Future[Unit] = {
+    val initAction = versionsRepo.init
+    initAction.onComplete {
+      case Success(()) =>
+        eventStream.publish(InitializedEvent.FileVersionsRepoInitialized)
+      case Failure(ex) =>
+        log.error("Failed to initialize versions repo", ex)
+    }
+    log.info("Initialized Versions repo.")
+    initAction
+  }
+
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/SequentialResourcesInitialization.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/SequentialResourcesInitialization.scala
@@ -1,0 +1,26 @@
+package org.enso.languageserver.boot.resource
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Initializes resources in sequence.
+  *
+  * @param resources the list of resources to initialize
+  */
+class SequentialResourcesInitialization(
+  resources: Seq[InitializationComponent]
+)(implicit ec: ExecutionContext)
+    extends InitializationComponent {
+
+  /** @inheritdoc */
+  override def init(): Future[InitializationComponent.Initialized.type] =
+    resources.foldLeft(Future.successful(InitializationComponent.Initialized)) {
+      (action, resource) => action.flatMap(_ => resource.init())
+    }
+}
+
+object SequentialResourcesInitialization {
+
+  def apply(resources: InitializationComponent*)(implicit
+    ec: ExecutionContext
+  ): SequentialResourcesInitialization =
+    new SequentialResourcesInitialization(resources)
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/TruffleContextInitialization.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/TruffleContextInitialization.scala
@@ -1,0 +1,25 @@
+package org.enso.languageserver.boot.resource
+import org.enso.polyglot.LanguageInfo
+import org.graalvm.polyglot.Context
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Initialize the Truffle context.
+  *
+  * @param truffleContext the Truffle context
+  */
+class TruffleContextInitialization(truffleContext: Context)(implicit
+  ec: ExecutionContext
+) extends InitializationComponent {
+
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  /** @inheritdoc */
+  override def init(): Future[InitializationComponent.Initialized.type] =
+    Future {
+      truffleContext.initialize(LanguageInfo.ID)
+      log.info("Initialized Runtime context.")
+      InitializationComponent.Initialized
+    }
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/data/Config.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/data/Config.scala
@@ -105,14 +105,6 @@ object DirectoriesConfig {
     * @param root the root directory path
     * @return data directory config
     */
-  def initialize(root: String): DirectoriesConfig =
-    initialize(new File(root))
-
-  /** Create default data directory config, creating directories if not exist.
-    *
-    * @param root the root directory path
-    * @return data directory config
-    */
   def initialize(root: File): DirectoriesConfig = {
     val config = new DirectoriesConfig(root)
     config.createDirectories()

--- a/engine/language-server/src/main/scala/org/enso/languageserver/data/Config.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/data/Config.scala
@@ -88,7 +88,7 @@ case class DirectoriesConfig(root: File) {
     new File(dataDirectory, DirectoriesConfig.SuggestionsDatabaseFile)
 
   /** Create data directories if not exist. */
-  private def createDirectories(): Unit =
+  def createDirectories(): Unit =
     Files.createDirectories(dataDirectory.toPath)
 }
 
@@ -96,6 +96,9 @@ object DirectoriesConfig {
 
   val DataDirectory: String           = ".enso"
   val SuggestionsDatabaseFile: String = "suggestions.db"
+
+  def apply(root: String): DirectoriesConfig =
+    new DirectoriesConfig(new File(root))
 
   /** Create default data directory config, creating directories if not exist.
     *

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
@@ -6,7 +6,7 @@ import akka.actor.{Actor, ActorLogging, ActorRef, Props, Stash, Status}
 import akka.pattern.pipe
 import akka.util.Timeout
 import org.enso.jsonrpc._
-import org.enso.languageserver.boot.InitializationComponent
+import org.enso.languageserver.boot.resource.InitializationComponent
 import org.enso.languageserver.capability.CapabilityApi.{
   AcquireCapability,
   ForceReleaseCapability,

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionControllerFactory.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionControllerFactory.scala
@@ -4,14 +4,17 @@ import java.util.UUID
 
 import akka.actor.{ActorRef, ActorSystem}
 import org.enso.jsonrpc.ClientControllerFactory
+import org.enso.languageserver.boot.InitializationComponent
 
 /** Language server client controller factory.
   *
+  * @param mainComponent the main initialization logic
   * @param bufferRegistry the buffer registry actor ref
   * @param capabilityRouter the capability router actor ref
   * @param system the actor system
   */
 class JsonConnectionControllerFactory(
+  mainComponent: InitializationComponent,
   bufferRegistry: ActorRef,
   capabilityRouter: ActorRef,
   fileManager: ActorRef,
@@ -27,12 +30,13 @@ class JsonConnectionControllerFactory(
   /** Creates a client controller actor.
     *
     * @param clientId the internal client id.
-    * @return
+    * @return the client controller actor
     */
   override def createClientController(clientId: UUID): ActorRef =
     system.actorOf(
       JsonConnectionController.props(
         clientId,
+        mainComponent,
         bufferRegistry,
         capabilityRouter,
         fileManager,

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionControllerFactory.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionControllerFactory.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import akka.actor.{ActorRef, ActorSystem}
 import org.enso.jsonrpc.ClientControllerFactory
-import org.enso.languageserver.boot.InitializationComponent
+import org.enso.languageserver.boot.resource.InitializationComponent
 
 /** Language server client controller factory.
   *

--- a/engine/language-server/src/main/scala/org/enso/languageserver/session/SessionApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/session/SessionApi.scala
@@ -31,4 +31,6 @@ object SessionApi {
   case object SessionAlreadyInitialisedError
       extends Error(6002, "Session already initialised")
 
+  case object ResourcesInitializationError
+      extends Error(6003, "Failed to initialize the Language Server resources")
 }

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectManagementApiSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectManagementApiSpec.scala
@@ -8,7 +8,6 @@ import io.circe.literal._
 import nl.gn0s1s.bump.SemVer
 import org.apache.commons.io.FileUtils
 import org.enso.pkg.SemVerJson._
-import org.enso.projectmanager.test.Net.tryConnect
 import org.enso.projectmanager.{BaseServerSpec, ProjectManagementOps}
 import org.enso.testkit.{FlakySpec, RetrySpec}
 
@@ -605,47 +604,6 @@ class ProjectManagementApiSpec
       val lines       = buffer.getLines()
       lines.contains("name: Bar") shouldBe true
       buffer.close()
-      //teardown
-      deleteProject(projectId)
-    }
-
-    "move project dir on project close".taggedAs(Retry, Flaky) in {
-      implicit val client = new WsTestClient(address)
-      //given
-      val projectId = createProject("foo")
-      openProject(projectId)
-      //when
-      client.send(json"""
-            { "jsonrpc": "2.0",
-              "method": "project/rename",
-              "id": 0,
-              "params": {
-                "projectId": $projectId,
-                "name": "bar"
-              }
-            }
-          """)
-      //then
-      client.expectJson(json"""
-          {
-            "jsonrpc":"2.0",
-            "id":0,
-            "result": null
-          }
-          """)
-      val projectDir = new File(userProjectDir, "bar")
-      projectDir.exists() shouldBe false
-      closeProject(projectId)
-      Thread.sleep(1000)
-      projectDir.exists() shouldBe true
-      val packageFile = new File(projectDir, "package.yaml")
-      val buffer      = Source.fromFile(packageFile)
-      val lines       = buffer.getLines()
-      lines.contains("name: Bar") shouldBe true
-      buffer.close()
-      val jsonSocket = openProject(projectId)
-      tryConnect(jsonSocket).isRight shouldBe true
-      closeProject(projectId)
       //teardown
       deleteProject(projectId)
     }

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/FileVersionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/FileVersionsRepo.scala
@@ -5,6 +5,9 @@ import java.io.File
 /** The object for accessing the database containing the file versions. */
 trait FileVersionsRepo[F[_]] {
 
+  /** Initialize the repo. */
+  def init: F[Unit]
+
   /** Get the file version.
     *
     * @param file the file path

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/SuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/SuggestionsRepo.scala
@@ -12,6 +12,9 @@ import org.enso.searcher.data.QueryResult
 /** The object for accessing the suggestions database. */
 trait SuggestionsRepo[F[_]] {
 
+  /** Initialize the repo. */
+  def init: F[Unit]
+
   /** Get current version of the repo. */
   def currentVersion: F[Long]
 

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
@@ -36,7 +36,7 @@ final class SqlSuggestionsRepo(db: SqlDatabase)(implicit ec: ExecutionContext)
       .on(_.suggestionId === _.id)
 
   /** Initialize the repo. */
-  def init: Future[Unit] =
+  override def init: Future[Unit] =
     db.run(initQuery)
 
   /** @inheritdoc */

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlVersionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlVersionsRepo.scala
@@ -12,7 +12,7 @@ final class SqlVersionsRepo(db: SqlDatabase)(implicit ec: ExecutionContext)
     extends FileVersionsRepo[Future] {
 
   /** Initialize the repo. */
-  def init: Future[Unit] =
+  override def init: Future[Unit] =
     db.run(initQuery)
 
   /** @inheritdoc */


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1403

Lazy initialization of the Language Server.

Changelog:
- add: `InitializationComponent` containing the init logic
- update: `MainModule` does not create the directories or initializes the databases, or the truffle context
- update: `JsonConnectionController` runs initialization logic when receiving the `InitProtocolConnection` message

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
