### PR TITLE
FlatBuffers Schema Fix

### DIFF
--- a/engine/language-server/src/main/schema/binary_protocol.fbs
+++ b/engine/language-server/src/main/schema/binary_protocol.fbs
@@ -77,7 +77,7 @@ table Error {
 }
 
 // The error payload for a read out of bounds error.
-struct ReadOutOfBoundsError {
+table ReadOutOfBoundsError {
   // The actual length of the file in which the read was out of bounds.
   fileLength : ulong;
 }


### PR DESCRIPTION
### Pull Request Description

The current schema for Language Server binary protocol makes flatc returns an error:

```
 error: only tables can be union elements in the generated language: READ_OOB
```

This is a simple fix for that.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
