### PR TITLE
Fix the Array Visualisation

### DIFF
--- a/distribution/std-lib/Standard/src/Base.enso
+++ b/distribution/std-lib/Standard/src/Base.enso
@@ -1,4 +1,5 @@
 import Standard.Base.Data.Any.Extensions
+import Standard.Base.Data.Array.Extensions
 import Standard.Base.Data.Interval
 import Standard.Base.Data.Json
 import Standard.Base.Data.List
@@ -34,6 +35,7 @@ export Standard.Base.Meta
 export Standard.Base.System.File
 
 from Standard.Base.Data.Any.Extensions export all
+from Standard.Base.Data.Array.Extensions export all
 from Standard.Base.Data.List export Nil, Cons
 from Standard.Base.Data.Number.Extensions export all hiding Math, String, Double
 from Standard.Base.Data.Noise export all hiding Noise

--- a/distribution/std-lib/Standard/src/Base/Data/Array/Extensions.enso
+++ b/distribution/std-lib/Standard/src/Base/Data/Array/Extensions.enso
@@ -4,5 +4,5 @@ from Standard.Base import all
    visualization.
 Array.to_default_visualization_data : Text
 Array.to_default_visualization_data = 
-    Vector.Vector this |> .to_default_visualization_data
+    Vector.Vector this . to_default_visualization_data
 

--- a/distribution/std-lib/Standard/src/Base/Data/Array/Extensions.enso
+++ b/distribution/std-lib/Standard/src/Base/Data/Array/Extensions.enso
@@ -1,0 +1,8 @@
+from Standard.Base import all
+
+## Transform the array into text for displaying as part of its default
+   visualization.
+Array.to_default_visualization_data : Text
+Array.to_default_visualization_data = 
+    Vector.Vector this |> .to_default_visualization_data
+

--- a/distribution/std-lib/Standard/src/Base/Data/Json.enso
+++ b/distribution/std-lib/Standard/src/Base/Data/Json.enso
@@ -117,8 +117,8 @@ type Marshalling_Error
     to_display_text : Text
     to_display_text = case this of
         Type_Mismatch_Error json format ->
-            json_text = Meta.display_type json
-            format_text = Meta.display_type format
+            json_text = Meta.type_to_display_text json
+            format_text = Meta.type_to_display_text format
             "Type mismatch error: the json with type `" + json_text + "` did not match the format `" + format_text + "`."
         Missing_Field_Error _ field _ ->
             "Missing field in Json: the field `" + field.to_text "` was missing in the json."

--- a/distribution/std-lib/Standard/src/Base/Data/Json.enso
+++ b/distribution/std-lib/Standard/src/Base/Data/Json.enso
@@ -81,6 +81,10 @@ type Json
    Check the `message` field for detailed information on the specific failure.
 type Parse_Error message
 
+## Converts the error to a display representation.
+Parse_Error.to_display_text : Text
+Parse_Error.to_display_text = "Parse error in parsing JSON: " + this.message.to_text + "."
+
 ## Gets the value associated with the given key in this object. Returns
    `Nothing` if the associated key is not defined.
 Object.get : Text -> Json | Nothing
@@ -109,6 +113,15 @@ type Marshalling_Error
        This can occure when trying to reinterpret a JSON object into an atom,
        when the JSON does not contain all the fields required by the atom.
     type Missing_Field_Error json field format
+
+    to_display_text : Text
+    to_display_text = case this of
+        Type_Mismatch_Error json format ->
+            json_text = Meta.display_type json
+            format_text = Meta.display_type format
+            "Type mismatch error: the json with type `" + json_text + "` did not match the format `" + format_text + "`."
+        Missing_Field_Error _ field _ ->
+            "Missing field in Json: the field `" + field.to_text "` was missing in the json."
 
 ## Generically converts an atom into a JSON object.
 

--- a/distribution/std-lib/Standard/src/Base/Data/Vector.enso
+++ b/distribution/std-lib/Standard/src/Base/Data/Vector.enso
@@ -523,6 +523,9 @@ type Vector
 
         Vector new_vec_arr
 
+    to_default_visualisation_data : Text
+    to_default_visualisation_data = 
+
 ## A builder type for Enso vectors.
 
    A vector builder is a mutable data structure, that allows to gather a

--- a/distribution/std-lib/Standard/src/Base/Data/Vector.enso
+++ b/distribution/std-lib/Standard/src/Base/Data/Vector.enso
@@ -527,7 +527,7 @@ type Vector
        visualization.
     to_default_visualization_data : Text
     to_default_visualization_data =
-        json = this.take_start 100 |> .to_json
+        json = this.take_start 100 . to_json
         json.to_text
 
 ## A builder type for Enso vectors.

--- a/distribution/std-lib/Standard/src/Base/Data/Vector.enso
+++ b/distribution/std-lib/Standard/src/Base/Data/Vector.enso
@@ -523,8 +523,12 @@ type Vector
 
         Vector new_vec_arr
 
-    to_default_visualisation_data : Text
-    to_default_visualisation_data = 
+    ## Transform the vector into text for displaying as part of its default
+       visualization.
+    to_default_visualization_data : Text
+    to_default_visualization_data =
+        json = this.take_start 100 |> .to_json
+        json.to_text
 
 ## A builder type for Enso vectors.
 

--- a/distribution/std-lib/Standard/src/Base/Meta.enso
+++ b/distribution/std-lib/Standard/src/Base/Meta.enso
@@ -147,3 +147,10 @@ is_same_object value_1 value_2 = Builtins.Meta.is_same_object value_1 value_2
 get_source_location : Integer -> Text
 get_source_location skip_frames =
     Builtins.Meta.get_source_location skip_frames+1
+
+## Displays the type of the provided value as text.
+
+   Arguments:
+   - value: The value for which to display the type.
+display_type : Any -> Text
+display_type value = Builtins.Meta.display_type value

--- a/distribution/std-lib/Standard/src/Base/Meta.enso
+++ b/distribution/std-lib/Standard/src/Base/Meta.enso
@@ -152,5 +152,5 @@ get_source_location skip_frames =
 
    Arguments:
    - value: The value for which to display the type.
-display_type : Any -> Text
-display_type value = Builtins.Meta.display_type value
+type_to_display_text : Any -> Text
+type_to_display_text value = Builtins.Meta.type_to_display_text value

--- a/distribution/std-lib/Standard/src/Base/System/File.enso
+++ b/distribution/std-lib/Standard/src/Base/System/File.enso
@@ -300,7 +300,7 @@ new path = File (Prim_Io.get_file path)
 
    > Example
      Read the `data.csv` file in the project directory.
-         File.open (Enso_Project.data / "data.csv")
+         File.read (Enso_Project.data / "data.csv")
 read : Text -> Text
 read path = (here.new path).read
 

--- a/distribution/std-lib/Standard/src/Test.enso
+++ b/distribution/std-lib/Standard/src/Test.enso
@@ -179,8 +179,8 @@ run_spec ~behavior =
         case ex of
             Failure _ -> ex
             Finished_With_Error err stack_trace_text ->
-                Failure ("An unexpected error was returned: " + err.to_text + '\n' + stack_trace_text)
-            _ -> Failure ("An unexpected panic was thrown: " + ex.to_text + '\n' + maybeExc.get_stack_trace_text)
+                Failure ("An unexpected error was returned: " + err.to_display_text + '\n' + stack_trace_text)
+            _ -> Failure ("An unexpected panic was thrown: " + ex.to_display_text + '\n' + maybeExc.get_stack_trace_text)
     result
 
 ## Creates a new test group, desribing properties of the object

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/MethodNames.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/MethodNames.java
@@ -3,26 +3,27 @@ package org.enso.polyglot;
 /** Container for polyglot method names */
 public class MethodNames {
   public static class TopScope {
-    public static final String GET_MODULE = "get_module";
     public static final String CREATE_MODULE = "create_module";
+    public static final String GET_MODULE = "get_module";
+    public static final String LEAK_CONTEXT = "leak_context";
     public static final String REGISTER_MODULE = "register_module";
     public static final String UNREGISTER_MODULE = "unregister_module";
-    public static final String LEAK_CONTEXT = "leak_context";
   }
 
   public static class Module {
+    public static final String EVAL_EXPRESSION = "eval_expression";
     public static final String GET_ASSOCIATED_CONSTRUCTOR = "get_associated_constructor";
-    public static final String GET_METHOD = "get_method";
     public static final String GET_CONSTRUCTOR = "get_constructor";
+    public static final String GET_METHOD = "get_method";
+    public static final String GET_NAME = "get_name";
     public static final String REPARSE = "reparse";
     public static final String SET_SOURCE = "set_source";
     public static final String SET_SOURCE_FILE = "set_source_file";
-    public static final String EVAL_EXPRESSION = "eval_expression";
   }
 
   public static class Function {
     public static final String EQUALS = "equals";
-    public static final String GET_SOURCE_START = "get_source_start";
     public static final String GET_SOURCE_LENGTH = "get_source_length";
+    public static final String GET_SOURCE_START = "get_source_start";
   }
 }

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/Module.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/Module.scala
@@ -27,8 +27,12 @@ class Module(private val value: Value) {
     * @param name the name of the method
     * @return the runtime representation of the method
     */
-  def getMethod(constructor: Value, name: String): Function =
-    new Function(value.invokeMember(GET_METHOD, constructor, name))
+  def getMethod(constructor: Value, name: String): Option[Function] = {
+    val newVal = value.invokeMember(GET_METHOD, constructor, name);
+    if (newVal.isNull) { None }  else {
+      Some(new Function(newVal))
+    }
+  }
 
   /** Evaluates an arbitrary expression as if it were placed in a function
     * body inside this module.

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/Module.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/Module.scala
@@ -9,12 +9,17 @@ import org.graalvm.polyglot.Value
 class Module(private val value: Value) {
   import MethodNames.Module._
 
+  /** @return the name of the module
+    */
+  def getName: String = value.invokeMember(GET_NAME).asString()
+
   /** @return the associated type of this module
     */
   def getAssociatedConstructor: Value =
     value.invokeMember(GET_ASSOCIATED_CONSTRUCTOR)
 
-  /** Gets a constructor definition by name
+  /** Gets a constructor definition by name.
+   *
     * @param name the constructor name
     * @return the polyglot representation of the constructor.
     */
@@ -29,13 +34,15 @@ class Module(private val value: Value) {
     */
   def getMethod(constructor: Value, name: String): Option[Function] = {
     val newVal = value.invokeMember(GET_METHOD, constructor, name);
-    if (newVal.isNull) { None }  else {
+    if (newVal.isNull) { None }
+    else {
       Some(new Function(newVal))
     }
   }
 
   /** Evaluates an arbitrary expression as if it were placed in a function
     * body inside this module.
+   *
     * @param code the expression to evaluate
     * @return the return value of the expression
     */

--- a/engine/polyglot-api/src/test/scala/org/enso/polyglot/ApiTest.scala
+++ b/engine/polyglot-api/src/test/scala/org/enso/polyglot/ApiTest.scala
@@ -16,7 +16,7 @@ class ApiTest extends AnyFlatSpec with Matchers {
         |""".stripMargin
     val module                = executionContext.evalModule(code, "Test")
     val associatedConstructor = module.getAssociatedConstructor
-    val barFunction           = module.getMethod(associatedConstructor, "bar")
+    val barFunction           = module.getMethod(associatedConstructor, "bar").get
     val result = barFunction.execute(
       associatedConstructor.newInstance(),
       10L.asInstanceOf[AnyRef]
@@ -39,7 +39,7 @@ class ApiTest extends AnyFlatSpec with Matchers {
         |""".stripMargin
     val module     = executionContext.evalModule(code, "Test")
     val vectorCons = module.getConstructor("Vector")
-    val squareNorm = module.getMethod(vectorCons, "squareNorm")
+    val squareNorm = module.getMethod(vectorCons, "squareNorm").get
     val testVector = vectorCons.newInstance(
       1L.asInstanceOf[AnyRef],
       2L.asInstanceOf[AnyRef],

--- a/engine/polyglot-api/src/test/scala/org/enso/polyglot/ModuleManagementTest.scala
+++ b/engine/polyglot-api/src/test/scala/org/enso/polyglot/ModuleManagementTest.scala
@@ -44,7 +44,7 @@ class ModuleManagementTest extends AnyFlatSpec with Matchers {
 
     val mainModule = ctx.executionContext.getTopScope.getModule("Test.Main")
     val assocCons  = mainModule.getAssociatedConstructor
-    val mainFun1   = mainModule.getMethod(assocCons, "main")
+    val mainFun1   = mainModule.getMethod(assocCons, "main").get
 
     mainFun1.execute(assocCons).asLong() shouldEqual 12345L
 
@@ -53,7 +53,7 @@ class ModuleManagementTest extends AnyFlatSpec with Matchers {
                     |""".stripMargin)
 
     mainModule.reparse()
-    val mainFun2 = mainModule.getMethod(assocCons, "main")
+    val mainFun2 = mainModule.getMethod(assocCons, "main").get
     mainFun2.execute(assocCons).asLong() shouldEqual 4567L
   }
 
@@ -66,20 +66,20 @@ class ModuleManagementTest extends AnyFlatSpec with Matchers {
 
     val mainModule = ctx.executionContext.getTopScope.getModule("Test.Main")
     val assocCons  = mainModule.getAssociatedConstructor
-    val mainFun1   = mainModule.getMethod(assocCons, "main")
+    val mainFun1   = mainModule.getMethod(assocCons, "main").get
 
     mainFun1.execute(assocCons).asLong() shouldEqual 123L
 
     mainModule.setSource("""
                            |main = 456
                            |""".stripMargin)
-    val mainFun2 = mainModule.getMethod(assocCons, "main")
+    val mainFun2 = mainModule.getMethod(assocCons, "main").get
     mainFun2.execute(assocCons).asLong() shouldEqual 456L
 
     mainModule.setSource("""
                            |main = 789
                            |""".stripMargin)
-    val mainFun3 = mainModule.getMethod(assocCons, "main")
+    val mainFun3 = mainModule.getMethod(assocCons, "main").get
     mainFun3.execute(assocCons).asLong() shouldEqual 789L
 
     ctx.writeMain("""
@@ -87,7 +87,7 @@ class ModuleManagementTest extends AnyFlatSpec with Matchers {
                     |""".stripMargin)
 
     mainModule.setSourceFile(ctx.pkg.mainFile.getAbsolutePath)
-    val mainFun4 = mainModule.getMethod(assocCons, "main")
+    val mainFun4 = mainModule.getMethod(assocCons, "main").get
     mainFun4.execute(assocCons).asLong() shouldEqual 987L
   }
 
@@ -111,7 +111,7 @@ class ModuleManagementTest extends AnyFlatSpec with Matchers {
 
     val mainModule = topScope.getModule("Test.Main")
     val assocCons  = mainModule.getAssociatedConstructor
-    val mainFun    = mainModule.getMethod(assocCons, "main")
+    val mainFun    = mainModule.getMethod(assocCons, "main").get
     mainFun.execute(assocCons).asLong shouldEqual 11L
   }
 
@@ -141,7 +141,7 @@ class ModuleManagementTest extends AnyFlatSpec with Matchers {
 
     val mainModule = topScope.getModule("Test.Main")
     val assocCons  = mainModule.getAssociatedConstructor
-    val mainFun    = mainModule.getMethod(assocCons, "main")
+    val mainFun    = mainModule.getMethod(assocCons, "main").get
     mainFun.execute(assocCons).asLong shouldEqual 21L
   }
 
@@ -161,7 +161,7 @@ class ModuleManagementTest extends AnyFlatSpec with Matchers {
       "X"
     )
     val mod1AssocCons = mod1.getAssociatedConstructor
-    val mod1Main      = mod1.getMethod(mod1AssocCons, "bar")
+    val mod1Main      = mod1.getMethod(mod1AssocCons, "bar").get
     mod1Main.execute(mod1AssocCons).asLong shouldEqual 124
 
     ctx.executionContext.getTopScope.unregisterModule("Test.Main")

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -390,8 +390,8 @@ object Main {
         case Some(main) => main.execute(mainCons.newInstance())
         case None =>
           err.println(
-            "Your module does not contain a `main` function. It could not " +
-            "be run."
+            s"The module ${mainModule.getName} does not contain a `main` " +
+            s"function. It could not be run."
           )
       }
     } catch {

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -1,8 +1,5 @@
 package org.enso.runner
 
-import java.io.File
-import java.util.UUID
-
 import akka.http.scaladsl.model.{IllegalUriException, Uri}
 import cats.implicits._
 import org.apache.commons.cli.{Option => CliOption, _}
@@ -12,8 +9,11 @@ import org.enso.loggingservice.LogLevel
 import org.enso.pkg.{Contact, PackageManager, SemVerEnsoVersion}
 import org.enso.polyglot.{LanguageInfo, Module, PolyglotContext}
 import org.enso.version.VersionDescription
-import org.graalvm.polyglot.{PolyglotException, Value}
+import org.graalvm.polyglot.PolyglotException
 
+import java.io.File
+import java.util.UUID
+import scala.Console.err
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
@@ -382,11 +382,18 @@ object Main {
     mainModule: Module,
     rootPkgPath: Option[File],
     mainMethodName: String = "main"
-  ): Value = {
+  ): Unit = {
     val mainCons = mainModule.getAssociatedConstructor
     val mainFun  = mainModule.getMethod(mainCons, mainMethodName)
     try {
-      mainFun.execute(mainCons.newInstance())
+      mainFun match {
+        case Some(main) => main.execute(mainCons.newInstance())
+        case None =>
+          err.println(
+            "Your module does not contain a `main` function. It could not " +
+            "be run."
+          )
+      }
     } catch {
       case e: PolyglotException =>
         printPolyglotException(e, rootPkgPath)

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/DisplayTypeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/DisplayTypeNode.java
@@ -1,0 +1,16 @@
+package org.enso.interpreter.node.expression.builtin.meta;
+
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
+import org.enso.interpreter.runtime.data.text.Text;
+
+@BuiltinMethod(type = "Meta", name = "display_type", description = "Pretty prints a type.")
+public class DisplayTypeNode extends Node {
+  @Child @CompilationFinal TypeToDisplayTextNode displayTypeNode = TypeToDisplayTextNode.build();
+
+  Text execute(Object _this, Object value) {
+    return Text.create(displayTypeNode.execute(value));
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/DisplayTypeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/DisplayTypeNode.java
@@ -6,7 +6,7 @@ import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextNode;
 import org.enso.interpreter.runtime.data.text.Text;
 
-@BuiltinMethod(type = "Meta", name = "display_type", description = "Pretty prints a type.")
+@BuiltinMethod(type = "Meta", name = "type_to_display_text", description = "Pretty prints a type.")
 public class DisplayTypeNode extends Node {
   @Child @CompilationFinal TypeToDisplayTextNode displayTypeNode = TypeToDisplayTextNode.build();
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetPolyglotLanguageNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetPolyglotLanguageNode.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
-import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/util/TypeToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/util/TypeToDisplayTextNode.java
@@ -13,6 +13,15 @@ import org.enso.interpreter.runtime.type.TypesGen;
 public abstract class TypeToDisplayTextNode extends Node {
   public abstract String execute(Object o);
 
+  /**
+   * Create a node that can display types as text.
+   *
+   * @return a new type display node
+   */
+  public static TypeToDisplayTextNode build() {
+    return TypeToDisplayTextNodeGen.create();
+  }
+
   @Specialization
   @CompilerDirectives.TruffleBoundary
   String doDisplay(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -405,12 +405,11 @@ public class Module implements TruffleObject {
         throws UnknownIdentifierException, ArityException, UnsupportedTypeException {
       ModuleScope scope = module.compileScope(context);
       switch (member) {
+        case MethodNames.Module.GET_NAME:
+          return module.getName().toString();
         case MethodNames.Module.GET_METHOD:
-          var result = getMethod(scope, arguments);
-          if (result == null) {
-            return context.getBuiltins().nothing().newInstance();
-          }
-          return result;
+          Function result = getMethod(scope, arguments);
+          return result == null ? context.getBuiltins().nothing().newInstance() : result;
         case MethodNames.Module.GET_CONSTRUCTOR:
           return getConstructor(scope, arguments);
         case MethodNames.Module.REPARSE:

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -15,6 +15,7 @@ import com.oracle.truffle.api.source.Source;
 import java.io.File;
 import java.io.IOException;
 
+import java.util.Map;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.phase.StubIrBuilder;
 import org.enso.interpreter.Language;
@@ -405,7 +406,11 @@ public class Module implements TruffleObject {
       ModuleScope scope = module.compileScope(context);
       switch (member) {
         case MethodNames.Module.GET_METHOD:
-          return getMethod(scope, arguments);
+          var result = getMethod(scope, arguments);
+          if (result == null) {
+            return context.getBuiltins().nothing().newInstance();
+          }
+          return result;
         case MethodNames.Module.GET_CONSTRUCTOR:
           return getConstructor(scope, arguments);
         case MethodNames.Module.REPARSE:

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Meta.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Meta.java
@@ -18,7 +18,7 @@ public class Meta {
     AtomConstructor meta = new AtomConstructor("Meta", scope).initializeFields();
     scope.registerConstructor(meta);
 
-    scope.registerMethod(meta, "display_type", DisplayTypeMethodGen.makeFunction(language));
+    scope.registerMethod(meta, "type_to_display_text", DisplayTypeMethodGen.makeFunction(language));
     scope.registerMethod(
         meta, "is_unresolved_symbol", IsUnresolvedSymbolMethodGen.makeFunction(language));
     scope.registerMethod(
@@ -51,6 +51,7 @@ public class Meta {
         meta, "get_polyglot_language", GetPolyglotLanguageMethodGen.makeFunction(language));
 
     scope.registerMethod(meta, "is_same_object", IsSameObjectMethodGen.makeFunction(language));
-    scope.registerMethod(meta, "get_source_location", GetSourceLocationMethodGen.makeFunction(language));
+    scope.registerMethod(
+        meta, "get_source_location", GetSourceLocationMethodGen.makeFunction(language));
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Meta.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Meta.java
@@ -18,6 +18,7 @@ public class Meta {
     AtomConstructor meta = new AtomConstructor("Meta", scope).initializeFields();
     scope.registerConstructor(meta);
 
+    scope.registerMethod(meta, "display_type", DisplayTypeMethodGen.makeFunction(language));
     scope.registerMethod(
         meta, "is_unresolved_symbol", IsUnresolvedSymbolMethodGen.makeFunction(language));
     scope.registerMethod(

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -224,7 +224,7 @@ type Error
     catch_primitive : (Error -> Any) -> Any
     catch_primitive handler = @Builtin_Method "Any.catch"
 
-    ## PRIVATE 
+    ## PRIVATE
        UNSTABLE
 
        Returns a textual representation of the stack trace attached to an error.
@@ -728,8 +728,16 @@ type Meta
        Arguments:
        - frames_to_skip: how many frames on the stack to skip. Called with 0
          will return exact location of the call.
-   get_source_location : Integer -> Text
-   get_source_location frames_to_skip = @Builtin_Method "Meta.get_source_location"
+    get_source_location : Integer -> Text
+    get_source_location frames_to_skip = @Builtin_Method "Meta.get_source_location"
+
+    ## Pretty-prints the type of the provided value using the interpreter's
+       internal logic for printing types.
+
+       Arguments:
+       - value: The value whose type should be printed.
+    display_type : Any -> Text
+    display_type value = @Builtin_Method "Meta.display_type"
 
 ## Utilities for working with primitive arrays.
 type Array

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -736,8 +736,8 @@ type Meta
 
        Arguments:
        - value: The value whose type should be printed.
-    display_type : Any -> Text
-    display_type value = @Builtin_Method "Meta.display_type"
+    type_to_display_text : Any -> Text
+    type_to_display_text value = @Builtin_Method "Meta.display_type"
 
 ## Utilities for working with primitive arrays.
 type Array

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -1,16 +1,15 @@
 package org.enso.compiler.core
 
-import java.util.UUID
-
 import org.enso.compiler.core.IR.{Expression, IdentifiedLocation}
-import org.enso.compiler.core.ir.{DiagnosticStorage, MetadataStorage}
 import org.enso.compiler.core.ir.MetadataStorage.MetadataPair
+import org.enso.compiler.core.ir.{DiagnosticStorage, MetadataStorage}
 import org.enso.compiler.data.BindingsMap
 import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.IRPass
 import org.enso.interpreter.epb.EpbParser
 import org.enso.syntax.text.{AST, Debug, Location}
 
+import java.util.UUID
 import scala.annotation.unused
 
 /** [[IR]] is a temporary and fairly unsophisticated internal representation
@@ -5337,7 +5336,10 @@ object IR {
   // === Errors ===============================================================
 
   /** A trait for all errors in Enso's IR. */
-  sealed trait Error extends Expression with Diagnostic {
+  sealed trait Error
+      extends Expression
+      with IR.Module.Scope.Definition
+      with Diagnostic {
     override def mapExpressions(fn: Expression => Expression):      Error
     override def setLocation(location: Option[IdentifiedLocation]): Error
     override def duplicate(

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/ComplexType.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/ComplexType.scala
@@ -169,6 +169,7 @@ case object ComplexType extends IRPass {
         matchSignaturesAndGenerate(name, binding)
       case funSugar @ IR.Function.Binding(name, _, _, _, _, _, _) =>
         matchSignaturesAndGenerate(name, funSugar)
+      case err: IR.Error => Seq(err)
       case _ =>
         throw new CompilerError("Unexpected IR node in complex type body.")
     }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
@@ -159,7 +159,7 @@ trait InterpreterRunner {
       interpreterContext.executionContext.evalModule(code, "Test")
     )
     val assocCons    = module.getAssociatedConstructor
-    val mainFunction = module.getMethod(assocCons, "main")
+    val mainFunction = module.getMethod(assocCons, "main").get
     MainMethod(assocCons, mainFunction)
   }
 

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
@@ -32,7 +32,7 @@ trait PackageTest extends AnyFlatSpec with Matchers with ValueEquality {
       val topScope        = executionContext.getTopScope
       val mainModuleScope = topScope.getModule(mainModule.toString)
       val assocCons       = mainModuleScope.getAssociatedConstructor
-      val mainFun         = mainModuleScope.getMethod(assocCons, "main")
+      val mainFun         = mainModuleScope.getMethod(assocCons, "main").get
       mainFun.execute(assocCons)
     }
   }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/CodeLocationsTest.scala
@@ -216,7 +216,7 @@ class CodeLocationsTest extends InterpreterTest {
 
       val mod    = interpreterContext.executionContext.evalModule(code, "Test")
       val tpe    = mod.getAssociatedConstructor
-      val method = mod.getMethod(tpe, "foo")
+      val method = mod.getMethod(tpe, "foo").get
       method.value.invokeMember(
         MethodNames.Function.GET_SOURCE_START
       ) shouldEqual 1

--- a/test/Tests/src/Data/Array_Spec.enso
+++ b/test/Tests/src/Data/Array_Spec.enso
@@ -1,0 +1,12 @@
+from Standard.Base import all
+
+import Standard.Test
+
+spec = Test.group "Arrays" <|
+    Test.specify "should be able to be converted to a visualization rep" <|
+        arr = Vector.fill 1000 0 |> .to_array
+        text = arr.to_default_visualization_data
+        json = Json.parse text
+        as_vec = json.into (Vector.Vector Number)
+        as_vec.should_equal <| Vector.fill 100 0
+

--- a/test/Tests/src/Data/Array_Spec.enso
+++ b/test/Tests/src/Data/Array_Spec.enso
@@ -4,7 +4,7 @@ import Standard.Test
 
 spec = Test.group "Arrays" <|
     Test.specify "should be able to be converted to a visualization rep" <|
-        arr = Vector.fill 1000 0 |> .to_array
+        arr = Vector.fill 1000 0 . to_array
         text = arr.to_default_visualization_data
         json = Json.parse text
         as_vec = json.into (Vector.Vector Number)

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -169,3 +169,7 @@ spec = Test.group "Vectors" <|
         fail a = Error.throw <| My_Error a
         [fail 1].map (x -> x.catch (x -> x.a)) . should_equal [1]
         [1].map fail . map .catch . should_equal [My_Error 1]
+    Test.specify "should be able to be efficiently converted to a visualisation" <|
+        vec = Vector.fill 1000 0
+        text = vec.to_default_visualisation_data
+        IO.println text

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -171,5 +171,8 @@ spec = Test.group "Vectors" <|
         [1].map fail . map .catch . should_equal [My_Error 1]
     Test.specify "should be able to be efficiently converted to a visualisation" <|
         vec = Vector.fill 1000 0
-        text = vec.to_default_visualisation_data
-        IO.println text
+        text = vec.to_default_visualization_data
+        json = Json.parse text
+        as_vec = json.into (Vector.Vector Number)
+        as_vec.should_equal <| Vector.fill 100 0
+

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -39,34 +39,34 @@ import Tests.System.File_Spec
 import Tests.System.Process_Spec
 
 main = Test.Suite.runMain <|
-    Any_Spec.spec
-    Case_Spec.spec
-    Deep_Export_Spec.spec
-    Error_Spec.spec
-    File_Spec.spec
-    Http_Header_Spec.spec
-    Http_Request_Spec.spec
-    Http_Spec.spec
-    Import_Loop_Spec.spec
-    Interval_Spec.spec
-    Java_Interop_Spec.spec
-    Js_Interop_Spec.spec
-    Json_Spec.spec
-    List_Spec.spec
-    Locale_Spec.spec
-    Map_Spec.spec
-    Maybe_Spec.spec
-    Meta_Spec.spec
-    Names_Spec.spec
-    Noise_Generator_Spec.spec
-    Noise_Spec.spec
-    Numbers_Spec.spec
-    Ordering_Spec.spec
-    Process_Spec.spec
-    Python_Interop_Spec.spec
-    R_Interop_Spec.spec
-    Range_Spec.spec
-    Text_Spec.spec
-    Time_Spec.spec
-    Uri_Spec.spec
+    # Any_Spec.spec
+    # Case_Spec.spec
+    # Deep_Export_Spec.spec
+    # Error_Spec.spec
+    # File_Spec.spec
+    # Http_Header_Spec.spec
+    # Http_Request_Spec.spec
+    # Http_Spec.spec
+    # Import_Loop_Spec.spec
+    # Interval_Spec.spec
+    # Java_Interop_Spec.spec
+    # Js_Interop_Spec.spec
+    # Json_Spec.spec
+    # List_Spec.spec
+    # Locale_Spec.spec
+    # Map_Spec.spec
+    # Maybe_Spec.spec
+    # Meta_Spec.spec
+    # Names_Spec.spec
+    # Noise_Generator_Spec.spec
+    # Noise_Spec.spec
+    # Numbers_Spec.spec
+    # Ordering_Spec.spec
+    # Process_Spec.spec
+    # Python_Interop_Spec.spec
+    # R_Interop_Spec.spec
+    # Range_Spec.spec
+    # Text_Spec.spec
+    # Time_Spec.spec
+    # Uri_Spec.spec
     Vector_Spec.spec

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -15,6 +15,7 @@ import Tests.Semantic.Js_Interop_Spec
 import Tests.Semantic.Python_Interop_Spec
 import Tests.Semantic.R_Interop_Spec
 
+import Tests.Data.Array_Spec
 import Tests.Data.Interval_Spec
 import Tests.Data.Json_Spec
 import Tests.Data.List_Spec
@@ -39,34 +40,35 @@ import Tests.System.File_Spec
 import Tests.System.Process_Spec
 
 main = Test.Suite.runMain <|
-    # Any_Spec.spec
-    # Case_Spec.spec
-    # Deep_Export_Spec.spec
-    # Error_Spec.spec
-    # File_Spec.spec
-    # Http_Header_Spec.spec
-    # Http_Request_Spec.spec
-    # Http_Spec.spec
-    # Import_Loop_Spec.spec
-    # Interval_Spec.spec
-    # Java_Interop_Spec.spec
-    # Js_Interop_Spec.spec
-    # Json_Spec.spec
-    # List_Spec.spec
-    # Locale_Spec.spec
-    # Map_Spec.spec
-    # Maybe_Spec.spec
-    # Meta_Spec.spec
-    # Names_Spec.spec
-    # Noise_Generator_Spec.spec
-    # Noise_Spec.spec
-    # Numbers_Spec.spec
-    # Ordering_Spec.spec
-    # Process_Spec.spec
-    # Python_Interop_Spec.spec
-    # R_Interop_Spec.spec
-    # Range_Spec.spec
-    # Text_Spec.spec
-    # Time_Spec.spec
-    # Uri_Spec.spec
+    Any_Spec.spec
+    Array_Spec.spec
+    Case_Spec.spec
+    Deep_Export_Spec.spec
+    Error_Spec.spec
+    File_Spec.spec
+    Http_Header_Spec.spec
+    Http_Request_Spec.spec
+    Http_Spec.spec
+    Import_Loop_Spec.spec
+    Interval_Spec.spec
+    Java_Interop_Spec.spec
+    Js_Interop_Spec.spec
+    Json_Spec.spec
+    List_Spec.spec
+    Locale_Spec.spec
+    Map_Spec.spec
+    Maybe_Spec.spec
+    Meta_Spec.spec
+    Names_Spec.spec
+    Noise_Generator_Spec.spec
+    Noise_Spec.spec
+    Numbers_Spec.spec
+    Ordering_Spec.spec
+    Process_Spec.spec
+    Python_Interop_Spec.spec
+    R_Interop_Spec.spec
+    Range_Spec.spec
+    Text_Spec.spec
+    Time_Spec.spec
+    Uri_Spec.spec
     Vector_Spec.spec


### PR DESCRIPTION
### Pull Request Description
This PR fixes an issue with the Array visualisation code that was returning `null`. It also updates the way we do visualisations for Vectors, and improves some error messages in the `Json` module.

Closes #1584.
Closes #1576.
Closes #1586.
Closes #1585.

### Important Notes
N/A

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
