### PR TITLE
Fix Evaluation of Cached Atoms

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
@@ -33,7 +33,7 @@ public abstract class ConstructorBranchNode extends BranchNode {
 
   @Specialization
   void doAtom(VirtualFrame frame, Object state, Atom target) {
-    if (profile.profile(matcher == target.getConstructor())) {
+    if (profile.profile(matcher.equals(target.getConstructor()))) {
       accept(frame, state, target.getFields());
     }
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
@@ -28,6 +28,8 @@ import org.enso.interpreter.runtime.library.dispatch.MethodDispatchLibrary;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.pkg.QualifiedName;
 
+import java.util.Objects;
+
 /** A representation of an Atom constructor. */
 @ExportLibrary(InteropLibrary.class)
 @ExportLibrary(MethodDispatchLibrary.class)
@@ -48,6 +50,25 @@ public final class AtomConstructor implements TruffleObject {
   public AtomConstructor(String name, ModuleScope definitionScope) {
     this.name = name;
     this.definitionScope = definitionScope;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AtomConstructor that = (AtomConstructor) o;
+    return name.equals(that.name)
+        && Objects.equals(
+        definitionScope.getAssociatedType(), that.definitionScope.getAssociatedType());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, definitionScope);
   }
 
   /**
@@ -231,8 +252,7 @@ public final class AtomConstructor implements TruffleObject {
     static final int CACHE_SIZE = 10;
 
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(
-        Context context, AtomConstructor cons, UnresolvedSymbol symbol) {
+    static Function doResolve(Context context, AtomConstructor cons, UnresolvedSymbol symbol) {
       return symbol.resolveFor(cons, context.getBuiltins().any());
     }
 
@@ -250,8 +270,7 @@ public final class AtomConstructor implements TruffleObject {
         @CachedContext(Language.class) Context context,
         @Cached("symbol") UnresolvedSymbol cachedSymbol,
         @Cached("_this") AtomConstructor cachedConstructor,
-        @Cached("doResolve(context, cachedConstructor, cachedSymbol)")
-            Function function) {
+        @Cached("doResolve(context, cachedConstructor, cachedSymbol)") Function function) {
       return function;
     }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -198,8 +198,8 @@ trait ProgramExecutionSupport {
     }
 
     val onCachedValueCallback: Consumer[ExpressionValue] = { value =>
+      logger.log(Level.FINEST, s"ON_CACHED_VALUE ${value.getExpressionId}")
       if (updatedVisualisations.contains(value.getExpressionId)) {
-        logger.log(Level.FINEST, s"ON_CACHED_VALUE ${value.getExpressionId}")
         fireVisualisationUpdates(contextId, value)
       }
     }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -55,7 +55,7 @@ class RuntimeServerTest
         .allowExperimentalOptions(true)
         .allowAllAccess(true)
         .option(RuntimeOptions.PACKAGES_PATH, pkg.root.getAbsolutePath)
-        .option(RuntimeOptions.LOG_LEVEL, "FINEST")
+        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
@@ -1628,7 +1628,7 @@ class RuntimeServerTest
     )
   }
 
-  it should "test shape" in {
+  it should "invoke methods on a cached atom" in {
     val contextId  = UUID.randomUUID()
     val requestId  = UUID.randomUUID()
     val newline    = System.lineSeparator()
@@ -1637,9 +1637,6 @@ class RuntimeServerTest
 
     val squareId  = metadata.addItem(125, 9)
     val surfaceId = metadata.addItem(139, 9)
-
-    println(s"square=$squareId")
-    println(s"surface=$surfaceId")
 
     val code =
       """from Builtins import all
@@ -1730,12 +1727,12 @@ class RuntimeServerTest
     )
     context.receive(3) should contain theSameElementsAs Seq(
       context.executionComplete(contextId),
-     TestMessages.update(
-       contextId,
-       surfaceId,
-       Constants.INTEGER,
-       Api.MethodPointer(moduleName, "Test.Main.Square", "surface")
-     ),
+      TestMessages.update(
+        contextId,
+        surfaceId,
+        Constants.INTEGER,
+        Api.MethodPointer(moduleName, "Test.Main.Square", "surface")
+      ),
       context.executionComplete(contextId)
     )
 

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -55,7 +55,7 @@ class RuntimeServerTest
         .allowExperimentalOptions(true)
         .allowAllAccess(true)
         .option(RuntimeOptions.PACKAGES_PATH, pkg.root.getAbsolutePath)
-        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+        .option(RuntimeOptions.LOG_LEVEL, "FINEST")
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
@@ -1626,6 +1626,119 @@ class RuntimeServerTest
       TestMessages.update(contextId, mainRes, Constants.NOTHING),
       context.executionComplete(contextId)
     )
+  }
+
+  it should "test shape" in {
+    val contextId  = UUID.randomUUID()
+    val requestId  = UUID.randomUUID()
+    val newline    = System.lineSeparator()
+    val moduleName = "Test.Main"
+    val metadata   = new Metadata
+
+    val squareId  = metadata.addItem(125, 9)
+    val surfaceId = metadata.addItem(139, 9)
+
+    println(s"square=$squareId")
+    println(s"surface=$surfaceId")
+
+    val code =
+      """from Builtins import all
+        |
+        |type Shape
+        |    type Square a
+        |
+        |    surface = case this of
+        |        Square a -> a * a
+        |
+        |main =
+        |    s = Square 12
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // Open the new file
+    context.send(
+      Api.Request(Api.OpenFileNotification(mainFile, contents, true))
+    )
+    context.receiveNone shouldEqual None
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, "Test.Main", "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+    context.receive(4) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      Api.Response(
+        Api.ExecutionUpdate(
+          contextId,
+          Seq(
+            Api.ExecutionResult.Diagnostic.warning(
+              "Unused variable s.",
+              Some(mainFile),
+              Some(model.Range(model.Position(9, 4), model.Position(9, 5))),
+              None
+            )
+          )
+        )
+      ),
+      TestMessages.update(contextId, squareId, "Test.Main.Square"),
+      context.executionComplete(contextId)
+    )
+
+    // Modify the file
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          mainFile,
+          Seq(
+            TextEdit(
+              model.Range(model.Position(9, 17), model.Position(9, 17)),
+              s"$newline    s"
+            )
+          )
+        )
+      )
+    )
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          mainFile,
+          Seq(
+            TextEdit(
+              model.Range(model.Position(10, 5), model.Position(10, 5)),
+              s".surface"
+            )
+          )
+        )
+      )
+    )
+    context.receive(3) should contain theSameElementsAs Seq(
+      context.executionComplete(contextId),
+     TestMessages.update(
+       contextId,
+       surfaceId,
+       Constants.INTEGER,
+       Api.MethodPointer(moduleName, "Test.Main.Square", "surface")
+     ),
+      context.executionComplete(contextId)
+    )
+
   }
 
   it should "support file modification operations without attached ids" in {


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1662

Fixes related to the evaluation of cached atoms.

The fact that an atom carries its own scope breaks the method resolution when this atom is cached. 
There are places in runtime where atom constructors are compared by reference. It would not work when the atom is cached and carries an instance of atom constructor created during the previous compilation.

Changelog:
- fix: method resolution involving cached atoms
- fix: case expressions containing cached atoms

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
