### PR TITLE
Fix some naming for Maybe

### DIFF
--- a/distribution/std-lib/Standard/src/Base/Data/Maybe.enso
+++ b/distribution/std-lib/Standard/src/Base/Data/Maybe.enso
@@ -18,24 +18,24 @@ type Maybe
        Arguments:
        - default: The value to return if `this` is Nothing. This value is lazy
          and hence will not execute any provided computation unless it is used.
-       - function: The function to execute on the value inside the `Just`, if it
+       - function: The function to execute on the value inside the `Some`, if it
          is a just.
 
        > Example
-         Apply a function over a Just value to get 4.
-             (Just 2).maybe 0 *2
+         Apply a function over a Some value to get 4.
+             (Some 2).maybe 0 *2
     maybe : Any -> (Any -> Any) -> Any
     maybe ~default function = case this of
         Nothing -> default
         Some val -> function val
 
-    ## Check if the maybe value is `Just`.
+    ## Check if the maybe value is `Some`.
 
        > Example
-         Check if `Nothing` is `Just`.
-             Nothing.is_just
-    is_just : Boolean
-    is_just = case this of
+         Check if `Nothing` is `Some`.
+             Nothing.is_some
+    is_some : Boolean
+    is_some = case this of
         Nothing -> False
         Some _ -> True
 
@@ -45,5 +45,5 @@ type Maybe
          Check if `Nothing` is `Nothing`.
              Nothing.is_nothing
     is_nothing : Boolean
-    is_nothing = this.is_just.not
+    is_nothing = this.is_some.not
 

--- a/test/Tests/src/Data/Maybe_Spec.enso
+++ b/test/Tests/src/Data/Maybe_Spec.enso
@@ -5,14 +5,14 @@ import Standard.Test
 spec = Test.group "Maybe" <|
     Test.specify "should have a Nothing variant" <|
         Nothing . should_equal Nothing
-    Test.specify "should have a Just variant" <|
+    Test.specify "should have a Some variant" <|
         (Maybe.Some 2).value . should_equal 2
     Test.specify "should provide the `maybe` function" <|
         Nothing.maybe 2 x->x . should_equal 2
         (Maybe.Some 7).maybe 2 (*2) . should_equal 14
-    Test.specify "should provide `is_just`" <|
-        Nothing.is_just . should_be_false
-        Maybe.Some 2 . is_just . should_be_true
+    Test.specify "should provide `is_some`" <|
+        Nothing.is_some . should_be_false
+        Maybe.Some 2 . is_some . should_be_true
     Test.specify "should provide `is_nothing`" <|
         Nothing.is_nothing . should_be_true
         Maybe.Some 2 . is_nothing . should_be_false


### PR DESCRIPTION
### Pull Request Description
Fixes the naming for the `Some` component of `Maybe`.

### Important Notes
Breaks the API for `Maybe`.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
