### PR TITLE
Case Insensitive Dataframe Support in Visualizations

### DIFF
--- a/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
@@ -1,4 +1,4 @@
- from Standard.Base import all
+from Standard.Base import all
 
 import Standard.Table.Data.Table
 import Standard.Test
@@ -21,7 +21,8 @@ json_from_table table =
 
 ## PRIVATE
 
-   Default preprocessor for the geo map visualization, generating JSON text describing the geo map visualization.
+   Default preprocessor for the geo map visualization, generating JSON text
+   describing the geo map visualization.
    
    Arguments:
    - value: the value to be visualized.

--- a/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
@@ -6,10 +6,10 @@ import Standard.Visualization.Helpers
 
 json_from_table : Table.Table -> Text
 json_from_table table = 
-    names = ['label', 'latitude', 'longitude']
+    names = ['label', 'latitude', 'longitude', 'radius', 'color']
     pairs = names.filter_map <| name-> 
         column = table.lookup_ignore_case name
-        column.when_valid [name, column.to_vector]
+        column.when_valid ["df_" + name, column.to_vector]
         
     Json.from_pairs pairs
 

--- a/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
@@ -4,6 +4,7 @@ import Standard.Table.Data.Table
 import Standard.Test
 import Standard.Visualization.Helpers
 
+## PRIVATE
 json_from_table : Table.Table -> Text
 json_from_table table = 
     names = ['label', 'latitude', 'longitude', 'radius', 'color']
@@ -13,6 +14,14 @@ json_from_table table =
         
     Json.from_pairs pairs
 
+## PRIVATE
+
+   Default preprocessor for the geo map visualization.
+   
+   Generates JSON text describing the geo map visualization.
+   
+   Arguments:
+   - value: the value to be visualized.
 process_to_json_text : Any -> Text
 process_to_json_text value = 
     json = case value of

--- a/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
@@ -16,9 +16,7 @@ json_from_table table =
 
 ## PRIVATE
 
-   Default preprocessor for the geo map visualization.
-   
-   Generates JSON text describing the geo map visualization.
+   Default preprocessor for the geo map visualization, generating JSON text describing the geo map visualization.
    
    Arguments:
    - value: the value to be visualized.

--- a/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
@@ -1,0 +1,22 @@
+from Standard.Base import all
+
+import Standard.Table.Data.Table
+import Standard.Test
+import Standard.Visualization.Helpers
+
+json_from_table : Table.Table -> Text
+json_from_table table = 
+    names = ['label', 'latitude', 'longitude']
+    pairs = names.filter_map <| name-> 
+        column = table.lookup_ignore_case name
+        column.when_valid [name, column.to_vector]
+        
+    Json.from_pairs pairs
+
+process_to_json_text : Any -> Text
+process_to_json_text value = 
+    json = case value of
+        Table.Table _   -> here.json_from_table value
+        _               -> value.to_json
+   
+    json.to_text

--- a/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Geo_Map.enso
@@ -1,11 +1,16 @@
-from Standard.Base import all
+ from Standard.Base import all
 
 import Standard.Table.Data.Table
 import Standard.Test
 import Standard.Visualization.Helpers
 
 ## PRIVATE
-json_from_table : Table.Table -> Text
+
+   Construct JSON describing table geo map visualization.
+   
+   Arguments:
+   - table: the Table to be visualized.
+json_from_table : Table.Table -> Object
 json_from_table table = 
     names = ['label', 'latitude', 'longitude', 'radius', 'color']
     pairs = names.filter_map <| name-> 
@@ -25,7 +30,7 @@ json_from_table table =
 process_to_json_text : Any -> Text
 process_to_json_text value = 
     json = case value of
-        Table.Table _   -> here.json_from_table value
-        _               -> value.to_json
+        Table.Table _ -> here.json_from_table value
+        _ -> value.to_json
    
     json.to_text

--- a/distribution/std-lib/Standard/src/Visualization/Helpers.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Helpers.enso
@@ -6,41 +6,41 @@ import Standard.Table.Data.Table
 
 ## PRIVATE
    Maps the vector using the given function. Filters out all error values.
-Vector.Vector.filter_map: Any -> Vector
+Vector.Vector.filter_map : Any -> Vector
 Vector.Vector.filter_map f = this.map f . filter .is_valid
 
 ## PRIVATE
    Returns the given value if this is not an error. Propagates error otherwise.
-Any.when_valid: Any -> Any
+Any.when_valid : Any -> Any
 Any.when_valid ~val = this.map_valid (_-> val)
 
 ## PRIVATE
    Returns the given value if this is not an error. Propagates error otherwise.
-Error.when_valid: Any -> Any
+Error.when_valid : Any -> Any
 Error.when_valid ~val = this.map_valid (_-> val)
 
 ## PRIVATE
    Checks if the value is not an error.
-Any.is_valid: Any -> Any
+Any.is_valid : Any -> Any
 Any.is_valid = this.is_error.not
 
 ## PRIVATE
    Checks if the value is not an error.
-Error.is_valid: Any -> Any
+Error.is_valid : Any -> Any
 Error.is_valid = this.is_error.not
 
 ## PRIVATE
    Maps over non-error value.
-Any.map_valid: Any -> Any
+Any.map_valid : Any -> Any
 Any.map_valid f = f this
 
 ## PRIVATE
    Maps over non-error value.
-Error.map_valid: Any -> Any
+Error.map_valid : Any -> Any
 Error.map_valid _ = this
 
 ## PRIVATE
-Any.catch_: Any -> Any
+Any.catch_ : Any -> Any
 Any.catch_ ~val = this.catch (_-> val)
 
 ## PRIVATE
@@ -56,8 +56,9 @@ recover_errors ~body =
 
 ## PRIVATE
 
-   Returns all the columns in the table, including indices. Index columns are 
-   placed before other columns.
+   Returns all the columns in the table, including indices. 
+   
+   Index columns are placed before other columns.
 Table.Table.all_columns : Vector
 Table.Table.all_columns =
     index = this.index.catch_ []
@@ -68,8 +69,12 @@ Table.Table.all_columns =
 
 ## PRIVATE
 
-   Looks for a column by a given name. Unlike `Table.at` looks into index
-   columns and name comparison is case-insensitive.
+   Looks for a column by a given name. 
+   
+   Unlike `Table.at` looks into index columns and name comparison is case-insensitive.
+
+   Arguments:
+   - text: the case-insensitive name of the searched column .
 Table.Table.lookup_ignore_case : Text -> Column ! Nothing
 Table.Table.lookup_ignore_case name =
     ret = this.all_columns.find <| col-> 

--- a/distribution/std-lib/Standard/src/Visualization/Helpers.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Helpers.enso
@@ -5,11 +5,46 @@ import Standard.Table.Data.Storage
 import Standard.Table.Data.Table
 
 ## PRIVATE
+   Maps the vector using the given function. Filters out all error values.
+Vector.Vector.filter_map: Any -> Vector
+Vector.Vector.filter_map f = this.map f . filter .is_valid
+
+## PRIVATE
+   Returns the given value if this is not an error. Propagates error otherwise.
+Any.when_valid: Any -> Any
+Any.when_valid ~val = this.map_valid (_-> val)
+
+## PRIVATE
+   Returns the given value if this is not an error. Propagates error otherwise.
+Error.when_valid: Any -> Any
+Error.when_valid ~val = this.map_valid (_-> val)
+
+## PRIVATE
+   Checks if the value is not an error.
+Any.is_valid: Any -> Any
+Any.is_valid = this.is_error.not
+
+## PRIVATE
+   Checks if the value is not an error.
+Error.is_valid: Any -> Any
+Error.is_valid = this.is_error.not
+
+## PRIVATE
+   Maps over non-error value.
+Any.map_valid: Any -> Any
+Any.map_valid f = f this
+
+## PRIVATE
+   Maps over non-error value.
+Error.map_valid: Any -> Any
+Error.map_valid _ = this
+
+## PRIVATE
 Any.catch_: Any -> Any
 Any.catch_ ~val = this.catch (_-> val)
 
 ## PRIVATE
-Any.catch_ : Any -> Any
+Error.catch_ : Any -> Any
 Error.catch_ ~val = this.catch (_-> val)
 
 ## PRIVATE
@@ -21,8 +56,8 @@ recover_errors ~body =
 
 ## PRIVATE
 
-   Returns all the columns in the table, including indices.
-   Index columns are placed before other columns.
+   Returns all the columns in the table, including indices. Index columns are 
+   placed before other columns.
 Table.Table.all_columns : Vector
 Table.Table.all_columns =
     index = this.index.catch_ []
@@ -31,6 +66,15 @@ Table.Table.all_columns =
         a -> [a]
     index_columns + this.columns
 
+## PRIVATE
+
+   Looks for a column by a given name. Unlike `Table.at` looks into index
+   columns and name comparison is case-insensitive.
+Table.Table.lookup_ignore_case : Text -> Column ! Nothing
+Table.Table.lookup_ignore_case name =
+    ret = this.all_columns.find <| col-> 
+        col.name.equals_ignore_case name
+    ret
 
 ## PRIVATE
 

--- a/distribution/std-lib/Standard/src/Visualization/Helpers.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Helpers.enso
@@ -5,45 +5,84 @@ import Standard.Table.Data.Storage
 import Standard.Table.Data.Table
 
 ## PRIVATE
+
    Maps the vector using the given function. Filters out all error values.
+
+   Arguments:
+   - f: unary invokable that is applied to each vector element. Non-error
+        values are returned in the resulting vector. Error values are dropped. 
 Vector.Vector.filter_map : Any -> Vector
 Vector.Vector.filter_map f = this.map f . filter .is_valid
 
 ## PRIVATE
+
    Returns the given value if this is not an error. Propagates error otherwise.
+
+   Arguments:
+   - val: a value that will be evaluated and returned if `this` is an error.
 Any.when_valid : Any -> Any
 Any.when_valid ~val = this.map_valid (_-> val)
 
 ## PRIVATE
+
    Returns the given value if this is not an error. Propagates error otherwise.
+
+   Arguments:
+   - val: a value that will be evaluated and returned if `this` is an error.
 Error.when_valid : Any -> Any
 Error.when_valid ~val = this.map_valid (_-> val)
 
 ## PRIVATE
+
    Checks if the value is not an error.
-Any.is_valid : Any -> Any
+Any.is_valid : Any
 Any.is_valid = this.is_error.not
 
 ## PRIVATE
+
    Checks if the value is not an error.
-Error.is_valid : Any -> Any
+Error.is_valid : Any
 Error.is_valid = this.is_error.not
 
 ## PRIVATE
+
    Maps over non-error value.
+
+   Arguments:
+   - f: a function that will be used to generate return value from a non-error
+        `this` value.
 Any.map_valid : Any -> Any
 Any.map_valid f = f this
 
 ## PRIVATE
+
    Maps over non-error value.
+
+   Arguments:
+   - _: a function that will be used to generate return value from a non-error
+        `this` value.
 Error.map_valid : Any -> Any
 Error.map_valid _ = this
 
 ## PRIVATE
+
+   Recovers from the error by returning the parameter value.
+
+   The error contents will be ignored. 
+
+   Arguments:
+   - val: a value that will be evaluated and returned if `this` is an error.
 Any.catch_ : Any -> Any
 Any.catch_ ~val = this.catch (_-> val)
 
 ## PRIVATE
+
+   Recovers from the error by returning the parameter value.
+
+   The error contents will be ignored. 
+
+   Arguments:
+   - val: a value that will be evaluated and returned if `this` is an error.
 Error.catch_ : Any -> Any
 Error.catch_ ~val = this.catch (_-> val)
 
@@ -74,7 +113,7 @@ Table.Table.all_columns =
    Unlike `Table.at` looks into index columns and name comparison is case-insensitive.
 
    Arguments:
-   - text: the case-insensitive name of the searched column .
+   - text: the case-insensitive name of the searched column.
 Table.Table.lookup_ignore_case : Text -> Column ! Nothing
 Table.Table.lookup_ignore_case name =
     ret = this.all_columns.find <| col-> 

--- a/distribution/std-lib/Standard/src/Visualization/Histogram.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Histogram.enso
@@ -13,8 +13,8 @@ Table.Table.first_numeric = this.all_columns.find _.is_numeric
    Get the value column - the column that will be used to create histogram.
 Table.Table.value_column : Table -> Column ! Nothing
 Table.Table.value_column = 
-    named_col = this.at 'value'
-    named_col.catch_ <| this.first_numeric
+    named_col = this.lookup_ignore_case 'value'
+    named_col.catch_ this.first_numeric
 
 ## PRIVATE
    Information that are placed in an update sent to a visualization.

--- a/distribution/std-lib/Standard/src/Visualization/Scatter_Plot.enso
+++ b/distribution/std-lib/Standard/src/Visualization/Scatter_Plot.enso
@@ -81,7 +81,7 @@ type PointData
     ## PRIVATE
     lookup_in : Table -> Column
     lookup_in table = 
-        named = table.at this.name
+        named = table.lookup_ignore_case this.name
         named.catch_ <| this.fallback_column table
 
 ## PRIVATE
@@ -89,8 +89,7 @@ type PointData
 Table.Table.point_data : Table -> Object
 Table.Table.point_data =
     get_point_data field = field.lookup_in this . rename field.name
-    is_valid column = column.is_error.not
-    columns = PointData.all_fields.map get_point_data . filter is_valid
+    columns = PointData.all_fields.filter_map get_point_data
     (0.up_to <| this.row_count + 1).to_vector.map <| row_n-> 
         pairs = columns.map column->
             value = column.at row_n . catch_ Nothing
@@ -109,7 +108,7 @@ Table.Table.axes =
     y_axis = describe_axis Y
     is_valid axis_pair =
         label = axis_pair.at 1
-        label.is_error.not && (this.all_columns.length > 0)
+        label.is_valid && (this.all_columns.length > 0)
     axes_obj = Json.from_pairs <| [x_axis, y_axis].filter is_valid
     if axes_obj.fields.size > 0 then axes_obj else Nothing
 

--- a/test/Visualization_Tests/src/Geo_Map_Spec.enso
+++ b/test/Visualization_Tests/src/Geo_Map_Spec.enso
@@ -22,16 +22,15 @@ spec =
             table  = Table.from_rows header [row_1, row_2]
             expect table '{}'
 
-        Test.specify "recognizes latitude and longitude" <|
-            header = ['latitude' , 'longitude']
-            row_1  = [11         , 10         ]
-            row_2  = [21         , 20         ]
-            table  = Table.from_rows header [row_1, row_2]
-            expect table '{"latitude":[11,21],"longitude":[10,20]}'
+        Test.specify "recognizes relevant columns" <|
+            header = ['latitude' , 'longitude' , 'color' , 'label' , 'radius']
+            row_1  = [11         , 10          , 'red'   , 'name'  , 195     ]
+            table  = Table.from_rows header [row_1]
+            expect table '{"df_color":["red"],"df_label":["name"],"df_latitude":[11],"df_longitude":[10],"df_radius":[195]}'
 
         Test.specify "is case insensitive" <|
             header = ['latitude' , 'LONGITUDE' , 'LaBeL']
             row_1  = [11         , 10          , 09     ]
             row_2  = [21         , 20          , 19     ]
             table  = Table.from_rows header [row_1, row_2]
-            expect table '{"label":[9,19],"latitude":[11,21],"longitude":[10,20]}'
+            expect table '{"df_label":[9,19],"df_latitude":[11,21],"df_longitude":[10,20]}'

--- a/test/Visualization_Tests/src/Geo_Map_Spec.enso
+++ b/test/Visualization_Tests/src/Geo_Map_Spec.enso
@@ -1,0 +1,37 @@
+from Standard.Base import all
+
+import Standard.Table.Data.Table
+import Standard.Test
+import Standard.Visualization.Geo_Map
+import Visualization_Tests.Helpers
+
+spec = 
+    expect value expected_json_text = 
+        result = Geo_Map.process_to_json_text value
+        Json.parse result . should_equal <| Json.parse expected_json_text
+
+    Test.group "Geo_Map" <|
+        Test.specify "works with empty table" <|
+            table  = Table.from_rows [] []
+            expect table '{}'
+
+        Test.specify "skips unrecognized columns" <|
+            header = ['α' , 'β' , 'ω']
+            row_1  = [11  , 10  , 09 ]
+            row_2  = [21  , 20  , 19 ]
+            table  = Table.from_rows header [row_1, row_2]
+            expect table '{}'
+
+        Test.specify "recognizes latitude and longitude" <|
+            header = ['latitude' , 'longitude']
+            row_1  = [11         , 10         ]
+            row_2  = [21         , 20         ]
+            table  = Table.from_rows header [row_1, row_2]
+            expect table '{"latitude":[11,21],"longitude":[10,20]}'
+
+        Test.specify "is case insensitive" <|
+            header = ['latitude' , 'LONGITUDE' , 'LaBeL']
+            row_1  = [11         , 10          , 09     ]
+            row_2  = [21         , 20          , 19     ]
+            table  = Table.from_rows header [row_1, row_2]
+            expect table '{"label":[9,19],"latitude":[11,21],"longitude":[10,20]}'

--- a/test/Visualization_Tests/src/Helpers.enso
+++ b/test/Visualization_Tests/src/Helpers.enso
@@ -1,0 +1,9 @@
+from Standard.Base import all
+
+import Standard.Table.Data.Column
+import Standard.Test
+
+Column.Column.expect : Text -> Vector -> Test.Success
+Column.Column.expect name contents =
+    this.name.should_equal name
+    this.to_vector.should_equal contents

--- a/test/Visualization_Tests/src/Helpers_Spec.enso
+++ b/test/Visualization_Tests/src/Helpers_Spec.enso
@@ -3,8 +3,7 @@ from Standard.Base import all
 import Standard.Table.Data.Table
 import Standard.Test
 import Standard.Visualization.Helpers
-
-import Visualization_Tests
+import Visualization_Tests.Helpers
 
 spec = 
     Test.group "Table.all_columns" <|
@@ -45,4 +44,3 @@ spec =
             table.lookup_ignore_case 'Ω' . expect 'ω' [12,22]
             table.lookup_ignore_case 'b' . is_error . should_equal True
             table.lookup_ignore_case 'B' . is_error . should_equal True
-    

--- a/test/Visualization_Tests/src/Helpers_Spec.enso
+++ b/test/Visualization_Tests/src/Helpers_Spec.enso
@@ -25,7 +25,7 @@ spec =
             table  = Table.from_rows header [row_1, row_2]
             table.all_columns.map (_.name) . should_equal ['a']
 
-        Test.specify "includes first index then normal columns" <|
+        Test.specify "includes the index first and then normal columns" <|
             header = ['a', 'b']
             row_1  = [11 , 10 ]
             row_2  = [21 , 20 ]

--- a/test/Visualization_Tests/src/Helpers_Spec.enso
+++ b/test/Visualization_Tests/src/Helpers_Spec.enso
@@ -26,9 +26,23 @@ spec =
             table  = Table.from_rows header [row_1, row_2]
             table.all_columns.map (_.name) . should_equal ['a']
 
-        Test.specify "includes both normal and index columns" <|
+        Test.specify "includes first index then normal columns" <|
             header = ['a', 'b']
             row_1  = [11 , 10 ]
             row_2  = [21 , 20 ]
             table  = Table.from_rows header [row_1, row_2] . set_index 'a'
             table.all_columns.map (_.name) . should_equal ['a','b']
+
+    Test.group "Table.lookup_ignore_case" <|
+        Test.specify "ignores case and takes first matching" <|
+            header = ['A', 'a' , 'ω' , 'Ω']
+            row_1  = [11 , 10  , 12  , 13]
+            row_2  = [21 , 20  , 22  , 23]
+            table  = Table.from_rows header [row_1, row_2]
+            table.lookup_ignore_case 'a' . expect 'A' [11,21]
+            table.lookup_ignore_case 'A' . expect 'A' [11,21]
+            table.lookup_ignore_case 'ω' . expect 'ω' [12,22]
+            table.lookup_ignore_case 'Ω' . expect 'ω' [12,22]
+            table.lookup_ignore_case 'b' . is_error . should_equal True
+            table.lookup_ignore_case 'B' . is_error . should_equal True
+    

--- a/test/Visualization_Tests/src/Histogram_Spec.enso
+++ b/test/Visualization_Tests/src/Histogram_Spec.enso
@@ -47,6 +47,13 @@ spec =
             table  = Table.from_rows header [row_1, row_2]
             expect table 'value' [10,20]
 
+        Test.specify "is case insensitive" <|
+            header = ['α', 'Value']
+            row_1  = [11 , 10 ]
+            row_2  = [21 , 20 ]
+            table  = Table.from_rows header [row_1, row_2]
+            expect table 'Value' [10,20]
+
         Test.specify "plots column" <|
             column = Column.from_vector 'my_name' [1,4,6]
             expect column 'my_name' [1,4,6]    

--- a/test/Visualization_Tests/src/Histogram_Spec.enso
+++ b/test/Visualization_Tests/src/Histogram_Spec.enso
@@ -4,7 +4,6 @@ import Standard.Table.Data.Column
 import Standard.Table.Data.Table
 import Standard.Test
 import Standard.Visualization.Histogram
-
 import Visualization_Tests
 
 spec = 

--- a/test/Visualization_Tests/src/Main.enso
+++ b/test/Visualization_Tests/src/Main.enso
@@ -1,14 +1,21 @@
 from Standard.Base import all
 
 import Standard.Test
+import Standard.Table.Data.Column
 
+import Visualization_Tests.Geo_Map_Spec
 import Visualization_Tests.Helpers_Spec
 import Visualization_Tests.Histogram_Spec
 import Visualization_Tests.Scatter_Plot_Spec
 import Visualization_Tests.Sql_Spec
 import Visualization_Tests.Table_Spec
 
+Column.Column.expect name contents =
+    this.name.should_equal name
+    this.to_vector.should_equal contents
+
 main = Test.Suite.runMain <|
+    Geo_Map_Spec.spec
     Helpers_Spec.spec
     Histogram_Spec.spec
     Scatter_Plot_Spec.spec

--- a/test/Visualization_Tests/src/Main.enso
+++ b/test/Visualization_Tests/src/Main.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 
 import Standard.Test
-import Standard.Table.Data.Column
 
 import Visualization_Tests.Geo_Map_Spec
 import Visualization_Tests.Helpers_Spec
@@ -9,10 +8,6 @@ import Visualization_Tests.Histogram_Spec
 import Visualization_Tests.Scatter_Plot_Spec
 import Visualization_Tests.Sql_Spec
 import Visualization_Tests.Table_Spec
-
-Column.Column.expect name contents =
-    this.name.should_equal name
-    this.to_vector.should_equal contents
 
 main = Test.Suite.runMain <|
     Geo_Map_Spec.spec

--- a/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
+++ b/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
@@ -49,6 +49,12 @@ spec =
             table = Table.from_rows header [row_1]
             expect table (labels 'x' 'y') '[{"color":"ff0000","label":"label","shape":"square","size":50,"x":11,"y":10}]'
             
+        Test.specify "is case insensitive" <|
+            header = ['X' , 'Y' , 'Size' , 'Shape'  , 'Label' , 'Color' ]
+            row_1 =  [11  , 10  , 50     , 'square' , 'label' , 'ff0000']
+            table = Table.from_rows header [row_1]
+            expect table (labels 'X' 'Y') '[{"color":"ff0000","label":"label","shape":"square","size":50,"x":11,"y":10}]'
+            
         Test.specify "uses first unrecognized numeric column as `y` fallback" <|
             header = ['x' , 'size' , 'name'   , 'z' , 'ω']
             row_1 =  [11  , 50     , 'circul' ,  20 ,  30]
@@ -69,16 +75,13 @@ spec =
             table = Table.from_rows header [row_1, row_2] . set_index 'baz'
             # [TODO] mwu: When it is possible to set multiple index columns, test such case.
             expect table (labels 'baz' 'y') '[{"size":40,"x":14,"y":10},{"size":50,"x":15,"y":20}]'
-          
 
         Test.specify "prefers explicit 'x' to index and looks into indices for recognized fields" <|
             header = [ 'x' , 'size']
             row_1 =  [ 10  , 21  ]
             row_2 =  [ 20  , 22  ]
             table = Table.from_rows header [row_1, row_2] . set_index 'size'
-            # FIXME [mwu] Below the `size` field should be present. Depends on 
-            #             https://github.com/enso-org/enso/issues/1602
-            expect table (labels 'x' 'size') '[{"x":10,"y":21},{"x":20,"y":22}]'
+            expect table (labels 'x' 'size') '[{"size":21,"x":10,"y":21},{"size":22,"x":20,"y":22}]'
 
         Test.specify "used default index for `x` if none set" <|
             header = [ 'y'  , 'bar' , 'size']


### PR DESCRIPTION
### Pull Request Description
This PR:
1. Adjusts visualization preprocessor code, so the column lookup is case-insensitive.
2. Adds preprocessor to be used in Geo Map visualization.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
