### PR TITLE
Provide Suggestions for Compatible Types

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
@@ -215,6 +215,12 @@ final class SuggestionsHandler(
         }
         .pipeTo(sender())
 
+    // TODO [AA] New message and message handler in the polyglot-api that contains these subsumption
+    //  relationships.
+    // TODO [AA] Initialize this in `ResourcesInitialization`.
+    // TODO [AA] What should this data look like?
+    // TODO [AA] The primary consideration here is about the `selfType`.
+
     case Completion(path, pos, selfType, returnType, tags) =>
       getModuleName(projectName, path)
         .fold(

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/Suggestions.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/Suggestions.scala
@@ -7,57 +7,95 @@ import org.enso.polyglot.Suggestion
 /** Suggestion instances used in tests. */
 object Suggestions {
 
-  val atom: Suggestion.Atom =
-    Suggestion.Atom(
-      externalId    = None,
-      module        = "Test.Main",
-      name          = "MyType",
-      arguments     = Vector(Suggestion.Argument("a", "Any", false, false, None)),
-      returnType    = "MyAtom",
-      documentation = None
-    )
+  val atom: Suggestion.Atom = Suggestion.Atom(
+    externalId    = None,
+    module        = "Test.Main",
+    name          = "MyType",
+    arguments     = Vector(Suggestion.Argument("a", "Any", false, false, None)),
+    returnType    = "MyAtom",
+    documentation = None
+  )
 
-  val method: Suggestion.Method =
-    Suggestion.Method(
-      externalId =
-        Some(UUID.fromString("ea9d7734-26a7-4f65-9dd9-c648eaf57d63")),
-      module = "Test.Main",
-      name   = "foo",
-      arguments = Vector(
-        Suggestion.Argument("this", "MyType", false, false, None),
-        Suggestion.Argument("foo", "Number", false, true, Some("42"))
-      ),
-      selfType      = "MyType",
-      returnType    = "Number",
-      documentation = Some("Lovely")
-    )
+  val method: Suggestion.Method = Suggestion.Method(
+    externalId = Some(UUID.fromString("ea9d7734-26a7-4f65-9dd9-c648eaf57d63")),
+    module     = "Test.Main",
+    name       = "foo",
+    arguments = Vector(
+      Suggestion.Argument("this", "MyType", false, false, None),
+      Suggestion.Argument("foo", "Number", false, true, Some("42"))
+    ),
+    selfType      = "MyType",
+    returnType    = "Number",
+    documentation = Some("Lovely")
+  )
 
-  val function: Suggestion.Function =
-    Suggestion.Function(
-      externalId =
-        Some(UUID.fromString("78d452ce-ed48-48f1-b4f2-b7f45f8dff89")),
-      module = "Test.Main",
-      name   = "print",
-      arguments = Vector(
-        Suggestion.Argument("a", "Any", false, false, None),
-        Suggestion.Argument("b", "Any", true, false, None),
-        Suggestion.Argument("c", "Any", false, true, Some("C"))
-      ),
-      returnType = "IO",
-      scope =
-        Suggestion.Scope(Suggestion.Position(1, 9), Suggestion.Position(1, 22))
-    )
+  val function: Suggestion.Function = Suggestion.Function(
+    externalId = Some(UUID.fromString("78d452ce-ed48-48f1-b4f2-b7f45f8dff89")),
+    module     = "Test.Main",
+    name       = "print",
+    arguments = Vector(
+      Suggestion.Argument("a", "Any", false, false, None),
+      Suggestion.Argument("b", "Any", true, false, None),
+      Suggestion.Argument("c", "Any", false, true, Some("C"))
+    ),
+    returnType = "IO",
+    scope =
+      Suggestion.Scope(Suggestion.Position(1, 9), Suggestion.Position(1, 22))
+  )
 
-  val local: Suggestion.Local =
-    Suggestion.Local(
-      externalId =
-        Some(UUID.fromString("dc077227-d9b6-4620-9b51-792c2a69419d")),
-      module     = "Test.Main",
-      name       = "x",
-      returnType = "Number",
-      scope =
-        Suggestion.Scope(Suggestion.Position(21, 0), Suggestion.Position(89, 0))
-    )
+  val local: Suggestion.Local = Suggestion.Local(
+    externalId = Some(UUID.fromString("dc077227-d9b6-4620-9b51-792c2a69419d")),
+    module     = "Test.Main",
+    name       = "x",
+    returnType = "Number",
+    scope =
+      Suggestion.Scope(Suggestion.Position(21, 0), Suggestion.Position(89, 0))
+  )
 
-  val all = Seq(atom, method, function, local)
+  val methodOnAny: Suggestion.Method = Suggestion.Method(
+    externalId = Some(UUID.fromString("6cfe1538-5df7-42e4-bf55-64f8ac2ededa")),
+    module     = "Standard.Base.Data.Any.Extensions",
+    name       = "<<",
+    arguments = Vector(
+      Suggestion.Argument("this", "Any", false, false, None),
+      Suggestion.Argument("that", "Any", false, false, None)
+    ),
+    selfType      = "Any",
+    returnType    = "Any",
+    documentation = Some("Lovely")
+  )
+
+  val methodOnNumber: Suggestion.Method = Suggestion.Method(
+    externalId = Some(UUID.fromString("33b426aa-2f74-42c0-9032-1159b5386eac")),
+    module     = "Standard.Base.Data.Number.Extensions",
+    name       = "asin",
+    arguments = Vector(
+      Suggestion.Argument("this", "Number", false, false, None)
+    ),
+    selfType      = "Number",
+    returnType    = "Number",
+    documentation = None
+  )
+
+  val methodOnInteger: Suggestion.Method = Suggestion.Method(
+    externalId = Some(UUID.fromString("2849c0f0-3c27-44df-abcb-5c163dd7ac91")),
+    module     = "Builtins.Main",
+    name       = "+",
+    arguments = Vector(
+      Suggestion.Argument("that", "Number", false, false, None)
+    ),
+    selfType      = "Integer",
+    returnType    = "Number",
+    documentation = Some("Blah, blah")
+  )
+
+  val all = Seq(
+    atom,
+    method,
+    function,
+    local,
+    methodOnAny,
+    methodOnNumber,
+    methodOnInteger
+  )
 }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -524,7 +524,7 @@ class SuggestionsHandlerSpec
 
     "search entries by self type" taggedAs Retry in withDb {
       (config, repo, _, _, handler) =>
-        val (_, Seq(_, methodId, _, _, _, _, _)) =
+        val (_, Seq(_, methodId, _, _, methodOnAnyId, _, _)) =
           Await.result(repo.insertAll(Suggestions.all), Timeout)
         handler ! SearchProtocol.Completion(
           file       = mkModulePath(config, "Main.enso"),
@@ -534,7 +534,12 @@ class SuggestionsHandlerSpec
           tags       = None
         )
 
-        expectMsg(SearchProtocol.CompletionResult(7L, Seq(methodId).flatten))
+        expectMsg(
+          SearchProtocol.CompletionResult(
+            7L,
+            Seq(methodOnAnyId, methodId).flatten
+          )
+        )
     }
 
     "search entries by return type" taggedAs Retry in withDb {

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -6,7 +6,10 @@ import java.util.UUID
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import org.apache.commons.io.FileUtils
-import org.enso.languageserver.capability.CapabilityProtocol.{AcquireCapability, CapabilityAcquired}
+import org.enso.languageserver.capability.CapabilityProtocol.{
+  AcquireCapability,
+  CapabilityAcquired
+}
 import org.enso.languageserver.data._
 import org.enso.languageserver.event.InitializedEvent
 import org.enso.languageserver.filemanager.Path
@@ -91,7 +94,10 @@ class SuggestionsHandlerSpec
         router.expectMsg(
           DeliverToJsonController(
             clientId,
-            SearchProtocol.SuggestionsDatabaseUpdateNotification(4L, updates)
+            SearchProtocol.SuggestionsDatabaseUpdateNotification(
+              Suggestions.all.size.toLong,
+              updates
+            )
           )
         )
 
@@ -150,7 +156,7 @@ class SuggestionsHandlerSpec
           DeliverToJsonController(
             clientId,
             SearchProtocol.SuggestionsDatabaseUpdateNotification(
-              8L,
+              Suggestions.all.size * 2L,
               updatesAdd ++ updatesRemove
             )
           )
@@ -339,6 +345,13 @@ class SuggestionsHandlerSpec
         )
         expectMsg(CapabilityAcquired)
 
+        val suggestions = Seq(
+          Suggestions.atom,
+          Suggestions.method,
+          Suggestions.function,
+          Suggestions.local
+        )
+
         val tree1 = Tree.Root(
           Vector(
             Tree.Node(
@@ -406,7 +419,7 @@ class SuggestionsHandlerSpec
           Tree.Root(Vector())
         )
 
-        val updates2 = Suggestions.all.zipWithIndex.map { case (_, ix) =>
+        val updates2 = suggestions.zipWithIndex.map { case (_, ix) =>
           SearchProtocol.SuggestionsDatabaseUpdate.Remove(ix + 1L)
         }
         router.expectMsg(
@@ -469,7 +482,9 @@ class SuggestionsHandlerSpec
           case Api.Request(_, msg) =>
             fail(s"Runtime connector receive unexpected message: $msg")
         }
-        connector.reply(Api.Response(Api.GetTypeGraphResponse(buildTestTypeGraph)))
+        connector.reply(
+          Api.Response(Api.GetTypeGraphResponse(buildTestTypeGraph))
+        )
 
         connector.expectMsgClass(classOf[Api.Request]) match {
           case Api.Request(_, Api.InvalidateModulesIndexRequest()) =>

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -510,15 +510,21 @@ class SuggestionsHandlerSpec
 
         expectMsg(
           SearchProtocol.CompletionResult(
-            4L,
-            Seq(inserted(0).get, inserted(1).get)
+            7L,
+            Seq(
+              inserted(0).get,
+              inserted(6).get,
+              inserted(4).get,
+              inserted(5).get,
+              inserted(1).get
+            )
           )
         )
     }
 
     "search entries by self type" taggedAs Retry in withDb {
       (config, repo, _, _, handler) =>
-        val (_, Seq(_, methodId, _, _)) =
+        val (_, Seq(_, methodId, _, _, _, _, _)) =
           Await.result(repo.insertAll(Suggestions.all), Timeout)
         handler ! SearchProtocol.Completion(
           file       = mkModulePath(config, "Main.enso"),
@@ -528,12 +534,12 @@ class SuggestionsHandlerSpec
           tags       = None
         )
 
-        expectMsg(SearchProtocol.CompletionResult(4L, Seq(methodId).flatten))
+        expectMsg(SearchProtocol.CompletionResult(7L, Seq(methodId).flatten))
     }
 
     "search entries by return type" taggedAs Retry in withDb {
       (config, repo, _, _, handler) =>
-        val (_, Seq(_, _, functionId, _)) =
+        val (_, Seq(_, _, functionId, _, _, _, _)) =
           Await.result(repo.insertAll(Suggestions.all), Timeout)
         handler ! SearchProtocol.Completion(
           file       = mkModulePath(config, "Main.enso"),
@@ -543,12 +549,12 @@ class SuggestionsHandlerSpec
           tags       = None
         )
 
-        expectMsg(SearchProtocol.CompletionResult(4L, Seq(functionId).flatten))
+        expectMsg(SearchProtocol.CompletionResult(7L, Seq(functionId).flatten))
     }
 
     "search entries by tags" taggedAs Retry in withDb {
       (config, repo, _, _, handler) =>
-        val (_, Seq(_, _, _, localId)) =
+        val (_, Seq(_, _, _, localId, _, _, _)) =
           Await.result(repo.insertAll(Suggestions.all), Timeout)
         handler ! SearchProtocol.Completion(
           file       = mkModulePath(config, "Main.enso"),
@@ -558,7 +564,7 @@ class SuggestionsHandlerSpec
           tags       = Some(Seq(SearchProtocol.SuggestionKind.Local))
         )
 
-        expectMsg(SearchProtocol.CompletionResult(4L, Seq(localId).flatten))
+        expectMsg(SearchProtocol.CompletionResult(7L, Seq(localId).flatten))
     }
   }
 

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/data/TypeGraph.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/data/TypeGraph.scala
@@ -1,0 +1,43 @@
+package org.enso.polyglot.data
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+import scala.collection.mutable
+
+class TypeGraph(defaultRootType: String) {
+  private val parentLinks: mutable.HashMap[String, Set[String]] =
+    mutable.HashMap()
+
+  insertDefault(defaultRootType)
+
+  @JsonIgnore
+  private def insertDefault(name: String): Unit = {
+    parentLinks.update(name, Set())
+  }
+
+  @JsonIgnore
+  def insert(name: String, parent: String): Unit = {
+    parentLinks.updateWith(name) {
+      case Some(parents) => Some(parents + parent)
+      case None          => Some(Set(parent))
+    }
+  }
+
+  @JsonIgnore
+  def getDirectParents(name: String): Set[String] = {
+    parentLinks.getOrElse(name, Set(defaultRootType))
+  }
+
+  @JsonIgnore
+  def getParents(name: String): Set[String] = {
+    var seenNodes: Set[String] = Set()
+
+    val parents = getDirectParents(name)
+    parents ++ parents.flatMap(parent => {
+      if (!seenNodes.contains(parent)) {
+        seenNodes += parent
+        getParents(parent)
+      } else { Set() }
+    })
+  }
+}

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/data/TypeGraph.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/data/TypeGraph.scala
@@ -4,35 +4,73 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 
 import scala.collection.mutable
 
-class TypeGraph(defaultRootType: String) {
-  private val parentLinks: mutable.HashMap[String, Set[String]] =
-    mutable.HashMap()
+/** A collection that represents subsumption relationships between types.
+  *
+  * These relationships are useful for dispatch and for collating suggestions
+  * for users. All names in this collection should be represented fully
+  * qualified.
+  *
+  * This structure is a graph and may contain loops. The query functions will
+  * ensure that an infinite loop doesn't occur in such circumstances.
+  *
+  * This collection does not implement the Any : Any axiom as that is currently
+  * not encoded anywhere in the language.
+  *
+  * @param defaultRootType the name of the root type of the type subsumption
+  *                        hierarchy
+  */
+case class TypeGraph(
+  defaultRootType: String,
+  parentLinks: mutable.HashMap[String, Set[String]] = mutable.HashMap()
+) {
+  insertWithoutParent(defaultRootType)
 
-  insertDefault(defaultRootType)
-
+  /** Inserts a type without a parent into the graph.
+    *
+    * @param name the fully-qualified typename
+    */
   @JsonIgnore
-  private def insertDefault(name: String): Unit = {
+  def insertWithoutParent(name: String): Unit = {
     parentLinks.update(name, Set())
   }
 
+  /** Insert a type-parent relationship into the graph.
+    *
+    * @param typeName the fully-qualified name of the type to set the parent for
+    * @param parentName the fully-qualified name of the parent of `typeName`
+    */
   @JsonIgnore
-  def insert(name: String, parent: String): Unit = {
-    parentLinks.updateWith(name) {
-      case Some(parents) => Some(parents + parent)
-      case None          => Some(Set(parent))
+  def insert(typeName: String, parentName: String): Unit = {
+    parentLinks.updateWith(typeName) {
+      case Some(parents) => Some(parents + parentName)
+      case None          => Some(Set(parentName))
     }
   }
 
+  /** Get the direct parents of the provided typename.
+    *
+    * The direct parents of a type are those that it is a child of
+    * non-transitively.
+    *
+    * @param typeName the fully-qualified name of the type to get the direct
+    *                 parents for
+    * @return the set of direct parents for `typeName`
+    */
   @JsonIgnore
-  def getDirectParents(name: String): Set[String] = {
-    parentLinks.getOrElse(name, Set(defaultRootType))
+  def getDirectParents(typeName: String): Set[String] = {
+    parentLinks.getOrElse(typeName, Set(defaultRootType))
   }
 
+  /** Get all of the parents (transitively) of the provided typename.
+    *
+    * @param typeName the fully-qualified type name for which to get the parents
+    * @return all parents of `typeName`
+    */
   @JsonIgnore
-  def getParents(name: String): Set[String] = {
+  def getParents(typeName: String): Set[String] = {
     var seenNodes: Set[String] = Set()
 
-    val parents = getDirectParents(name)
+    val parents = getDirectParents(typeName)
     parents ++ parents.flatMap(parent => {
       if (!seenNodes.contains(parent)) {
         seenNodes += parent
@@ -40,4 +78,8 @@ class TypeGraph(defaultRootType: String) {
       } else { Set() }
     })
   }
+}
+object TypeGraph{
+  def fromJava(rootTypeName: String): TypeGraph =
+    new TypeGraph(rootTypeName)
 }

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/data/TypeGraph.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/data/TypeGraph.scala
@@ -18,6 +18,7 @@ import scala.collection.mutable
   *
   * @param defaultRootType the name of the root type of the type subsumption
   *                        hierarchy
+  * @param parentLinks the parent links for the types
   */
 case class TypeGraph(
   defaultRootType: String,
@@ -79,7 +80,7 @@ case class TypeGraph(
     })
   }
 }
-object TypeGraph{
+object TypeGraph {
   def fromJava(rootTypeName: String): TypeGraph =
     new TypeGraph(rootTypeName)
 }

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.module.scala.{
   ScalaObjectMapper
 }
 import org.enso.polyglot.Suggestion
-import org.enso.polyglot.data.Tree
+import org.enso.polyglot.data.{Tree, TypeGraph}
 import org.enso.text.ContentVersion
 import org.enso.text.editing.model
 import org.enso.text.editing.model.{Range, TextEdit}
@@ -188,6 +188,14 @@ object Runtime {
       new JsonSubTypes.Type(
         value = classOf[Api.ImportSuggestionResponse],
         name  = "importSuggestionResponse"
+      ),
+      new JsonSubTypes.Type(
+        value = classOf[Api.GetTypeGraphRequest],
+        name  = "getTypeGraphRequest"
+      ),
+      new JsonSubTypes.Type(
+        value = classOf[Api.GetTypeGraphResponse],
+        name  = "getTypeGraphResponse"
       )
     )
   )
@@ -1051,6 +1059,15 @@ object Runtime {
       symbol: String,
       exports: Seq[Export]
     ) extends ApiResponse
+
+    /** A request for the type hierarchy graph. */
+    case class GetTypeGraphRequest() extends ApiRequest
+
+    /** The result of the type graph request.
+      *
+      * @param graph the graph.
+      */
+    case class GetTypeGraphResponse(graph: TypeGraph) extends ApiResponse
 
     private lazy val mapper = {
       val factory = new CBORFactory()

--- a/engine/polyglot-api/src/test/scala/org/enso/polyglot/data/TypeGraphTest.scala
+++ b/engine/polyglot-api/src/test/scala/org/enso/polyglot/data/TypeGraphTest.scala
@@ -62,7 +62,5 @@ class TypeGraphTest extends AnyWordSpec with Matchers {
         "Builtins.Main.Any"
       )
     }
-
   }
-
 }

--- a/engine/polyglot-api/src/test/scala/org/enso/polyglot/data/TypeGraphTest.scala
+++ b/engine/polyglot-api/src/test/scala/org/enso/polyglot/data/TypeGraphTest.scala
@@ -1,0 +1,68 @@
+package org.enso.polyglot.data
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class TypeGraphTest extends AnyWordSpec with Matchers {
+
+  "The type graph" should {
+    "be able to insert parents" in {
+      val graph = new TypeGraph("Builtins.Main.Any")
+      graph.insert("Builtins.Main.Number", "Builtins.Main.Any")
+      graph.insert("Builtins.Main.Decimal", "Builtins.Main.Number")
+      graph.insert("Builtins.Main.Integer", "Builtins.Main.Number")
+    }
+
+    "be able to query direct parents" in {
+      val graph = new TypeGraph("Builtins.Main.Any")
+      graph.insert("Builtins.Main.Number", "Builtins.Main.Any")
+      graph.insert("Builtins.Main.Decimal", "Builtins.Main.Number")
+      graph.insert("Builtins.Main.Integer", "Builtins.Main.Number")
+
+      graph.getDirectParents("Builtins.Main.Decimal") shouldEqual Set(
+        "Builtins.Main.Number"
+      )
+      graph.getDirectParents("Builtins.Main.Integer") shouldEqual Set(
+        "Builtins.Main.Number"
+      )
+      graph.getDirectParents("Builtins.Main.Number") shouldEqual Set(
+        "Builtins.Main.Any"
+      )
+      graph.getDirectParents("Builtins.Main.Any") shouldBe empty
+    }
+
+    "be able to query all parents" in {
+      val graph = new TypeGraph("Builtins.Main.Any")
+      graph.insert("Builtins.Main.Number", "Builtins.Main.Any")
+      graph.insert("Builtins.Main.Decimal", "Builtins.Main.Number")
+      graph.insert("Builtins.Main.Integer", "Builtins.Main.Number")
+
+      graph.getParents("Builtins.Main.Any") shouldEqual Set()
+      graph.getParents("Builtins.Main.Number") shouldEqual Set(
+        "Builtins.Main.Any"
+      )
+      graph.getParents("Builtins.Main.Integer") shouldEqual Set(
+        "Builtins.Main.Number",
+        "Builtins.Main.Any"
+      )
+      graph.getParents("Builtins.Main.Decimal") shouldEqual Set(
+        "Builtins.Main.Number",
+        "Builtins.Main.Any"
+      )
+    }
+
+    "have a fallback parent for any typename" in {
+      val graph = new TypeGraph("Builtins.Main.Any")
+      graph.insert("Builtins.Main.Number", "Builtins.Main.Any")
+      graph.insert("Builtins.Main.Decimal", "Builtins.Main.Number")
+      graph.insert("Builtins.Main.Integer", "Builtins.Main.Number")
+
+      graph.getParents("My_User_Type") shouldEqual Set("Builtins.Main.Any")
+      graph.getParents("Standard.Base.Vector") shouldEqual Set(
+        "Builtins.Main.Any"
+      )
+    }
+
+  }
+
+}

--- a/engine/polyglot-api/src/test/scala/org/enso/polyglot/data/TypeGraphTest.scala
+++ b/engine/polyglot-api/src/test/scala/org/enso/polyglot/data/TypeGraphTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.wordspec.AnyWordSpec
 class TypeGraphTest extends AnyWordSpec with Matchers {
 
   "The type graph" should {
-    "be able to insert parents" in {
+    "be able to insert links" in {
       val graph = new TypeGraph("Builtins.Main.Any")
       graph.insert("Builtins.Main.Number", "Builtins.Main.Any")
       graph.insert("Builtins.Main.Decimal", "Builtins.Main.Number")

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
@@ -17,6 +17,8 @@ import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.PanicSentinel;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 import org.enso.interpreter.runtime.scope.ModuleScope;
+import org.enso.polyglot.data.TypeGraph;
+import org.yaml.snakeyaml.scanner.Constant;
 
 /**
  * This class defines the interpreter-level type system for Enso.
@@ -48,6 +50,8 @@ import org.enso.interpreter.runtime.scope.ModuleScope;
   PanicSentinel.class
 })
 public class Types {
+
+  private static TypeGraph typeHierarchy = buildTypeHierarchy();
 
   /**
    * A simple pair type
@@ -194,5 +198,31 @@ public class Types {
           arguments, "The second argument must be a " + cls2.getSimpleName() + ".");
     }
     return new Pair<>((A) arguments[0], (B) arguments[1]);
+  }
+
+  /** @return the language type hierarchy */
+  public static TypeGraph getTypeHierarchy() {
+    return typeHierarchy;
+  }
+
+  private static TypeGraph buildTypeHierarchy() {
+    TypeGraph graph = TypeGraph.fromJava(Constants.ANY);
+
+    graph.insert(Constants.ARRAY, Constants.ANY);
+    graph.insert(Constants.BOOLEAN, Constants.ANY);
+    graph.insert(Constants.DECIMAL, Constants.NUMBER);
+    graph.insert(Constants.ERROR, Constants.ANY);
+    graph.insert(Constants.FUNCTION, Constants.ANY);
+    graph.insert(Constants.INTEGER, Constants.NUMBER);
+    graph.insert(Constants.MANAGED_RESOURCE, Constants.ANY);
+    graph.insert(Constants.NOTHING, Constants.ANY);
+    graph.insert(Constants.PANIC, Constants.ANY);
+    graph.insert(Constants.REF, Constants.ANY);
+    graph.insert(Constants.TEXT, Constants.ANY);
+    graph.insertWithoutParent(Constants.PANIC);
+    graph.insertWithoutParent(Constants.THUNK);
+    graph.insertWithoutParent(Constants.UNRESOLVED_SYMBOL);
+
+    return graph;
   }
 }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/CommandFactory.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/CommandFactory.scala
@@ -54,6 +54,9 @@ object CommandFactory {
         throw new IllegalArgumentException(
           "ShutDownRuntimeServer request is not convertible to command object"
         )
+
+      case _: Api.GetTypeGraphRequest =>
+        new GetTypeGraphCommand(request.requestId)
     }
 
 }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/GetTypeGraphCommand.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/GetTypeGraphCommand.scala
@@ -1,0 +1,21 @@
+package org.enso.interpreter.instrument.command
+
+import org.enso.interpreter.instrument.execution.RuntimeContext
+import org.enso.interpreter.runtime.`type`.Types
+import org.enso.polyglot.runtime.Runtime.Api
+import org.enso.polyglot.runtime.Runtime.Api.RequestId
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class GetTypeGraphCommand(maybeRequestId: Option[RequestId])
+    extends Command(maybeRequestId) {
+
+  /** @inheritdoc */
+  override def execute(implicit
+    ctx: RuntimeContext,
+    ec: ExecutionContext
+  ): Future[Unit] = Future {
+    val typeGraph = Types.getTypeHierarchy
+    reply(Api.GetTypeGraphResponse(typeGraph))
+  }
+}

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -1,11 +1,12 @@
 package org.enso.interpreter.test.instrument
 
 import org.enso.interpreter.instrument.execution.Timer
-import org.enso.interpreter.runtime.`type`.Constants
+import org.enso.interpreter.runtime.`type`.{Constants, Types}
 import org.enso.interpreter.runtime.{Context => EnsoContext}
 import org.enso.interpreter.test.Metadata
 import org.enso.pkg.{Package, PackageManager}
 import org.enso.polyglot._
+import org.enso.polyglot.data.TypeGraph
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.text.editing.model
 import org.enso.text.editing.model.TextEdit
@@ -3706,4 +3707,13 @@ class RuntimeServerTest
     )
   }
 
+  it should "send the type graph" in {
+    val requestId                = UUID.randomUUID()
+    val expectedGraph: TypeGraph = Types.getTypeHierarchy
+
+    context.send(Api.Request(requestId, Api.GetTypeGraphRequest()))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.GetTypeGraphResponse(expectedGraph))
+    )
+  }
 }

--- a/lib/scala/searcher/src/bench/java/org/enso/searcher/sql/SuggestionsRepoBenchmark.java
+++ b/lib/scala/searcher/src/bench/java/org/enso/searcher/sql/SuggestionsRepoBenchmark.java
@@ -1,5 +1,6 @@
 package org.enso.searcher.sql;
 
+import java.util.ArrayList;
 import org.enso.polyglot.Suggestion;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
@@ -17,6 +18,8 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
+
+import scala.jdk.CollectionConverters;
 
 @BenchmarkMode(Mode.AverageTime)
 @Fork(1)
@@ -69,35 +72,64 @@ public class SuggestionsRepoBenchmark {
 
   @Benchmark
   public Object searchBaseline() throws TimeoutException, InterruptedException {
-    return Await.result(repo.search(none(), none(), none(), none(), none()), TIMEOUT);
+    return Await.result(
+        repo.search(
+            none(),
+            CollectionConverters.ListHasAsScala(new ArrayList<String>()).asScala().toSeq(),
+            none(),
+            none(),
+            none()),
+        TIMEOUT);
   }
 
   @Benchmark
   public Object searchByReturnType() throws TimeoutException, InterruptedException {
     return Await.result(
-        repo.search(none(), none(), scala.Some.apply("MyType"), none(), none()), TIMEOUT);
+        repo.search(
+            none(),
+            CollectionConverters.ListHasAsScala(new ArrayList<String>()).asScala().toSeq(),
+            scala.Some.apply("MyType"),
+            none(),
+            none()),
+        TIMEOUT);
   }
 
   @Benchmark
   public Object searchBySelfType() throws TimeoutException, InterruptedException {
+    var selfTypes = new ArrayList<String>();
+    selfTypes.add("MyType");
     return Await.result(
-        repo.search(none(), scala.Some.apply("MyType"), none(), none(), none()), TIMEOUT);
+        repo.search(
+            none(),
+            CollectionConverters.ListHasAsScala(selfTypes).asScala().toSeq(),
+            none(),
+            none(),
+            none()),
+        TIMEOUT);
   }
 
   @Benchmark
   public Object searchBySelfReturnTypes() throws TimeoutException, InterruptedException {
+    var selfTypes = new ArrayList<String>();
+    selfTypes.add("SelfType");
     return Await.result(
         repo.search(
-            none(), scala.Some.apply("SelfType"), scala.Some.apply("ReturnType"), none(), none()),
+            none(),
+            CollectionConverters.ListHasAsScala(selfTypes).asScala().toSeq(),
+            scala.Some.apply("ReturnType"),
+            none(),
+            none()),
         TIMEOUT);
   }
 
   @Benchmark
   public Object searchByAll() throws TimeoutException, InterruptedException {
+    var selfTypes = new ArrayList<String>();
+    selfTypes.add("SelfType");
     return Await.result(
         repo.search(
             none(),
-            scala.Some.apply("SelfType"),
+            CollectionConverters.ListHasAsScala(selfTypes).asScala().toSeq(),
             scala.Some.apply("ReturnType"),
             scala.Some.apply(kinds),
             none()),

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/SuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/SuggestionsRepo.scala
@@ -34,7 +34,7 @@ trait SuggestionsRepo[F[_]] {
   /** Search suggestion by various parameters.
     *
     * @param module the module name search parameter
-    * @param selfType the selfType search parameter
+    * @param selfType the self types to search for
     * @param returnType the returnType search parameter
     * @param kinds the list suggestion kinds to search
     * @param position the absolute position in the text
@@ -42,7 +42,7 @@ trait SuggestionsRepo[F[_]] {
     */
   def search(
     module: Option[String],
-    selfType: Option[String],
+    selfType: Seq[String],
     returnType: Option[String],
     kinds: Option[Seq[Suggestion.Kind]],
     position: Option[Suggestion.Position]

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
@@ -656,7 +656,7 @@ final class SqlSuggestionsRepo(db: SqlDatabase)(implicit ec: ExecutionContext)
     * global symbols (atoms and method).
     *
     * @param module the module name search parameter
-    * @param selfType the selfType search parameter
+    * @param selfTypes the selfType search parameter
     * @param returnType the returnType search parameter
     * @param kinds the list suggestion kinds to search
     * @param position the absolute position in the text
@@ -664,7 +664,7 @@ final class SqlSuggestionsRepo(db: SqlDatabase)(implicit ec: ExecutionContext)
     */
   private def searchQueryBuilder(
     module: Option[String],
-    selfType: Seq[String],
+    selfTypes: Seq[String],
     returnType: Option[String],
     kinds: Option[Seq[Suggestion.Kind]],
     position: Option[Suggestion.Position]
@@ -673,9 +673,7 @@ final class SqlSuggestionsRepo(db: SqlDatabase)(implicit ec: ExecutionContext)
       .filterOpt(module) { case (row, value) =>
         row.scopeStartLine === ScopeColumn.EMPTY || row.module === value
       }
-      .filterOpt(selfType) { case (row, value) =>
-        row.selfType === value
-      }
+      .filter { row => row.selfType.inSet(selfTypes) }
       .filterOpt(returnType) { case (row, value) =>
         row.returnType === value
       }

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
@@ -673,7 +673,7 @@ final class SqlSuggestionsRepo(db: SqlDatabase)(implicit ec: ExecutionContext)
       .filterOpt(module) { case (row, value) =>
         row.scopeStartLine === ScopeColumn.EMPTY || row.module === value
       }
-      .filter { row => row.selfType.inSet(selfTypes) }
+      .filterIf(selfTypes.nonEmpty) {row => row.selfType.inSet(selfTypes) }
       .filterOpt(returnType) { case (row, value) =>
         row.returnType === value
       }

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
@@ -56,7 +56,7 @@ final class SqlSuggestionsRepo(db: SqlDatabase)(implicit ec: ExecutionContext)
   /** @inheritdoc */
   override def search(
     module: Option[String],
-    selfType: Option[String],
+    selfType: Seq[String],
     returnType: Option[String],
     kinds: Option[Seq[Suggestion.Kind]],
     position: Option[Suggestion.Position]
@@ -219,7 +219,7 @@ final class SqlSuggestionsRepo(db: SqlDatabase)(implicit ec: ExecutionContext)
     */
   private def searchQuery(
     module: Option[String],
-    selfType: Option[String],
+    selfType: Seq[String],
     returnType: Option[String],
     kinds: Option[Seq[Suggestion.Kind]],
     position: Option[Suggestion.Position]
@@ -664,7 +664,7 @@ final class SqlSuggestionsRepo(db: SqlDatabase)(implicit ec: ExecutionContext)
     */
   private def searchQueryBuilder(
     module: Option[String],
-    selfType: Option[String],
+    selfType: Seq[String],
     returnType: Option[String],
     kinds: Option[Seq[Suggestion.Kind]],
     position: Option[Suggestion.Position]

--- a/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
+++ b/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
@@ -718,7 +718,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         _   <- repo.insert(suggestion.method)
         _   <- repo.insert(suggestion.function)
         _   <- repo.insert(suggestion.local)
-        res <- repo.search(None, None, None, None, None)
+        res <- repo.search(None, Seq(), None, None, None)
       } yield res._2
 
       val res = Await.result(action, Timeout)
@@ -731,7 +731,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         id2 <- repo.insert(suggestion.method)
         id3 <- repo.insert(suggestion.function)
         id4 <- repo.insert(suggestion.local)
-        res <- repo.search(Some("Test.Main"), None, None, None, None)
+        res <- repo.search(Some("Test.Main"), Seq(), None, None, None)
       } yield (id1, id2, id3, id4, res._2)
 
       val (id1, id2, id3, id4, res) = Await.result(action, Timeout)
@@ -744,7 +744,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         id2 <- repo.insert(suggestion.method)
         _   <- repo.insert(suggestion.function)
         _   <- repo.insert(suggestion.local)
-        res <- repo.search(Some(""), None, None, None, None)
+        res <- repo.search(Some(""), Seq(), None, None, None)
       } yield (res._2, Seq(id1, id2))
 
       val (res, globals) = Await.result(action, Timeout)
@@ -757,7 +757,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         id2 <- repo.insert(suggestion.method)
         _   <- repo.insert(suggestion.function)
         _   <- repo.insert(suggestion.local)
-        res <- repo.search(None, Some("Main"), None, None, None)
+        res <- repo.search(None, Seq("Main"), None, None, None)
       } yield (id2, res._2)
 
       val (id, res) = Await.result(action, Timeout)
@@ -770,7 +770,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         _   <- repo.insert(suggestion.method)
         id3 <- repo.insert(suggestion.function)
         id4 <- repo.insert(suggestion.local)
-        res <- repo.search(None, None, Some("MyType"), None, None)
+        res <- repo.search(None, Seq(), Some("MyType"), None, None)
       } yield (id3, id4, res._2)
 
       val (id1, id2, res) = Await.result(action, Timeout)
@@ -784,7 +784,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         _   <- repo.insert(suggestion.method)
         _   <- repo.insert(suggestion.function)
         id4 <- repo.insert(suggestion.local)
-        res <- repo.search(None, None, None, Some(kinds), None)
+        res <- repo.search(None, Seq(), None, Some(kinds), None)
       } yield (id1, id4, res._2)
 
       val (id1, id2, res) = Await.result(action, Timeout)
@@ -797,7 +797,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         _   <- repo.insert(suggestion.method)
         _   <- repo.insert(suggestion.function)
         _   <- repo.insert(suggestion.local)
-        res <- repo.search(None, None, None, Some(Seq()), None)
+        res <- repo.search(None, Seq(), None, Some(Seq()), None)
       } yield res._2
 
       val res = Await.result(action, Timeout)
@@ -811,7 +811,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         _   <- repo.insert(suggestion.function)
         _   <- repo.insert(suggestion.local)
         res <-
-          repo.search(None, None, None, None, Some(Suggestion.Position(99, 42)))
+          repo.search(None, Seq(), None, None, Some(Suggestion.Position(99, 42)))
       } yield (id1, id2, res._2)
 
       val (id1, id2, res) = Await.result(action, Timeout)
@@ -825,7 +825,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         id3 <- repo.insert(suggestion.function)
         _   <- repo.insert(suggestion.local)
         res <-
-          repo.search(None, None, None, None, Some(Suggestion.Position(1, 5)))
+          repo.search(None, Seq(), None, None, Some(Suggestion.Position(1, 5)))
       } yield (id1, id2, id3, res._2)
 
       val (id1, id2, id3, res) = Await.result(action, Timeout)
@@ -839,7 +839,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
           id2 <- repo.insert(suggestion.method)
           _   <- repo.insert(suggestion.function)
           _   <- repo.insert(suggestion.local)
-          res <- repo.search(Some("Test.Main"), Some("Main"), None, None, None)
+          res <- repo.search(Some("Test.Main"), Seq("Main"), None, None, None)
         } yield (id2, res._2)
 
         val (id, res) = Await.result(action, Timeout)
@@ -854,7 +854,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
           _   <- repo.insert(suggestion.method)
           _   <- repo.insert(suggestion.function)
           id4 <- repo.insert(suggestion.local)
-          res <- repo.search(None, None, Some("MyType"), Some(kinds), None)
+          res <- repo.search(None, Seq(), Some("MyType"), Some(kinds), None)
         } yield (id4, res._2)
 
         val (id, res) = Await.result(action, Timeout)
@@ -870,7 +870,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
           id4 <- repo.insert(suggestion.local)
           res <- repo.search(
             None,
-            None,
+            Seq(),
             Some("MyType"),
             None,
             Some(Suggestion.Position(42, 0))
@@ -890,7 +890,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         _   <- repo.insert(suggestion.local)
         res <- repo.search(
           None,
-          None,
+          Seq(),
           None,
           Some(kinds),
           Some(Suggestion.Position(99, 1))
@@ -908,7 +908,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
           _   <- repo.insert(suggestion.method)
           _   <- repo.insert(suggestion.function)
           _   <- repo.insert(suggestion.local)
-          res <- repo.search(None, Some("Main"), Some("MyType"), None, None)
+          res <- repo.search(None, Seq("Main"), Some("MyType"), None, None)
         } yield res._2
 
         val res = Await.result(action, Timeout)
@@ -925,7 +925,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
           id4 <- repo.insert(suggestion.local)
           res <- repo.search(
             Some("Test.Main"),
-            None,
+            Seq(),
             Some("MyType"),
             Some(kinds),
             None
@@ -946,7 +946,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
           id4 <- repo.insert(suggestion.local)
           res <- repo.search(
             None,
-            None,
+            Seq(),
             Some("MyType"),
             Some(kinds),
             Some(Suggestion.Position(42, 0))
@@ -970,7 +970,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         _ <- repo.insert(suggestion.local)
         res <- repo.search(
           Some("Test.Main"),
-          Some("Main"),
+          Seq("Main"),
           Some("MyType"),
           Some(kinds),
           Some(Suggestion.Position(42, 0))


### PR DESCRIPTION
### Pull Request Description
This PR implements a basic type hierarchy of parent relations to allow the searcher to suggest completions for compatible types. This _only_ works for self types as doing it for return types would require implementing proper type checking logic.

Closes #1445.

### Important Notes
N/A

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
