### PR TITLE
Fix Logger Disconnect

### DIFF
--- a/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/printers/FileOutputPrinter.scala
+++ b/lib/scala/logging-service/src/main/scala/org/enso/loggingservice/printers/FileOutputPrinter.scala
@@ -29,6 +29,10 @@ class FileOutputPrinter(
   override def print(message: WSLogMessage): Unit = {
     val lines = renderer.render(message)
     writer.println(lines)
+    // TODO [RW] we may consider making flushing configurable as it is mostly
+    //  useful for debugging crashes, whereas for usual usecases buffering could
+    //  give slightly better performance
+    writer.flush()
   }
 
   /** @inheritdoc */


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

After some idle time, the logging service was being disconnected with the message
```
[internal-logger-error] Server has disconnected, logging is falling back to stderr.
```

This PR fixes this, keeping the logging service connection alive even if logs are not being sent for some time.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
