### PR TITLE
Resolve Clashing Project Ids

### DIFF
--- a/engine/language-server/src/test/resources/application.conf
+++ b/engine/language-server/src/test/resources/application.conf
@@ -5,3 +5,4 @@ akka.loglevel = "ERROR"
 akka.test.timefactor = ${?CI_TEST_TIMEFACTOR}
 akka.test.single-expect-default = 5s
 searcher.db.numThreads = 1
+searcher.db.properties.journal_mode = "memory"

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/util/TruffleFileSystem.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/util/TruffleFileSystem.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -91,5 +92,10 @@ public class TruffleFileSystem implements FileSystem<TruffleFile> {
   @Override
   public boolean isRegularFile(TruffleFile file) {
     return file.isRegularFile();
+  }
+
+  @Override
+  public FileTime getCreationTime(TruffleFile file) throws IOException {
+    return file.getCreationTime();
   }
 }

--- a/lib/scala/pkg/src/main/scala/org/enso/filesystem/FileSystem.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/filesystem/FileSystem.scala
@@ -3,7 +3,7 @@ package org.enso.filesystem
 import scala.jdk.CollectionConverters._
 import java.io.{BufferedReader, BufferedWriter, File, IOException}
 import java.nio.file.Files
-import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.{BasicFileAttributes, FileTime}
 import java.util.stream
 
 /** A generic specification of file operations based on an abstract notion
@@ -110,12 +110,13 @@ trait FileSystem[F] {
     */
   def isRegularFile(file: F): Boolean
 
-  /** Read basic file attributes.
+  /** Get creation time of the file.
     *
-    * @param file the file to check
-    * @return the file attributes
+    * @param file the file to check.
+    * @return the file creation time.
     */
-  def readAttributes(file: F): BasicFileAttributes
+  @throws[IOException]
+  def getCreationTime(file: F): FileTime
 }
 
 object FileSystem {
@@ -151,7 +152,7 @@ object FileSystem {
 
     def isRegularFile: Boolean = fs.isRegularFile(file)
 
-    def readAttributes: BasicFileAttributes = fs.readAttributes(file)
+    def getCreationTime: FileTime = fs.getCreationTime(file)
   }
 
   /** A [[File]] based implementation of [[FileSystem]].
@@ -191,7 +192,9 @@ object FileSystem {
     override def isRegularFile(file: File): Boolean =
       Files.isRegularFile(file.toPath)
 
-    override def readAttributes(file: File): BasicFileAttributes =
-      Files.readAttributes(file.toPath, classOf[BasicFileAttributes])
+    override def getCreationTime(file: File): FileTime =
+      Files
+        .readAttributes(file.toPath, classOf[BasicFileAttributes])
+        .creationTime()
   }
 }

--- a/lib/scala/pkg/src/main/scala/org/enso/filesystem/FileSystem.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/filesystem/FileSystem.scala
@@ -3,6 +3,7 @@ package org.enso.filesystem
 import scala.jdk.CollectionConverters._
 import java.io.{BufferedReader, BufferedWriter, File, IOException}
 import java.nio.file.Files
+import java.nio.file.attribute.BasicFileAttributes
 import java.util.stream
 
 /** A generic specification of file operations based on an abstract notion
@@ -109,6 +110,12 @@ trait FileSystem[F] {
     */
   def isRegularFile(file: F): Boolean
 
+  /** Read basic file attributes.
+    *
+    * @param file the file to check
+    * @return the file attributes
+    */
+  def readAttributes(file: F): BasicFileAttributes
 }
 
 object FileSystem {
@@ -143,6 +150,8 @@ object FileSystem {
     def isDirectory: Boolean = fs.isDirectory(file)
 
     def isRegularFile: Boolean = fs.isRegularFile(file)
+
+    def readAttributes: BasicFileAttributes = fs.readAttributes(file)
   }
 
   /** A [[File]] based implementation of [[FileSystem]].
@@ -181,5 +190,8 @@ object FileSystem {
 
     override def isRegularFile(file: File): Boolean =
       Files.isRegularFile(file.toPath)
+
+    override def readAttributes(file: File): BasicFileAttributes =
+      Files.readAttributes(file.toPath, classOf[BasicFileAttributes])
   }
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectFileRepository.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectFileRepository.scala
@@ -94,14 +94,16 @@ class ProjectFileRepository[
       pkg  <- pkgOpt
       meta <- metaOpt
     } yield {
+      val attributes = pkg.fileSystem.readAttributes(pkg.root)
       Project(
-        id            = meta.id,
-        name          = pkg.name,
-        kind          = meta.kind,
-        created       = meta.created,
-        engineVersion = pkg.config.ensoVersion,
-        lastOpened    = meta.lastOpened,
-        path          = Some(directory.toString)
+        id                    = meta.id,
+        name                  = pkg.name,
+        kind                  = meta.kind,
+        created               = meta.created,
+        engineVersion         = pkg.config.ensoVersion,
+        lastOpened            = meta.lastOpened,
+        path                  = Some(directory.toString),
+        directoryCreationTime = Some(attributes.creationTime())
       )
     }
   }
@@ -331,7 +333,7 @@ class ProjectFileRepository[
     projects.groupBy(_.id).foldRight(List.empty[(Boolean, Project)]) {
       case ((_, groupedProjects), acc) =>
         // groupBy always returns non-empty list
-        (groupedProjects: @unchecked) match {
+        (groupedProjects.sortBy(_.directoryCreationTime): @unchecked) match {
           case project :: clashingProjects =>
             (false, project) :: clashingProjects.map((true, _)) ::: acc
         }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/model/Project.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/model/Project.scala
@@ -1,5 +1,6 @@
 package org.enso.projectmanager.model
 
+import java.nio.file.attribute.FileTime
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -20,7 +21,8 @@ case class Project(
   name: String,
   kind: ProjectKind,
   created: OffsetDateTime,
-  engineVersion: EnsoVersion         = DefaultEnsoVersion,
-  lastOpened: Option[OffsetDateTime] = None,
-  path: Option[String]               = None
+  engineVersion: EnsoVersion              = DefaultEnsoVersion,
+  lastOpened: Option[OffsetDateTime]      = None,
+  path: Option[String]                    = None,
+  directoryCreationTime: Option[FileTime] = None
 )

--- a/lib/scala/project-manager/src/test/resources/application.conf
+++ b/lib/scala/project-manager/src/test/resources/application.conf
@@ -59,3 +59,5 @@ akka.loglevel = "ERROR"
 akka.test.timefactor = ${?CI_TEST_TIMEFACTOR}
 akka.test.single-expect-default = 5s
 searcher.db.numThreads = 1
+searcher.db.properties.journal_mode = "memory"
+


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1581

Project manager assigns fresh identifiers to the projects that have duplicate project ids. Which project is original is decided by the directory creation time.

Changelog
- feat: when reading the projects list, resolve duplicate project ids based on the directory creation time
- test: set SQLite journaling mode to memory, to avoid messing up the test environment

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
