### PR TITLE
Remove Unused JAR Launcher Prefix to Fix Issue with Signing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1108,16 +1108,6 @@ lazy val `engine-runner` = project
       case x =>
         MergeStrategy.first
     },
-    assemblyOption in assembly := (assemblyOption in assembly).value
-      .copy(
-        prependShellScript = Some(
-          defaultUniversalScript(
-            shebang = false,
-            javaOpts = truffleRunOptions ++
-              Seq("-Dtruffle.class.path.append=runtime.jar")
-          )
-        )
-      ),
     commands += WithDebugCommand.withDebug,
     inConfig(Compile)(truffleRunOptionsSettings),
     libraryDependencies ++= Seq(

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -661,7 +661,7 @@ Below are options uses by the Language Server:
 To run the Language Server on 127.0.0.1:8080 type:
 
 ```bash
-./runner.jar \
+distribution/bin/enso \
   --server \
   --root-id 3256d10d-45be-45b1-9ea4-7912ef4226b1 \
   --path /tmp/content-root


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

A fix that seems necessary for https://github.com/enso-org/ide/pull/1366

The prefix was needed to launch `runner.jar` directly (by typing `./runner.jar`), it was setting up the reference to the runtime. It is not really needed because we have the launch scripts for debugging and for the users, the recommended way it to just use the official laumcher.

It seems that the prefix was causing some issues with how the JAR archive was handled during signing, making it not runnable at all after being signed, so removing this unnecessary prefix was the simplest fix for the issue.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
