### PR TITLE
Histogram and Scatterplot visualizations support for Table

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -236,6 +236,7 @@ jobs:
           $ENGINE_DIST_DIR/bin/enso --run test/Table_Tests
           $ENGINE_DIST_DIR/bin/enso --run test/Database_Tests
           $ENGINE_DIST_DIR/bin/enso --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso --run test/Visualization_Tests
 
       - name: Test Engine Distribution (Windows)
         shell: bash
@@ -245,6 +246,7 @@ jobs:
           $ENGINE_DIST_DIR/bin/enso.bat --run test/Table_Tests
           $ENGINE_DIST_DIR/bin/enso.bat --run test/Database_Tests
           $ENGINE_DIST_DIR/bin/enso.bat --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --run test/Visualization_Tests
 
       # Publish
       - name: Publish the Engine Distribution Artifact

--- a/distribution/std-lib/Standard/src/Visualization/Helpers.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Helpers.enso
@@ -1,8 +1,31 @@
 from Standard.Base import all
 
+import Standard.Table.Data.Column
+import Standard.Table.Data.Storage
+import Standard.Table.Data.Table
+
 ## PRIVATE
 recover_errors ~body =
     result = Panic.recover body
     result.catch err->
         Json.from_pairs [["error", err.to_display_text]] . to_text
 
+## PRIVATE
+
+   Returns all the columns in the table, including indices.
+   Index columns are placed after other columns.
+Table.Table.all_columns : Vector
+Table.Table.all_columns =
+    index = this.index.catch (_-> [])
+    index_columns = case index of
+        Vector.Vector _ -> index
+        _               -> [this.index]
+    this.columns + index_columns
+
+
+## PRIVATE
+
+  Checks if the column stores numbers.
+Column.Column.is_numeric : Bool
+Column.Column.is_numeric =
+    [Storage.Integer,Storage.Decimal].contains this.storage_type

--- a/distribution/std-lib/Standard/src/Visualization/Helpers.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Helpers.enso
@@ -5,6 +5,12 @@ import Standard.Table.Data.Storage
 import Standard.Table.Data.Table
 
 ## PRIVATE
+Any.catch_ ~val = this.catch (_-> val)
+
+## PRIVATE
+Error.catch_ ~val = this.catch (_-> val)
+
+## PRIVATE
 recover_errors ~body =
     result = Panic.recover body
     result.catch err->

--- a/distribution/std-lib/Standard/src/Visualization/Helpers.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Helpers.enso
@@ -5,12 +5,15 @@ import Standard.Table.Data.Storage
 import Standard.Table.Data.Table
 
 ## PRIVATE
+Any.catch_: Any -> Any
 Any.catch_ ~val = this.catch (_-> val)
 
 ## PRIVATE
+Any.catch_ : Any -> Any
 Error.catch_ ~val = this.catch (_-> val)
 
 ## PRIVATE
+recover_errors : Any -> Any
 recover_errors ~body =
     result = Panic.recover body
     result.catch err->
@@ -19,19 +22,19 @@ recover_errors ~body =
 ## PRIVATE
 
    Returns all the columns in the table, including indices.
-   Index columns are placed after other columns.
+   Index columns are placed before other columns.
 Table.Table.all_columns : Vector
 Table.Table.all_columns =
-    index = this.index.catch (_-> [])
+    index = this.index.catch_ []
     index_columns = case index of
         Vector.Vector _ -> index
-        _               -> [this.index]
-    this.columns + index_columns
+        a               -> [a]
+    index_columns + this.columns
 
 
 ## PRIVATE
 
   Checks if the column stores numbers.
-Column.Column.is_numeric : Bool
+Column.Column.is_numeric : Boolean
 Column.Column.is_numeric =
     [Storage.Integer,Storage.Decimal].contains this.storage_type

--- a/distribution/std-lib/Standard/src/Visualization/Helpers.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Helpers.enso
@@ -28,7 +28,7 @@ Table.Table.all_columns =
     index = this.index.catch_ []
     index_columns = case index of
         Vector.Vector _ -> index
-        a               -> [a]
+        a -> [a]
     index_columns + this.columns
 
 

--- a/distribution/std-lib/Standard/src/Visualization/Histogram.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Histogram.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table.Data.Column import Column
-
+import Standard.Table.Data.Column
 import Standard.Table.Data.Table
 import Standard.Visualization.Helpers
 

--- a/distribution/std-lib/Standard/src/Visualization/Histogram.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Histogram.enso
@@ -7,15 +7,15 @@ import Standard.Visualization.Helpers
 
 ## PRIVATE
    Get first numeric column of the table.
-first_numeric : Table -> Column ! Nothing
-first_numeric table = table.columns.find _.is_numeric
+Table.Table.first_numeric : Table -> Column ! Nothing
+Table.Table.first_numeric = this.all_columns.find _.is_numeric
 
 ## PRIVATE
    Get the value column - the column that will be used to create histogram.
-value_column : Table -> Column ! Nothing
-value_column table = 
-    named_col = table.at 'value'
-    named_col.catch_ <| here.first_numeric table
+Table.Table.value_column : Table -> Column ! Nothing
+Table.Table.value_column = 
+    named_col = this.at 'value'
+    named_col.catch_ <| this.first_numeric
 
 ## PRIVATE
    Information that are placed in an update sent to a visualization.
@@ -25,7 +25,7 @@ type Update
 
     ## PRIVATE
        Generate JSON that can be consumed by the visualization.
-    from_table : Object
+    to_json : Object
     to_json = 
         data = ['data', Json.from_pairs [['values', this.values]]]
         axis = ['axis', Json.from_pairs [['x', Json.from_pairs [['label', this.label]]]]]
@@ -35,15 +35,15 @@ type Update
         Json.from_pairs ret_pairs
 
 ## PRIVATE
-from_table : Vector -> Update
+from_table : Table -> Update
 from_table table = 
-    col = here.value_column table
+    col = table.value_column
     label = col.name.catch_ Nothing
     values = col.to_vector.catch_ []
     Update values label
 
 ## PRIVATE
-from_value : Vector -> Update
+from_vector : Vector -> Update
 from_vector vector = 
     Update vector Nothing
 

--- a/distribution/std-lib/Standard/src/Visualization/Histogram.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Histogram.enso
@@ -5,6 +5,56 @@ from Standard.Table.Data.Column import Column
 import Standard.Table.Data.Table
 import Standard.Visualization.Helpers
 
+## PRIVATE
+   Get first numeric column of the table.
+first_numeric : Table -> Column ! Nothing
+first_numeric table = table.columns.find _.is_numeric
+
+## PRIVATE
+   Get the value column - the column that will be used to create histogram.
+value_column : Table -> Column ! Nothing
+value_column table = 
+    named_col = table.at 'value'
+    named_col.catch_ <| here.first_numeric table
+
+## PRIVATE
+   Information that are placed in an update sent to a visualization.
+type Update
+    ## PRIVATE
+    type Update values label
+
+    ## PRIVATE
+       Generate JSON that can be consumed by the visualization.
+    from_table : Object
+    to_json = 
+        data = ['data', Json.from_pairs [['values', this.values]]]
+        axis = ['axis', Json.from_pairs [['x', Json.from_pairs [['label', this.label]]]]]
+        ret_pairs = case this.label of
+            Nothing -> [data]
+            _       -> [axis,data]
+        Json.from_pairs ret_pairs
+
+## PRIVATE
+from_table : Vector -> Update
+from_table table = 
+    col = here.value_column table
+    label = col.name.catch_ Nothing
+    values = col.to_vector.catch_ []
+    Update values label
+
+## PRIVATE
+from_value : Vector -> Update
+from_vector vector = 
+    Update vector Nothing
+
+## PRIVATE
+from_value : Any -> Update
+from_value value = 
+    case value of
+        Table.Table _   -> here.from_table value
+        Vector.Vector _ -> here.from_vector value
+        Column.Column _ -> here.from_table value.to_table
+        _               -> here.from_vector value.to_vector
 
 ## PRIVATE
 
@@ -16,15 +66,5 @@ import Standard.Visualization.Helpers
    - value: the value to be visualized.
 process_to_json_text : Any -> Text
 process_to_json_text value = 
-    values = case value of
-        Table.Table _   -> 
-            value_col = value.at 'value' 
-            col       = value_col.catch (_-> value.columns.find _.is_numeric)
-            col.to_vector.catch (_-> [])
-            
-        Vector.Vector _ -> value
-        _               -> value.to_vector
-    
-    data = Json.from_pairs [['values', values]]
-    ret  = Json.from_pairs [["data", data]]
-    ret.to_text
+    update = here.from_value value
+    update.to_json.to_text

--- a/distribution/std-lib/Standard/src/Visualization/Histogram.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Histogram.enso
@@ -1,0 +1,30 @@
+from Standard.Base import all
+
+from Standard.Table.Data.Column import Column
+
+import Standard.Table.Data.Table
+import Standard.Visualization.Helpers
+
+
+## PRIVATE
+
+   Default preprocessor for the histogram visualization.
+
+   Generates JSON text describing the histogram visualization.
+
+   Arguments:
+   - value: the value to be visualized.
+process_to_json_text : Any -> Text
+process_to_json_text value = 
+    values = case value of
+        Table.Table _   -> 
+            value_col = value.at 'value' 
+            col       = value_col.catch (_-> value.columns.find _.is_numeric)
+            col.to_vector.catch (_-> [])
+            
+        Vector.Vector _ -> value
+        _               -> value.to_vector
+    
+    data = Json.from_pairs [['values', values]]
+    ret  = Json.from_pairs [["data", data]]
+    ret.to_text

--- a/distribution/std-lib/Standard/src/Visualization/Scatter_Plot.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Scatter_Plot.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table.Data.Column import Column
-
+import Standard.Table.Data.Column
 import Standard.Table.Data.Table
 import Standard.Visualization.Helpers
 

--- a/distribution/std-lib/Standard/src/Visualization/Scatter_Plot.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Scatter_Plot.enso
@@ -6,6 +6,19 @@ import Standard.Table.Data.Table
 import Standard.Visualization.Helpers
 
 ## PRIVATE
+    Name of the index column that may be generated to plot against.
+index_name = 'index'
+
+## PRIVATE
+data_field = 'data'
+
+## PRIVATE
+axis_field = 'axis'
+
+## PRIVATE
+label_field = 'label'
+
+## PRIVATE
    
    Represents a recognized point data field for a scatter plot visualization.
 type PointData 
@@ -29,7 +42,7 @@ type PointData
     all_fields = [X,Y,Color,Shape,Label,Size]
 
     ## PRIVATE
-    recognized_names = [X,Y,Color,Shape,Label,Size].map _.name
+    recognized_names = this.all_fields.map _.name
 
     ## PRIVATE
     is_recognized column = this.recognized_names.contains column.name
@@ -39,14 +52,14 @@ type PointData
 
     ## PRIVATE
     fallback_column table = case this of
-        X -> table.index.catch (_-> this.iota table.row_count)
+        X -> table.index.catch_ <| this.iota table.row_count
         Y ->
             x_column         = X.lookup table
             candidates       = table.all_columns
             is_good_enough c = c.is_numeric && c.name != x_column.name
             is_good c        = is_good_enough c && (this.is_recognized c).not
 
-            candidates.find is_good . catch (_-> candidates.find is_good_enough)
+            candidates.find is_good . catch_ <| candidates.find is_good_enough
         _ -> Error.throw Nothing
 
     ## PRIVATE
@@ -56,22 +69,43 @@ type PointData
         # FIXME [mwu]: Adjust once https://github.com/enso-org/enso/issues/1439
         #              is addressed.
         range = 0.up_to <| count + 1
-        Column.from_vector this.name range.to_vector
+        Column.from_vector here.index_name range.to_vector
 
     ## PRIVATE
+    lookup : Table -> Column
     lookup table = 
         named = table.at this.name
-        named.catch (_-> this.fallback_column table . rename this.name)
+        named.catch_ <| this.fallback_column table
 
 ## PRIVATE
+    Generates JSON that describes points data.
 data_from_table : Table -> Object
-data_from_table df = 
-    columns = PointData.all_fields.map (field-> field.lookup df) . filter (column-> column.is_error.not)
+data_from_table df =
+    # IO.println <| "data from table: " + df.to_text
+    get_point_data field = field.lookup df . rename field.name
+    is_valid column = column.is_error.not
+    columns = PointData.all_fields.map get_point_data . filter is_valid
     (0.up_to (df.row_count + 1)).to_vector.map <| row_n-> 
         pairs = columns.map column->
-            value = column.at row_n . catch (_-> Nothing)
+            value = column.at row_n . catch_ Nothing
             [column.name, value]
         Json.from_pairs pairs
+
+## PRIVATE
+    Generates JSON that describes plot axes.
+axes_from_table : Table -> Object
+axes_from_table table =
+    describe_axis field = 
+        col_name = field.lookup table . name
+        label    = Json.from_pairs [[here.label_field, col_name]]
+        [field.name, label]
+    x_axis = describe_axis X
+    y_axis = describe_axis Y
+    is_valid axis_pair =
+        label = axis_pair.at 1
+        label.is_error.not && (table.all_columns.length > 0)
+    axes_obj = Json.from_pairs <| [x_axis, y_axis].filter is_valid
+    if axes_obj.fields.size > 0 then axes_obj else Nothing
 
 ## PRIVATE
 data_from_vector : Vector -> Object
@@ -79,6 +113,19 @@ data_from_vector vec =
         vec.map_with_index <| i-> elem-> 
             Json.from_pairs [[X.name,i],[Y.name,elem]]
 
+## PRIVATE
+json_from_table table = 
+    data = here.data_from_table table
+    # IO.println <| "data: " + data.to_text
+    axes = here.axes_from_table table
+    # IO.println <| "axes: " + axes.to_text
+    Json.from_pairs <| [[here.data_field,data], [here.axis_field, axes]]
+
+## PRIVATE
+json_from_vector vec = 
+    data = [here.data_field,here.data_from_vector vec]
+    axes = [here.axis_field,Nothing]
+    Json.from_pairs [data,axes]
 
 ## PRIVATE
 
@@ -90,11 +137,10 @@ data_from_vector vec =
    - value: the value to be visualized.
 process_to_json_text : Any -> Text
 process_to_json_text value = 
-    data = case value of
-        Table.Table _   -> here.data_from_table  value
-        Vector.Vector _ -> here.data_from_vector value
-        _               -> here.data_from_vector value.to_vector
+    json = case value of
+        Column.Column _ -> here.json_from_table  value.to_table
+        Table.Table _   -> here.json_from_table  value
+        Vector.Vector _ -> here.json_from_vector value
+        _               -> here.json_from_vector value.to_vector
 
-    points = Json.from_pairs [['labels', 'visible']]
-    ret    = Json.from_pairs [['data',data], ['points',points]]
-    ret.to_text
+    json.to_text

--- a/distribution/std-lib/Standard/src/Visualization/Scatter_Plot.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Scatter_Plot.enso
@@ -1,0 +1,100 @@
+from Standard.Base import all
+
+from Standard.Table.Data.Column import Column
+
+import Standard.Table.Data.Table
+import Standard.Visualization.Helpers
+
+## PRIVATE
+   
+   Represents a recognized point data field for a scatter plot visualization.
+type PointData 
+    ## PRIVATE
+    type PointData
+    ## PRIVATE
+    type X
+    ## PRIVATE
+    type Y
+    ## PRIVATE
+    type Color
+    ## PRIVATE
+    type Shape
+    ## PRIVATE
+    type Label
+    ## PRIVATE
+    type Size
+
+    ## PRIVATE
+       Returns all recognized point data fields.
+    all_fields = [X,Y,Color,Shape,Label,Size]
+
+    ## PRIVATE
+    recognized_names = [X,Y,Color,Shape,Label,Size].map _.name
+
+    ## PRIVATE
+    is_recognized column = this.recognized_names.contains column.name
+
+    ## PRIVATE
+    name       = this.to_text.to_lower_case
+
+    ## PRIVATE
+    fallback_column table = case this of
+        X -> table.index.catch (_-> this.iota table.row_count)
+        Y ->
+            x_column         = X.lookup table
+            candidates       = table.all_columns
+            is_good_enough c = c.is_numeric && c.name != x_column.name
+            is_good c        = is_good_enough c && (this.is_recognized c).not
+
+            candidates.find is_good . catch (_-> candidates.find is_good_enough)
+        _ -> Error.throw Nothing
+
+    ## PRIVATE
+       Returns a vector of subsequent integers beginning from 0.
+    iota : Number -> Vector
+    iota count = 
+        # FIXME [mwu]: Adjust once https://github.com/enso-org/enso/issues/1439
+        #              is addressed.
+        range = 0.up_to <| count + 1
+        Column.from_vector this.name range.to_vector
+
+    ## PRIVATE
+    lookup table = 
+        named = table.at this.name
+        named.catch (_-> this.fallback_column table . rename this.name)
+
+## PRIVATE
+data_from_table : Table -> Object
+data_from_table df = 
+    columns = PointData.all_fields.map (field-> field.lookup df) . filter (column-> column.is_error.not)
+    (0.up_to (df.row_count + 1)).to_vector.map <| row_n-> 
+        pairs = columns.map column->
+            value = column.at row_n . catch (_-> Nothing)
+            [column.name, value]
+        Json.from_pairs pairs
+
+## PRIVATE
+data_from_vector : Vector -> Object
+data_from_vector vec = 
+        vec.map_with_index <| i-> elem-> 
+            Json.from_pairs [[X.name,i],[Y.name,elem]]
+
+
+## PRIVATE
+
+   Default preprocessor for the scatterplot visualization.
+   
+   Generates JSON text describing the scatterplot visualization.
+   
+   Arguments:
+   - value: the value to be visualized.
+process_to_json_text : Any -> Text
+process_to_json_text value = 
+    data = case value of
+        Table.Table _   -> here.data_from_table  value
+        Vector.Vector _ -> here.data_from_vector value
+        _               -> here.data_from_vector value.to_vector
+
+    points = Json.from_pairs [['labels', 'visible']]
+    ret    = Json.from_pairs [['data',data], ['points',points]]
+    ret.to_text

--- a/distribution/std-lib/Standard/src/Visualization/Scatter_Plot.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Scatter_Plot.enso
@@ -7,19 +7,22 @@ import Standard.Visualization.Helpers
 
 ## PRIVATE
     Name of the index column that may be generated to plot against.
+index_name : Text
 index_name = 'index'
 
 ## PRIVATE
+data_field : Text
 data_field = 'data'
 
 ## PRIVATE
+axis_field : Text
 axis_field = 'axis'
 
 ## PRIVATE
+label_field : Text
 label_field = 'label'
 
 ## PRIVATE
-   
    Represents a recognized point data field for a scatter plot visualization.
 type PointData 
     ## PRIVATE
@@ -39,25 +42,30 @@ type PointData
 
     ## PRIVATE
        Returns all recognized point data fields.
+    all_fields : Vector
     all_fields = [X,Y,Color,Shape,Label,Size]
 
     ## PRIVATE
+    recognized_names : Vector
     recognized_names = this.all_fields.map _.name
 
     ## PRIVATE
+    is_recognized : Column -> Boolean
     is_recognized column = this.recognized_names.contains column.name
 
     ## PRIVATE
-    name       = this.to_text.to_lower_case
+    name : Text
+    name = this.to_text.to_lower_case
 
     ## PRIVATE
+    fallback_column : Table -> Column ! Nothing
     fallback_column table = case this of
         X -> table.index.catch_ <| this.iota table.row_count
         Y ->
-            x_column         = X.lookup table
-            candidates       = table.all_columns
+            x_column = X.lookup_in table
+            candidates = table.all_columns
             is_good_enough c = c.is_numeric && c.name != x_column.name
-            is_good c        = is_good_enough c && (this.is_recognized c).not
+            is_good c = is_good_enough c && (this.is_recognized c).not
 
             candidates.find is_good . catch_ <| candidates.find is_good_enough
         _ -> Error.throw Nothing
@@ -72,20 +80,19 @@ type PointData
         Column.from_vector here.index_name range.to_vector
 
     ## PRIVATE
-    lookup : Table -> Column
-    lookup table = 
+    lookup_in : Table -> Column
+    lookup_in table = 
         named = table.at this.name
         named.catch_ <| this.fallback_column table
 
 ## PRIVATE
     Generates JSON that describes points data.
-data_from_table : Table -> Object
-data_from_table df =
-    # IO.println <| "data from table: " + df.to_text
-    get_point_data field = field.lookup df . rename field.name
+Table.Table.point_data : Table -> Object
+Table.Table.point_data =
+    get_point_data field = field.lookup_in this . rename field.name
     is_valid column = column.is_error.not
     columns = PointData.all_fields.map get_point_data . filter is_valid
-    (0.up_to (df.row_count + 1)).to_vector.map <| row_n-> 
+    (0.up_to <| this.row_count + 1).to_vector.map <| row_n-> 
         pairs = columns.map column->
             value = column.at row_n . catch_ Nothing
             [column.name, value]
@@ -93,39 +100,38 @@ data_from_table df =
 
 ## PRIVATE
     Generates JSON that describes plot axes.
-axes_from_table : Table -> Object
-axes_from_table table =
+Table.Table.axes : Table -> Object
+Table.Table.axes =
     describe_axis field = 
-        col_name = field.lookup table . name
-        label    = Json.from_pairs [[here.label_field, col_name]]
+        col_name = field.lookup_in this . name
+        label = Json.from_pairs [[here.label_field, col_name]]
         [field.name, label]
     x_axis = describe_axis X
     y_axis = describe_axis Y
     is_valid axis_pair =
         label = axis_pair.at 1
-        label.is_error.not && (table.all_columns.length > 0)
+        label.is_error.not && (this.all_columns.length > 0)
     axes_obj = Json.from_pairs <| [x_axis, y_axis].filter is_valid
     if axes_obj.fields.size > 0 then axes_obj else Nothing
 
 ## PRIVATE
-data_from_vector : Vector -> Object
-data_from_vector vec = 
-        vec.map_with_index <| i-> elem-> 
+Vector.Vector.point_data : Vector -> Object
+Vector.Vector.point_data = 
+        this.map_with_index <| i-> elem-> 
             Json.from_pairs [[X.name,i],[Y.name,elem]]
 
 ## PRIVATE
+
 json_from_table table = 
-    data = here.data_from_table table
-    # IO.println <| "data: " + data.to_text
-    axes = here.axes_from_table table
-    # IO.println <| "axes: " + axes.to_text
+    data = table.point_data
+    axes = table.axes
     Json.from_pairs <| [[here.data_field,data], [here.axis_field, axes]]
 
 ## PRIVATE
 json_from_vector vec = 
-    data = [here.data_field,here.data_from_vector vec]
-    axes = [here.axis_field,Nothing]
-    Json.from_pairs [data,axes]
+    data = [here.data_field, vec.point_data]
+    axes = [here.axis_field, Nothing]
+    Json.from_pairs [data, axes]
 
 ## PRIVATE
 

--- a/test/Visualization_Tests/package.yaml
+++ b/test/Visualization_Tests/package.yaml
@@ -1,0 +1,6 @@
+name: Visualization_Tests
+version: 0.0.1
+enso-version: default
+license: MIT
+author: enso-dev@enso.org
+maintainer: enso-dev@enso.org

--- a/test/Visualization_Tests/src/Helpers_Spec.enso
+++ b/test/Visualization_Tests/src/Helpers_Spec.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table.Data.Table import Table
-from Standard.Table.Data.Column import Column
+import Standard.Table.Data.Table
 import Standard.Test
 import Standard.Visualization.Helpers
 

--- a/test/Visualization_Tests/src/Helpers_Spec.enso
+++ b/test/Visualization_Tests/src/Helpers_Spec.enso
@@ -1,0 +1,35 @@
+from Standard.Base import all
+
+from Standard.Table.Data.Table import Table
+from Standard.Table.Data.Column import Column
+import Standard.Test
+import Standard.Visualization.Helpers
+
+import Visualization_Tests
+
+spec = 
+    Test.group "Table.all_columns" <|
+        Test.specify "works with empty table" <|
+            table  = Table.from_rows [] []
+            table.all_columns.map (_.name) . should_equal []
+
+        Test.specify "works when there is no index set" <|
+            header = ['a', 'b']
+            row_1  = [11 , 10 ]
+            row_2  = [21 , 20 ]
+            table  = Table.from_rows header [row_1, row_2]
+            table.all_columns.map (_.name) . should_equal ['a','b']
+
+        Test.specify "works when there is nothing but index" <|
+            header = ['a']
+            row_1  = [11 ]
+            row_2  = [21 ]
+            table  = Table.from_rows header [row_1, row_2]
+            table.all_columns.map (_.name) . should_equal ['a']
+
+        Test.specify "includes both normal and index columns" <|
+            header = ['a', 'b']
+            row_1  = [11 , 10 ]
+            row_2  = [21 , 20 ]
+            table  = Table.from_rows header [row_1, row_2] . set_index 'a'
+            table.all_columns.map (_.name) . should_equal ['b','a']

--- a/test/Visualization_Tests/src/Helpers_Spec.enso
+++ b/test/Visualization_Tests/src/Helpers_Spec.enso
@@ -32,4 +32,4 @@ spec =
             row_1  = [11 , 10 ]
             row_2  = [21 , 20 ]
             table  = Table.from_rows header [row_1, row_2] . set_index 'a'
-            table.all_columns.map (_.name) . should_equal ['b','a']
+            table.all_columns.map (_.name) . should_equal ['a','b']

--- a/test/Visualization_Tests/src/Histogram_Spec.enso
+++ b/test/Visualization_Tests/src/Histogram_Spec.enso
@@ -1,0 +1,43 @@
+from Standard.Base import all
+
+from Standard.Table.Data.Table import Table
+from Standard.Table.Data.Column import Column
+import Standard.Test
+import Standard.Visualization.Histogram
+
+import Visualization_Tests
+
+spec = 
+    expect value expected_values =
+        text          = Histogram.process_to_json_text value
+        json          = Json.parse text
+        expected_json = Json.from_pairs [['values', expected_values]]
+        json.should_equal expected_json
+
+    Test.group "Histogram Visualization" <|
+    
+        Test.specify "deals with an empty table" <|
+            table  = Table.from_rows [] []
+            expect table []
+
+        Test.specify "plots first column if none recognized" <|
+            header = ['α', 'ω']
+            row_1  = [11 , 10 ]
+            row_2  = [21 , 20 ]
+            table  = Table.from_rows header [row_1, row_2]
+            expect table [11,21]          
+
+        Test.specify "plots 'value' numeric column if present" <|
+            header = ['α', 'value']
+            row_1  = [11 , 10 ]
+            row_2  = [21 , 20 ]
+            table  = Table.from_rows header [row_1, row_2]
+            expect table [10,20]
+        
+        Test.specify "plots vector" <|
+            vector = [1,2,3]
+            expect vector vector
+
+        Test.specify "plots range" <|
+            vector = 2.up_to 4
+            expect vector [2,3,4]

--- a/test/Visualization_Tests/src/Histogram_Spec.enso
+++ b/test/Visualization_Tests/src/Histogram_Spec.enso
@@ -8,36 +8,46 @@ import Standard.Visualization.Histogram
 import Visualization_Tests
 
 spec = 
-    expect value expected_values =
+    expect value expected_label expected_values =
         text          = Histogram.process_to_json_text value
         json          = Json.parse text
-        expected_json = Json.from_pairs [['values', expected_values]]
+        expected_data = Json.from_pairs [['values', expected_values]]
+        expected_json = case expected_label of
+            Nothing -> Json.from_pairs [['data', expected_data]]
+            _       ->
+                expected_x = Json.from_pairs [['label', expected_label]]
+                expected_axis = ['axis', Json.from_pairs [['x', expected_x]]]
+                Json.from_pairs [['data', expected_data], expected_axis]
         json.should_equal expected_json
 
     Test.group "Histogram Visualization" <|
     
         Test.specify "deals with an empty table" <|
             table  = Table.from_rows [] []
-            expect table []
+            expect table Nothing []
 
         Test.specify "plots first column if none recognized" <|
             header = ['α', 'ω']
             row_1  = [11 , 10 ]
             row_2  = [21 , 20 ]
             table  = Table.from_rows header [row_1, row_2]
-            expect table [11,21]          
+            expect table 'α' [11,21]          
 
         Test.specify "plots 'value' numeric column if present" <|
             header = ['α', 'value']
             row_1  = [11 , 10 ]
             row_2  = [21 , 20 ]
             table  = Table.from_rows header [row_1, row_2]
-            expect table [10,20]
+            expect table 'value' [10,20]
+
+        Test.specify "plots column" <|
+            column = Column.from_vector 'my_name' [1,4,6]
+            expect column 'my_name' [1,4,6]    
         
         Test.specify "plots vector" <|
             vector = [1,2,3]
-            expect vector vector
+            expect vector Nothing vector
 
         Test.specify "plots range" <|
             vector = 2.up_to 4
-            expect vector [2,3,4]
+            expect vector Nothing [2,3,4]

--- a/test/Visualization_Tests/src/Histogram_Spec.enso
+++ b/test/Visualization_Tests/src/Histogram_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
-from Standard.Table.Data.Table import Table
-from Standard.Table.Data.Column import Column
+import Standard.Table.Data.Column
+import Standard.Table.Data.Table
 import Standard.Test
 import Standard.Visualization.Histogram
 

--- a/test/Visualization_Tests/src/Histogram_Spec.enso
+++ b/test/Visualization_Tests/src/Histogram_Spec.enso
@@ -9,8 +9,8 @@ import Visualization_Tests
 
 spec = 
     expect value expected_label expected_values =
-        text          = Histogram.process_to_json_text value
-        json          = Json.parse text
+        text = Histogram.process_to_json_text value
+        json = Json.parse text
         expected_data = Json.from_pairs [['values', expected_values]]
         expected_json = case expected_label of
             Nothing -> Json.from_pairs [['data', expected_data]]
@@ -32,6 +32,13 @@ spec =
             row_2  = [21 , 20 ]
             table  = Table.from_rows header [row_1, row_2]
             expect table 'α' [11,21]          
+
+        Test.specify "plots first column if none recognized even if index" <|
+            header = ['α']
+            row_1  = [11 ]
+            row_2  = [21 ]
+            table  = Table.from_rows header [row_1, row_2] . set_index 'α'
+            expect table 'α' [11,21]     
 
         Test.specify "plots 'value' numeric column if present" <|
             header = ['α', 'value']

--- a/test/Visualization_Tests/src/Main.enso
+++ b/test/Visualization_Tests/src/Main.enso
@@ -6,18 +6,7 @@ import Visualization_Tests.Helpers_Spec
 import Visualization_Tests.Histogram_Spec
 import Visualization_Tests.Scatter_Plot_Spec
 
-parse_to_single_field json_text field = 
-    json = Json.parse json_text
-    json.fields.keys.should_equal [field]
-    json.get field
-
-# expect_single_data_field_text json_text field_expected_json_text = 
-#     field     = here.parse_to_single_field json_text 'data'
-#     json_text = field.to_json.to_text
-#     json_text.should_equal field_expected_json_text
-
 main = Test.Suite.runMain <|
-    # Helpers_Spec.spec 
+    Helpers_Spec.spec 
     Histogram_Spec.spec 
     Scatter_Plot_Spec.spec 
-

--- a/test/Visualization_Tests/src/Main.enso
+++ b/test/Visualization_Tests/src/Main.enso
@@ -1,0 +1,23 @@
+from Standard.Base import all
+
+import Standard.Test
+
+import Visualization_Tests.Helpers_Spec
+import Visualization_Tests.Histogram_Spec
+import Visualization_Tests.Scatter_Plot_Spec
+
+parse_to_single_field json_text field = 
+    json = Json.parse json_text
+    json.fields.keys.should_equal [field]
+    json.get field
+
+# expect_single_data_field_text json_text field_expected_json_text = 
+#     field     = here.parse_to_single_field json_text 'data'
+#     json_text = field.to_json.to_text
+#     json_text.should_equal field_expected_json_text
+
+main = Test.Suite.runMain <|
+    # Helpers_Spec.spec 
+    Histogram_Spec.spec 
+    Scatter_Plot_Spec.spec 
+

--- a/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
+++ b/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
-from Standard.Table.Data.Table import Table
-from Standard.Table.Data.Column import Column
+import Standard.Table.Data.Column
+import Standard.Table.Data.Table
 import Standard.Test
 import Standard.Visualization.Scatter_Plot
 

--- a/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
+++ b/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
@@ -8,55 +8,59 @@ import Standard.Visualization.Scatter_Plot
 import Visualization_Tests
 
 spec =
-    expect value data_expected_text = 
+    expect value axis_expected_text data_expected_text = 
         text = Scatter_Plot.process_to_json_text value
         json = Json.parse text
-        json.fields.keys.should_equal ['data','points']
+        json.fields.keys.should_equal ['axis','data']
 
-        expected_points_labels = Json.from_pairs [['labels','visible']]
-        expected_points_pair   = ['points',expected_points_labels]
+        expected_axis_labels   = ['axis', Json.parse axis_expected_text]
         expected_data_pair     = ['data', Json.parse data_expected_text]
-        expected_result        = Json.from_pairs [expected_points_pair, expected_data_pair]
+        expected_result        = Json.from_pairs [expected_axis_labels, expected_data_pair]
         json.should_equal expected_result
+
+    index = Scatter_Plot.index_name
+    axis label = Json.from_pairs [['label',label]]
+    labels x y = Json.from_pairs [['x', axis x], ['y', axis y]] . to_text
+    no_labels  = 'null'
 
     Test.group "Scatter Plot Visualization" <|
     
         Test.specify "deals with an empty table" <|
             table  = Table.from_rows [] []
-            expect table '[]'
+            expect table 'null' '[]'
     
         Test.specify "plots first column if none recognized" <|
             header = ['α', 'ω']
             row_1  = [11 , 10 ]
             row_2  = [21 , 20 ]
             table  = Table.from_rows header [row_1, row_2]
-            expect table '[{"x":0,"y":11},{"x":1,"y":21}]'
+            expect table (labels index 'α') '[{"x":0,"y":11},{"x":1,"y":21}]'
     
         Test.specify "plots 'y' against indices when no 'x' recognized" <|
             header = ['α', 'y']
             row_1 =  [11 , 10 ]
             row_2 =  [21 , 20 ]
             table = Table.from_rows header [row_1, row_2]
-            expect table '[{"x":0,"y":10},{"x":1,"y":20}]'
+            expect table (labels index 'y') '[{"x":0,"y":10},{"x":1,"y":20}]'
             
         Test.specify "recognizes all relevant columns" <|
             header = ['x' , 'y' , 'size' , 'shape'  , 'label' , 'color' ]
             row_1 =  [11  , 10  , 50     , 'square' , 'label' , 'ff0000']
             table = Table.from_rows header [row_1]
-            expect table '[{"color":"ff0000","label":"label","shape":"square","size":50,"x":11,"y":10}]'
+            expect table (labels 'x' 'y') '[{"color":"ff0000","label":"label","shape":"square","size":50,"x":11,"y":10}]'
             
         Test.specify "uses first unrecognized numeric column as `y` fallback" <|
             header = ['x' , 'size' , 'name'   , 'z' , 'ω']
             row_1 =  [11  , 50     , 'circul' ,  20 ,  30]
             table = Table.from_rows header [row_1]
-            expect table '[{"size":50,"x":11,"y":20}]'
+            expect table (labels 'x' 'z') '[{"size":50,"x":11,"y":20}]'
 
         Test.specify "provided only recognized columns" <|
             header = ['x', 'y' , 'bar' , 'size']
             row_1 =  [11 , 10  , 'aa'  , 40    ]
             row_2 =  [21 , 20  , 'bb'  , 50    ]
             table = Table.from_rows header [row_1, row_2]
-            expect table '[{"size":40,"x":11,"y":10},{"size":50,"x":21,"y":20}]'
+            expect table (labels 'x' 'y') '[{"size":40,"x":11,"y":10},{"size":50,"x":21,"y":20}]'
 
         Test.specify "used specified numeric index for x if missing 'x' column from table" <|
             header = [ 'y' , 'foo', 'bar', 'baz' , 'size']
@@ -64,7 +68,7 @@ spec =
             row_2 =  [ 20  , 'bb' , 13   , 15    , 50    ]
             table = Table.from_rows header [row_1, row_2] . set_index 'baz'
             # [TODO] mwu: When it is possible to set multiple index columns, test such case.
-            expect table '[{"size":40,"x":14,"y":10},{"size":50,"x":15,"y":20}]'
+            expect table (labels 'baz' 'y') '[{"size":40,"x":14,"y":10},{"size":50,"x":15,"y":20}]'
           
 
         Test.specify "prefers explicit 'x' to index and looks into indices for recognized fields" <|
@@ -74,32 +78,23 @@ spec =
             table = Table.from_rows header [row_1, row_2] . set_index 'size'
             # FIXME [mwu] Below the `size` field should be present. Depends on 
             #             https://github.com/enso-org/enso/issues/1602
-            expect table '[{"x":10,"y":21},{"x":20,"y":22}]'
+            expect table (labels 'x' 'size') '[{"x":10,"y":21},{"x":20,"y":22}]'
 
         Test.specify "used default index for `x` if none set" <|
             header = [ 'y'  , 'bar' , 'size']
             row_1 =  [ 10   , 'aa'  , 40    ]
             row_2 =  [ 20   , 'bb'  , 50    ]
             table = Table.from_rows header [row_1, row_2]
-            expect table '[{"size":40,"x":0,"y":10},{"size":50,"x":1,"y":20}]'
+            expect table (labels index 'y') '[{"size":40,"x":0,"y":10},{"size":50,"x":1,"y":20}]'
 
         Test.specify "using indices for x if given a vector" <|
             vector = [0,10,20]
-            expect vector '[{"x":0,"y":0},{"x":1,"y":10},{"x":2,"y":20}]'
+            expect vector no_labels '[{"x":0,"y":0},{"x":1,"y":10},{"x":2,"y":20}]'
 
         Test.specify "using indices for x if given a column" <|
-            column = Column.from_vector "some_col" [10,2,3]
-            expect column '[{"x":0,"y":10},{"x":1,"y":2},{"x":2,"y":3}]'
+            column = Column.from_vector 'some_col' [10,2,3]
+            expect column (labels 'index' 'some_col') '[{"x":0,"y":10},{"x":1,"y":2},{"x":2,"y":3}]'
 
         Test.specify "using indices for x if given a range" <|
             value = 2.up_to 4
-            expect value '[{"x":0,"y":2},{"x":1,"y":3},{"x":2,"y":4}]'
-
-        Test.specify "aggregated table" <|
-            name = ['name', ["foo", "bar", "foo", "baz", "foo", "bar", "quux"]]
-            price = ['price', [0.4, 3.5, Nothing, 6.7, Nothing, 97, Nothing]]
-            quantity = ['quantity', [10, 20, 30, 40, 50, 60, 70]]
-            table = Table.new [name, price, quantity] . group 'name'
-            expect table '[{"x":0,"y":2},{"x":1,"y":3},{"x":2,"y":4}]'
-
-            
+            expect value no_labels '[{"x":0,"y":2},{"x":1,"y":3},{"x":2,"y":4}]'

--- a/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
+++ b/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
@@ -1,0 +1,105 @@
+from Standard.Base import all
+
+from Standard.Table.Data.Table import Table
+from Standard.Table.Data.Column import Column
+import Standard.Test
+import Standard.Visualization.Scatter_Plot
+
+import Visualization_Tests
+
+spec =
+    expect value data_expected_text = 
+        text = Scatter_Plot.process_to_json_text value
+        json = Json.parse text
+        json.fields.keys.should_equal ['data','points']
+
+        expected_points_labels = Json.from_pairs [['labels','visible']]
+        expected_points_pair   = ['points',expected_points_labels]
+        expected_data_pair     = ['data', Json.parse data_expected_text]
+        expected_result        = Json.from_pairs [expected_points_pair, expected_data_pair]
+        json.should_equal expected_result
+
+    Test.group "Scatter Plot Visualization" <|
+    
+        Test.specify "deals with an empty table" <|
+            table  = Table.from_rows [] []
+            expect table '[]'
+    
+        Test.specify "plots first column if none recognized" <|
+            header = ['α', 'ω']
+            row_1  = [11 , 10 ]
+            row_2  = [21 , 20 ]
+            table  = Table.from_rows header [row_1, row_2]
+            expect table '[{"x":0,"y":11},{"x":1,"y":21}]'
+    
+        Test.specify "plots 'y' against indices when no 'x' recognized" <|
+            header = ['α', 'y']
+            row_1 =  [11 , 10 ]
+            row_2 =  [21 , 20 ]
+            table = Table.from_rows header [row_1, row_2]
+            expect table '[{"x":0,"y":10},{"x":1,"y":20}]'
+            
+        Test.specify "recognizes all relevant columns" <|
+            header = ['x' , 'y' , 'size' , 'shape'  , 'label' , 'color' ]
+            row_1 =  [11  , 10  , 50     , 'square' , 'label' , 'ff0000']
+            table = Table.from_rows header [row_1]
+            expect table '[{"color":"ff0000","label":"label","shape":"square","size":50,"x":11,"y":10}]'
+            
+        Test.specify "uses first unrecognized numeric column as `y` fallback" <|
+            header = ['x' , 'size' , 'name'   , 'z' , 'ω']
+            row_1 =  [11  , 50     , 'circul' ,  20 ,  30]
+            table = Table.from_rows header [row_1]
+            expect table '[{"size":50,"x":11,"y":20}]'
+
+        Test.specify "provided only recognized columns" <|
+            header = ['x', 'y' , 'bar' , 'size']
+            row_1 =  [11 , 10  , 'aa'  , 40    ]
+            row_2 =  [21 , 20  , 'bb'  , 50    ]
+            table = Table.from_rows header [row_1, row_2]
+            expect table '[{"size":40,"x":11,"y":10},{"size":50,"x":21,"y":20}]'
+
+        Test.specify "used specified numeric index for x if missing 'x' column from table" <|
+            header = [ 'y' , 'foo', 'bar', 'baz' , 'size']
+            row_1 =  [ 10  , 'aa' , 12   , 14    , 40    ]
+            row_2 =  [ 20  , 'bb' , 13   , 15    , 50    ]
+            table = Table.from_rows header [row_1, row_2] . set_index 'baz'
+            # [TODO] mwu: When it is possible to set multiple index columns, test such case.
+            expect table '[{"size":40,"x":14,"y":10},{"size":50,"x":15,"y":20}]'
+          
+
+        Test.specify "prefers explicit 'x' to index and looks into indices for recognized fields" <|
+            header = [ 'x' , 'size']
+            row_1 =  [ 10  , 21  ]
+            row_2 =  [ 20  , 22  ]
+            table = Table.from_rows header [row_1, row_2] . set_index 'size'
+            # FIXME [mwu] Below the `size` field should be present. Depends on 
+            #             https://github.com/enso-org/enso/issues/1602
+            expect table '[{"x":10,"y":21},{"x":20,"y":22}]'
+
+        Test.specify "used default index for `x` if none set" <|
+            header = [ 'y'  , 'bar' , 'size']
+            row_1 =  [ 10   , 'aa'  , 40    ]
+            row_2 =  [ 20   , 'bb'  , 50    ]
+            table = Table.from_rows header [row_1, row_2]
+            expect table '[{"size":40,"x":0,"y":10},{"size":50,"x":1,"y":20}]'
+
+        Test.specify "using indices for x if given a vector" <|
+            vector = [0,10,20]
+            expect vector '[{"x":0,"y":0},{"x":1,"y":10},{"x":2,"y":20}]'
+
+        Test.specify "using indices for x if given a column" <|
+            column = Column.from_vector "some_col" [10,2,3]
+            expect column '[{"x":0,"y":10},{"x":1,"y":2},{"x":2,"y":3}]'
+
+        Test.specify "using indices for x if given a range" <|
+            value = 2.up_to 4
+            expect value '[{"x":0,"y":2},{"x":1,"y":3},{"x":2,"y":4}]'
+
+        Test.specify "aggregated table" <|
+            name = ['name', ["foo", "bar", "foo", "baz", "foo", "bar", "quux"]]
+            price = ['price', [0.4, 3.5, Nothing, 6.7, Nothing, 97, Nothing]]
+            quantity = ['quantity', [10, 20, 30, 40, 50, 60, 70]]
+            table = Table.new [name, price, quantity] . group 'name'
+            expect table '[{"x":0,"y":2},{"x":1,"y":3},{"x":2,"y":4}]'
+
+            


### PR DESCRIPTION
### Pull Request Description
This PR expands the `Visualization` library with code for histogram and scatterplot visualizations, that are currently built into IDE.

There will be PR for IDE making use of these facilities added soon.

### Important Notes
As `Visualization` library had no corresponding test project, I've created one.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
