### PR TITLE
Don't use thread interrupts to cancel executions

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadManager.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadManager.java
@@ -51,6 +51,7 @@ public class ThreadManager {
     if (safepoint) {
       CompilerDirectives.transferToInterpreter();
       safepointPhaser.arriveAndAwaitAdvance();
+      safepoint = false;
       // TODO[MK]: Make this conditional on the interrupt flag when
       // https://github.com/oracle/graal/issues/3273 is resolved.
       throw new ThreadInterruptedException();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadManager.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadManager.java
@@ -51,15 +51,15 @@ public class ThreadManager {
     if (safepoint) {
       CompilerDirectives.transferToInterpreter();
       safepointPhaser.arriveAndAwaitAdvance();
-      if (Thread.interrupted()) {
-        throw new ThreadInterruptedException();
-      }
+      // TODO[MK]: Make this conditional on the interrupt flag when
+      // https://github.com/oracle/graal/issues/3273 is resolved.
+      throw new ThreadInterruptedException();
     }
   }
 
   /**
    * Forces all threads managed by this system to halt at the next safepoint (i.e. a {@link #poll()}
-   * call) and throw an exception if they were interrupted.
+   * call) and throw a {@link ThreadInterruptedException}.
    *
    * <p>This method is blocking, does not return until the last managed thread reports at a
    * safepoint.
@@ -67,7 +67,7 @@ public class ThreadManager {
    * <p>This method may not be called from a thread that is itself managed by this system, as doing
    * so may result in a deadlock.
    */
-  public void checkInterrupts() {
+  public void interruptThreads() {
     lock.lock();
     try {
       enter();

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -91,7 +91,7 @@ class JobExecutionEngine(
       runningJob.future.cancel(runningJob.job.mayInterruptIfRunning)
     }
     runtimeContext.executionService.getContext.getThreadManager
-      .checkInterrupts()
+      .interruptThreads()
   }
 
   /** @inheritdoc */
@@ -104,7 +104,7 @@ class JobExecutionEngine(
       }
     }
     runtimeContext.executionService.getContext.getThreadManager
-      .checkInterrupts()
+      .interruptThreads()
   }
 
   /** @inheritdoc */
@@ -112,7 +112,7 @@ class JobExecutionEngine(
     val allJobs = runningJobsRef.get()
     allJobs.foreach(_.future.cancel(true))
     runtimeContext.executionService.getContext.getThreadManager
-      .checkInterrupts()
+      .interruptThreads()
     jobExecutor.shutdownNow()
   }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
@@ -19,7 +19,13 @@ class ExecuteJob(
   stack: List[InstrumentFrame],
   updatedVisualisations: Seq[UUID],
   sendMethodCallUpdates: Boolean
-) extends Job[Unit](List(contextId), true, true)
+) extends Job[Unit](
+      List(contextId),
+      isCancellable = true,
+      // TODO[MK]: make this interruptible when https://github.com/oracle/graal/issues/3273
+      // is resolved
+      mayInterruptIfRunning = false
+    )
     with ProgramExecutionSupport {
 
   def this(exe: Executable) =

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
@@ -51,8 +51,7 @@ class RuntimeManagementTest extends InterpreterTest {
           reportedCount += consumeOut.length
         }
         val expectedOut = List.fill(n)("Interrupted.")
-        threads.foreach(_.interrupt())
-        langCtx.getThreadManager.checkInterrupts()
+        langCtx.getThreadManager.interruptThreads()
         threads.foreach(_.join())
         consumeOut shouldEqual expectedOut
         threads.forall(!_.isAlive) shouldBe true

--- a/table/src/main/java/org/enso/table/data/index/HashIndex.java
+++ b/table/src/main/java/org/enso/table/data/index/HashIndex.java
@@ -44,7 +44,7 @@ public class HashIndex extends Index {
 
   @Override
   public String ilocString(int loc) {
-    return iloc(loc).toString();
+    return String.valueOf(iloc(loc));
   }
 
   @Override


### PR DESCRIPTION
### Pull Request Description
Thread interrupts currently break the polyglot classloader: https://github.com/oracle/graal/issues/3273
This means we have to stop using them for now, to fix #1560.
Also a small fix for the table library.

Closes #1560 

### Important Notes
This all means we won't be able to cancel out of polyglot java executions. We should bring back the interrupts as soon as the Graal issue is fixed.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
