### PR TITLE
Make the process library more IDE-friendly

### DIFF
--- a/distribution/std-lib/Standard/src/Base/System/Process.enso
+++ b/distribution/std-lib/Standard/src/Base/System/Process.enso
@@ -4,44 +4,42 @@ from Standard.Base.Data.Vector import Vector
 from Builtins import Array, System, True, False
 
 ## The builder object that is used to create operating system processes.
-type Process_Builder command arguments stdin
+type Builder
+    type Builder command arguments=[] stdin=""
+
+    ## Sets the arguments that should be passed to the created process.
+    set_arguments : Vector.Vector Text -> Builder
+    set_arguments arguments = Builder this.command arguments this.stdin
+
+    ## Sets the text that will be used to feed standard input to the created
+       process.
+    set_stdin : Text -> Builder
+    set_stdin stdin = Builder this.command this.arguments stdin
+
+    ## Create a process using a builder returning the result of execution.
+
+       > Example
+         Create a script redirecting the input to stdout:
+             builder = Process.builder "bash" ["-c", "read line; echo -n $line"] "test"
+             builder.create
+         The result is:
+             Process_Result Exit_Success "test" ""
+    create : Result
+    create =
+        result = System.create_process this.command this.arguments.to_array this.stdin redirect_in=False redirect_out=False redirect_err=False
+        Result (Exit_Code.from_number result.exit_code) result.stdout result.stderr
 
 ## The result of the process invocation.
-type Process_Result exit_code stdout stderr
-
-## Call a system executable by name.
-
-   > Example
-     Call the `nproc` command:
-         Process.execute "nproc"
-     The result is printed to stdout:
-         8
-Process.execute : String -> Exit_Code
-Process.execute command =
-    result = System.create_process command (arguments = Array.empty) (input = "") (redirectIn = True) (redirectOut = True) (redirectErr = True)
-    Exit_Code.from_number result.exit_code
+type Result exit_code stdout stderr
 
 ## Call a command with a list of arguments.
 
    > Example
      Call the `echo` command with arguments
-         Process.run_command "echo" ["-n", "Hello!"]
+         Process.run "echo" ["-n", "Hello!"]
      The result is printed to stdout:
          Hello!
-Process.run_command : String -> Vector.Vector -> Exit_Code
-Process.run_command command arguments =
-    result = System.create_process command arguments.to_array (input = "") (redirectIn = True) (redirectOut = True) (redirectErr = True)
+run : Text -> Vector.Vector Text -> Exit_Code
+run command arguments=[] =
+    result = System.create_process command arguments.to_array input="" redirect_in=True redirect_out=True redirect_err=True
     Exit_Code.from_number result.exit_code
-
-## Create a process using a builder returning the result of execution.
-
-   > Example
-     Create a script redirecting the input to stdout:
-         builder = Process_Builder "bash" ["-c", "read line; echo -n $line"] "test"
-         Process.create_process builder
-     The result is:
-         Process_Result Exit_Success "test" ""
-Process.create : Process_Builder -> Process_Result
-Process.create b =
-    result = System.create_process b.command b.arguments.to_array b.stdin (redirectIn = False) (redirectOut = False) (redirectErr = False)
-    Process_Result (Exit_Code.from_number result.exit_code) result.stdout result.stderr

--- a/distribution/std-lib/Standard/src/Base/System/Process.enso
+++ b/distribution/std-lib/Standard/src/Base/System/Process.enso
@@ -3,20 +3,28 @@ import Standard.Base.System.Process.Exit_Code
 from Standard.Base.Data.Vector import Vector
 from Builtins import Array, System, True, False
 
-## The builder object that is used to create operating system processes.
+## UNSTABLE
+
+   The builder object that is used to create operating system processes.
 type Builder
     type Builder command arguments=[] stdin=""
 
-    ## Sets the arguments that should be passed to the created process.
+    ## UNSTABLE
+
+       Sets the arguments that should be passed to the created process.
     set_arguments : Vector.Vector Text -> Builder
     set_arguments arguments = Builder this.command arguments this.stdin
 
-    ## Sets the text that will be used to feed standard input to the created
+    ## UNSTABLE
+
+       Sets the text that will be used to feed standard input to the created
        process.
     set_stdin : Text -> Builder
     set_stdin stdin = Builder this.command this.arguments stdin
 
-    ## Create a process using a builder returning the result of execution.
+    ## UNSTABLE
+
+       Create a process using a builder returning the result of execution.
 
        > Example
          Create a script redirecting the input to stdout:
@@ -29,10 +37,14 @@ type Builder
         result = System.create_process this.command this.arguments.to_array this.stdin redirect_in=False redirect_out=False redirect_err=False
         Result (Exit_Code.from_number result.exit_code) result.stdout result.stderr
 
-## The result of the process invocation.
+## UNSTABLE
+
+   The result of the process invocation.
 type Result exit_code stdout stderr
 
-## Call a command with a list of arguments.
+## UNSTABLE
+
+   Call a command with a list of arguments.
 
    > Example
      Call the `echo` command with arguments

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/system/CreateProcessNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/system/CreateProcessNode.java
@@ -32,9 +32,9 @@ public abstract class CreateProcessNode extends Node {
       Object command,
       Array arguments,
       Object input,
-      boolean redirectIn,
-      boolean redirectOut,
-      boolean redirectErr);
+      boolean redirect_in,
+      boolean redirect_out,
+      boolean redirect_err);
 
   @Specialization
   @CompilerDirectives.TruffleBoundary

--- a/test/Tests/src/System/Process_Spec.enso
+++ b/test/Tests/src/System/Process_Spec.enso
@@ -10,39 +10,35 @@ spec = Test.group "Process" <|
     Test.specify "should call simple command" <|
         result = case Platform.os of
             Platform.Windows ->
-                Process.run_command "PowerShell" ["-Command", "exit 0"]
+                Process.run "PowerShell" ["-Command", "exit 0"]
             _ ->
-                Process.run_command "bash" ["-c", "exit 0"]
-        case result of
-            Exit_Success -> Test.Success
-            Exit_Failure code -> Test.fail ("Process failed with code " + code)
+                Process.run "bash" ["-c", "exit 0"]
+        result.should_equal Exit_Success
     Test.specify "should return exit code" <|
         case Platform.os of
             Platform.Windows ->
-                case Process.run_command "PowerShell" ["-Command", "exit 42"] of
-                    Exit_Success -> Test.fail "Process exist code mismatch"
-                    Exit_Failure code -> code.should_equal 42
+                r = Process.run "PowerShell" ["-Command", "exit 42"]
+                r.should_equal <| Exit_Failure 42
             _ ->
-                case Process.run_command "bash" ["-c", "exit 42"] of
-                    Exit_Success -> Test.fail "Process exit code mismatch."
-                    Exit_Failure code -> code.should_equal 42
+                r = Process.run "bash" ["-c", "exit 42"]
+                r.should_equal <| Exit_Failure 42
     Test.specify "should return stdout" <|
         case Platform.os of
             Platform.Linux ->
-                builder = Process.Process_Builder "bash" ["-c", "echo -n Hello"] ""
-                result = Process.create builder
+                builder = Process.builder "bash" ["-c", "echo -n Hello"]
+                result = builder.create
                 result.exit_code.to_number . should_equal 0
                 result.stdout . should_equal "Hello"
                 result.stderr . should_equal ""
             Platform.MacOS ->
-                builder = Process.Process_Builder "bash" ["-c", "echo -n Hello"] ""
-                result = Process.create builder
+                builder = Process.builder "bash" ["-c", "echo -n Hello"]
+                result = builder.create
                 result.exit_code.to_number . should_equal 0
                 result.stdout . should_equal "Hello"
                 result.stderr . should_equal ""
             Platform.Windows ->
-                builder = Process.Process_Builder "PowerShell" ["-Command", "[System.Console]::Out.Write('Hello')"] ""
-                result = Process.create builder
+                builder = Process.builder "PowerShell" ["-Command", "[System.Console]::Out.Write('Hello')"]
+                result = builder.create
                 result.exit_code.to_number . should_equal 0
                 result.stdout . should_equal "Hello"
                 result.stderr . should_equal ""
@@ -51,20 +47,20 @@ spec = Test.group "Process" <|
     Test.specify "should return stderr" <|
         case Platform.os of
             Platform.Linux ->
-                builder = Process.Process_Builder "bash" ["-c", "echo -n Error 1>&2"] ""
-                result = Process.create builder
+                builder = Process.builder "bash" ["-c", "echo -n Error 1>&2"]
+                result = builder.create
                 result.exit_code.to_number . should_equal 0
                 result.stdout . should_equal ""
                 result.stderr . should_equal "Error"
             Platform.MacOS ->
-                builder = Process.Process_Builder "bash" ["-c", "echo -n Error 1>&2"] ""
-                result = Process.create builder
+                builder = Process.builder "bash" ["-c", "echo -n Error 1>&2"] ""
+                result = builder.create
                 result.exit_code.to_number . should_equal 0
                 result.stdout . should_equal ""
                 result.stderr . should_equal "Error"
             Platform.Windows ->
-                builder = Process.Process_Builder "PowerShell" ["-Command", "[System.Console]::Error.Write('Error')"] ""
-                result = Process.create builder
+                builder = Process.builder "PowerShell" ["-Command", "[System.Console]::Error.Write('Error')"] ""
+                result = builder.create
                 result.exit_code.to_number . should_equal 0
                 result.stdout . should_equal ""
                 result.stderr . should_equal "Error"
@@ -73,20 +69,20 @@ spec = Test.group "Process" <|
     Test.specify "should feed stdin" <|
         case Platform.os of
             Platform.Linux ->
-                builder = Process.Process_Builder "bash" ["-c", "read line; echo -n $line"] "sample"
-                result = Process.create builder
+                builder = Process.builder "bash" ["-c", "read line; echo -n $line"] . set_stdin "sample"
+                result = builder.create
                 result.exit_code.to_number . should_equal 0
                 result.stdout . should_equal "sample"
                 result.stderr . should_equal ""
             Platform.MacOS ->
-                builder = Process.Process_Builder "bash" ["-c", "read line; echo -n $line"] "sample"
-                result = Process.create builder
+                builder = Process.builder "bash" ["-c", "read line; echo -n $line"] . set_stdin "sample"
+                result = builder.create
                 result.exit_code.to_number . should_equal 0
                 result.stdout . should_equal "sample"
                 result.stderr . should_equal ""
             Platform.Windows ->
-                builder = Process.Process_Builder "PowerShell" ["-Command", "[System.Console]::ReadLine()"] "sample"
-                result = Process.create builder
+                builder = Process.builder "PowerShell" ["-Command", "[System.Console]::ReadLine()"] . set_stdin "sample"
+                result = builder.create
                 result.exit_code.to_number . should_equal 0
                 result.stdout . should_equal 'sample\r\n'
                 result.stderr . should_equal ""


### PR DESCRIPTION
### Pull Request Description
Makes the Process API require fewer arguments upfront, making it more IDE friendly.

### Important Notes
This is a much smaller change than actually needed for this library.
The fact that it uses Text to handle std streams is plain wrong – it should be using streams instead, such that
piping can be done without any memory overhead. This, however, will break in the presence of caching, until we have
proper support for streaming data in the interactive mode. Therefore this change is mostly cosmetic and the whole thing is marked unstable. 

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
