### PR TITLE
Fix Table Visualization When No Index Is Present

### DIFF
--- a/distribution/std-lib/Standard/src/Visualization/Table/Visualization.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Table/Visualization.enso
@@ -16,8 +16,10 @@ prepare_visualization x max_rows = Helpers.recover_errors <| case x of
     Dataframe_Table.Table _ ->
         dataframe = x.take_start max_rows
         all_rows_count = x.row_count
-        indices = [dataframe.index] . catch _-> []
-        here.make_json dataframe indices all_rows_count
+        included_rows = dataframe.row_count
+        index = dataframe.index.catch _->
+            Dataframe_Column.from_vector "" (Vector.new included_rows i->i)
+        here.make_json dataframe [index] all_rows_count
 
     Database_Table.Table _ _ _ _ ->
         # Materialize a table with indices as normal columns (because dataframe does not support multi-indexing).


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Fixes an issue introduced in #1582 
- the code would fail for dataframes with no index set
- dataframes without index would not get their default 0-N index displayed

With these changes these issues are resolved.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

- It would be very important to merge this before the upcoming release.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
