### PR TITLE
Remove Reflective Access when Loading OpenCV

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -237,6 +237,7 @@ jobs:
           $ENGINE_DIST_DIR/bin/enso --run test/Database_Tests
           $ENGINE_DIST_DIR/bin/enso --run test/Geo_Tests
           $ENGINE_DIST_DIR/bin/enso --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso --run test/Image_Tests
 
       - name: Test Engine Distribution (Windows)
         shell: bash
@@ -247,6 +248,7 @@ jobs:
           $ENGINE_DIST_DIR/bin/enso.bat --run test/Database_Tests
           $ENGINE_DIST_DIR/bin/enso.bat --run test/Geo_Tests
           $ENGINE_DIST_DIR/bin/enso.bat --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --run test/Image_Tests
 
       # Publish
       - name: Publish the Engine Distribution Artifact

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Enso Next
 
+## Libraries
+
+- Removed reflective access when loading OpenCV library
+  ([#1727](https://github.com/enso-org/enso/pull/1727)). Illegal reflective
+  access operations were deprecated and will be denied in future JVM releases.
+
 ## Miscellaneous
 
 - Adding a pipeline for automatic nightly builds - during the night after each

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 ## Libraries
 
-- Removed reflective access when loading OpenCV library
+- Removed reflective access when loading the OpenCV library
   ([#1727](https://github.com/enso-org/enso/pull/1727)). Illegal reflective
   access operations were deprecated and will be denied in future JVM releases.
 

--- a/std-bits/src/main/java/org/enso/image/Codecs.java
+++ b/std-bits/src/main/java/org/enso/image/Codecs.java
@@ -1,7 +1,6 @@
 package org.enso.image;
 
 import org.enso.image.opencv.OpenCV;
-import org.opencv.core.Core;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfInt;
 import org.opencv.imgcodecs.Imgcodecs;
@@ -12,8 +11,7 @@ public class Codecs {
   public static final int READ_FLAG_EMPTY = -127;
 
   static {
-    OpenCV.loadShared();
-    System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+    OpenCV.loadLocally();
   }
 
   /** An error occurred when reading a file. */

--- a/std-bits/src/main/java/org/enso/image/data/Image.java
+++ b/std-bits/src/main/java/org/enso/image/data/Image.java
@@ -11,8 +11,7 @@ import java.util.Base64;
 public class Image {
 
   static {
-    OpenCV.loadShared();
-    System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+    OpenCV.loadLocally();
   }
 
   private static final byte MAX_SIGNED_BYTE = -1;

--- a/std-bits/src/main/java/org/enso/image/data/Matrix.java
+++ b/std-bits/src/main/java/org/enso/image/data/Matrix.java
@@ -7,8 +7,7 @@ import org.opencv.core.*;
 public class Matrix {
 
   static {
-    OpenCV.loadShared();
-    System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+    OpenCV.loadLocally();
   }
 
   /**

--- a/test/Image_Tests/src/Codecs_Spec.enso
+++ b/test/Image_Tests/src/Codecs_Spec.enso
@@ -9,7 +9,7 @@ import Standard.Test
 polyglot java import java.lang.System as Java_System
 
 fetch addr file =
-    Process.run_command "curl" [addr, "--silent", "--output", file.path]
+    Process.run "curl" [addr, "--silent", "--output", file.path]
 
 spec =
     is_ci = Java_System.getenv "CI" == "true"


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #1721

Changelog:
- update: load OpenCV library without using reflection. The library is copied to a temporary directory and removed during the shutdown.
- fix: run `Image_Tests` on CI

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
