### PR TITLE
Refactor the LS to Support Multiple Content Roots

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           sleep 1
           sbt --no-colors "launcher/assembly"
-          sbt --no-colors --mem 1536 "launcher-manager/buildNativeImage"
+          sbt --no-colors --mem 1536 "launcher/buildNativeImage"
 
       - name: Build the PM Native Image
         working-directory: repo

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -108,11 +108,21 @@ jobs:
         run: |
           echo "CI_TEST_TIMEFACTOR=2" >> $GITHUB_ENV
           echo "CI_TEST_FLAKY_ENABLE=true" >> $GITHUB_ENV
-      - name: Build the Launcher
+
+      - name: Build the Launcher Native Image
+        working-directory: repo
+        shell: bash
         run: |
           sleep 1
           sbt --no-colors "launcher/assembly"
           sbt --no-colors --mem 1536 "launcher/buildNativeImage"
+      - name: Build the PM Native Image
+        working-directory: repo
+        shell: bash
+        run: |
+          sleep 1
+          sbt --no-colors "project-manager/assembly"
+          sbt --no-colors --mem 1536 "project-manager/buildNativeImage"
 
       - name: Build the Runner & Runtime Uberjars
         run: |

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -111,12 +111,12 @@ jobs:
 
       - name: Build the Launcher Native Image
         working-directory: repo
-        run:
+        run: |
           sbt --no-colors "launcher/assembly"
           sbt --no-colors --mem 1536 "launcher/buildNativeImage"
       - name: Build the PM Native Image
         working-directory: repo
-        run:
+        run: |
           sbt --no-colors "project-manager/assembly"
           sbt --no-colors --mem 1536 "project-manager/buildNativeImage"
 

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -111,16 +111,12 @@ jobs:
 
       - name: Build the Launcher Native Image
         working-directory: repo
-        shell: bash
-        run: |
-          sleep 1
+        run:
           sbt --no-colors "launcher/assembly"
           sbt --no-colors --mem 1536 "launcher/buildNativeImage"
       - name: Build the PM Native Image
         working-directory: repo
-        shell: bash
-        run: |
-          sleep 1
+        run:
           sbt --no-colors "project-manager/assembly"
           sbt --no-colors --mem 1536 "project-manager/buildNativeImage"
 

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -110,12 +110,10 @@ jobs:
           echo "CI_TEST_FLAKY_ENABLE=true" >> $GITHUB_ENV
 
       - name: Build the Launcher Native Image
-        working-directory: repo
         run: |
           sbt --no-colors "launcher/assembly"
           sbt --no-colors --mem 1536 "launcher/buildNativeImage"
       - name: Build the PM Native Image
-        working-directory: repo
         run: |
           sbt --no-colors "project-manager/assembly"
           sbt --no-colors --mem 1536 "project-manager/buildNativeImage"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -36,6 +36,9 @@
 - Added support for reading and writing byte ranges in files remotely
   ([#1795](https://github.com/enso-org/enso/pull/1795)). This allows the IDE to
   transfer files to a remote back-end in a streaming fashion.
+- Added support for multiple content roots in the language server
+  ([#1800](https://github.com/enso-org/enso/pull/1800/)). It is not yet exposed
+  to the IDE, as this will be done as part of future work.
 
 ## Libraries
 

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -1,6 +1,8 @@
 ---
-layout: developer-doc title: Enso Protocol Language Server Message Specification category:
-language-server tags: [language-server, protocol, specification]
+layout: developer-doc
+title: Enso Protocol Language Server Message Specification
+category: language-server
+tags: [language-server, protocol, specification]
 order: 4
 ---
 
@@ -55,8 +57,6 @@ transport formats, please look [here](./protocol-architecture).
   - [`WorkspaceEdit`](#workspaceedit)
   - [`EnsoDigest`](#ensodigest)
   - [`FileSegment`](#filesegment)
-  - [`ContentRoot`](#contentroot)
-  - [`ContentRootType`](#contentroottype)
 - [Connection Management](#connection-management)
   - [`session/initProtocolConnection`](#sessioninitprotocolconnection)
   - [`session/initBinaryConnection`](#sessioninitbinaryconnection)
@@ -991,8 +991,7 @@ structure on the binary connection please see [`EnsoDigest`](#ensodigest)
 #### Format
 
 ```typescript
-type SHA3
--224 = String;
+type SHA3-224 = String;
 ```
 
 ### `FileEdit`
@@ -1024,12 +1023,8 @@ applyEdits buffer (first : rest) = applyEdits (applyTextEdit buffer first) rest
 interface FileEdit {
   path: Path;
   edits: [TextEdit];
-  oldVersion: SHA3
-  -
-  224;
-  newVersion: SHA3
-  -
-  224;
+  oldVersion: SHA3-224;
+  newVersion: SHA3-224;
 }
 ```
 
@@ -1044,7 +1039,7 @@ interface FileContents<T> {
   contents: T;
 }
 
-class TextFileContents extends FileContents[String] {}
+class TextFileContents extends FileContents<String> {}
 ```
 
 ### `FileSystemObject`
@@ -1162,10 +1157,9 @@ VFS.
 interface ContentRoot {
   // A unique identifier for the content root.
   id: UUID;
-
   // The type of content root.
   type: ContentRootType;
-  
+
   // The name of the content root.
   name: String;
 }
@@ -1182,11 +1176,11 @@ type ContentRootType = Project | Root | Home | Library | Custom;
 These represent:
 
 - `Project`: This content root points to the project home.
-- `Root`: This content root points to the system root (`/`) on unix systems,
-  or to a drive root on Windows. In Windows' case, there may be multiple
-  `Root` entries corresponding to the various drives.
+- `Root`: This content root points to the system root (`/`) on unix systems, or
+  to a drive root on Windows. In Windows' case, there may be multiple `Root`
+  entries corresponding to the various drives.
 - `Home`: The user's home directory.
-- `Library`: An Enso library location.  
+- `Library`: An Enso library location.
 - `Custom`: A content root that has been added by the IDE (unused for now).
 
 ## Connection Management
@@ -1217,7 +1211,7 @@ be correlated between the textual and data connections.
 
 ```typescript
 {
-  contentRoots: [ContentRoot];
+  contentRoots: [UUID];
 }
 ```
 
@@ -1289,7 +1283,7 @@ client.
 ```typescript
 {
   method: String;
-  registerOptions ? : any;
+  registerOptions?: any;
 }
 ```
 
@@ -1511,7 +1505,7 @@ must fail.
 ```typescript
 {
   path: Path;
-  contents: FileContents[T];
+  contents: FileContents<T>;
 }
 ```
 
@@ -1555,7 +1549,7 @@ return the contents from the in-memory buffer rather than the file on disk.
 
 ```typescript
 {
-  contents: FileContents[T];
+  contents: FileContents<T>;
 }
 ```
 
@@ -1968,7 +1962,7 @@ directory tree starting at a given path.
 ```typescript
 {
   path: Path;
-  depth ? : Number;
+  depth?: Number;
 }
 ```
 
@@ -2083,9 +2077,7 @@ interface ChecksumRequest {
 ```typescript
 interface ChecksumResponse {
   // The checksum of the file at `path`.
-  checksum: SHA3
-  -
-  224;
+  checksum : SHA3-224;
 }
 ```
 
@@ -2301,9 +2293,9 @@ client that sent the `text/openFile` message.
 
 ```typescript
 {
-  writeCapability ? : CapabilityRegistration;
+  writeCapability?: CapabilityRegistration;
   content: String;
-  currentVersion: SHA3 - 224;
+  currentVersion: SHA3-224;
 }
 ```
 
@@ -2512,7 +2504,7 @@ server undoing that same action for all clients in the workspace.
 
 ```typescript
 {
-  requestID ? : UUID; // If not specified, it undoes the latest request
+  requestID?: UUID; // If not specified, it undoes the latest request
 }
 ```
 
@@ -2543,7 +2535,7 @@ server redoing that same action for all clients in the workspace.
 
 ```typescript
 {
-  requestID ? : UUID; // If not specified, it redoes the latest request
+  requestID?: UUID; // If not specified, it redoes the latest request
 }
 ```
 
@@ -3034,7 +3026,7 @@ May include a list of expressions for which caches should be invalidated.
 ```typescript
 {
   contextId: ContextId;
-  invalidatedExpressions ? : "all" | [ExpressionId]
+  invalidatedExpressions?: "all" | [ExpressionId]
 }
 ```
 
@@ -3110,7 +3102,7 @@ stack, an error location a method or a module when issuing a
   /**
    * The location of a file producing the error.
    */
-  path ? : Path;
+  path?: Path;
 }
 ```
 
@@ -3685,11 +3677,11 @@ Sent from client to the server to receive the autocomplete suggestion.
   // The cursor position
   position: Position;
   // Filter by methods with the provided self type
-  selfType ? : string;
+  selfType?: string;
   // Filter by the return type
-  returnType ? : string;
+  returnType?: string;
   // Filter by the suggestion types
-  tags ? : [SuggestionEntryType];
+  tags?: [SuggestionEntryType];
 }
 ```
 
@@ -3999,15 +3991,9 @@ Note:
 It signals that a user doesn't have access to a resource.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  100,
-      "message"
-:
-  "Access denied"
+"error" : {
+  "code" : 100,
+  "message" : "Access denied"
 }
 ```
 
@@ -4016,15 +4002,9 @@ It signals that a user doesn't have access to a resource.
 This error signals generic file system errors.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  1000,
-      "message"
-:
-  String
+"error" : {
+  "code" : 1000,
+  "message" : String
 }
 ```
 
@@ -4033,15 +4013,9 @@ This error signals generic file system errors.
 The error informs that the requested content root cannot be found.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  1001,
-      "message"
-:
-  "Content root not found"
+"error" : {
+  "code" : 1001,
+  "message" : "Content root not found"
 }
 ```
 
@@ -4050,15 +4024,9 @@ The error informs that the requested content root cannot be found.
 It signals that requested file doesn't exist.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  1003,
-      "message"
-:
-  "File not found"
+"error" : {
+  "code" : 1003,
+  "message" : "File not found"
 }
 ```
 
@@ -4067,15 +4035,9 @@ It signals that requested file doesn't exist.
 It signals that file already exists.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  1004,
-      "message"
-:
-  "File already exists"
+"error" : {
+  "code" : 1004,
+  "message" : "File already exists"
 }
 ```
 
@@ -4084,15 +4046,9 @@ It signals that file already exists.
 It signals that IO operation timed out.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  1005,
-      "message"
-:
-  "IO operation timeout"
+"error" : {
+  "code" : 1005,
+  "message" : "IO operation timeout"
 }
 ```
 
@@ -4101,15 +4057,9 @@ It signals that IO operation timed out.
 It signals that provided path is not a directory.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  1006,
-      "message"
-:
-  "Path is not a directory"
+"error" : {
+  "code" : 1006,
+  "message" : "Path is not a directory"
 }
 ```
 
@@ -4118,15 +4068,9 @@ It signals that provided path is not a directory.
 It signals that the provided path is not a file.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  1007,
-      "message"
-:
-  "Path is not a file"
+"error" : {
+  "code" : 1007,
+  "message" : "Path is not a file"
 }
 ```
 
@@ -4136,15 +4080,9 @@ Signals that a streaming file write cannot overwrite a portion of the requested
 file.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  1008,
-      "message"
-:
-  "Cannot overwrite the file without `overwriteExisting` set"
+"error" : {
+  "code" : 1008,
+  "message" : "Cannot overwrite the file without `overwriteExisting` set"
 }
 ```
 
@@ -4153,21 +4091,11 @@ file.
 Signals that the requested file read was out of bounds for the file's size.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  1009
-  "message"
-:
-  "Read is out of bounds for the file"
-  "data"
-:
-  {
-    "fileLength"
-  :
-    0
+"error" : {
+  "code" : 1009
+  "message" : "Read is out of bounds for the file"
+  "data" : {
+    "fileLength" : 0
   }
 }
 ```
@@ -4177,15 +4105,9 @@ Signals that the requested file read was out of bounds for the file's size.
 Signals that the project configuration cannot be decoded.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  1010
-  "message"
-:
-  "Cannot decode the project configuration"
+"error" : {
+  "code" : 1010
+  "message" : "Cannot decode the project configuration"
 }
 ```
 
@@ -4203,15 +4125,9 @@ table ReadOutOfBoundsError {
 It signals that provided stack item was not found.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  2001,
-      "message"
-:
-  "Stack item not found"
+"error" : {
+  "code" : 2001,
+  "message" : "Stack item not found"
 }
 
 ```
@@ -4221,15 +4137,9 @@ It signals that provided stack item was not found.
 It signals that provided context was not found.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  2002,
-      "message"
-:
-  "Context not found"
+"error" : {
+  "code" : 2002,
+  "message" : "Context not found"
 }
 ```
 
@@ -4238,15 +4148,9 @@ It signals that provided context was not found.
 It signals that stack is empty.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  2003,
-      "message"
-:
-  "Stack is empty"
+"error" : {
+  "code" : 2003,
+  "message" : "Stack is empty"
 }
 ```
 
@@ -4255,15 +4159,9 @@ It signals that stack is empty.
 It signals that stack is invalid in this context.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  2004,
-      "message"
-:
-  "Invalid stack item"
+"error" : {
+  "code" : 2004,
+  "message" : "Invalid stack item"
 }
 ```
 
@@ -4272,15 +4170,9 @@ It signals that stack is invalid in this context.
 It signals that the given module cannot be found.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  2005,
-      "message"
-:
-  "Module not found [Foo.Bar.Baz]"
+"error" : {
+  "code" : 2005,
+  "message" : "Module not found [Foo.Bar.Baz]"
 }
 ```
 
@@ -4289,15 +4181,9 @@ It signals that the given module cannot be found.
 It signals that the visualisation cannot be found.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  2006,
-      "message"
-:
-  "Visualisation not found"
+"error" : {
+  "code" : 2006,
+  "message" : "Visualisation not found"
 }
 ```
 
@@ -4308,59 +4194,25 @@ cannot be evaluated. The error contains an optional `data` field of type
 [`Diagnostic`](#diagnostic) providing error details.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  2007,
-      "message"
-:
-  "Evaluation of the visualisation expression failed [i is not defined]"
-  "data"
-:
-  {
-    "kind"
-  :
-    "Error",
-        "message"
-  :
-    "i is not defined",
-        "path"
-  :
-    null,
-        "location"
-  :
-    {
-      "start"
-    :
-      {
-        "line"
-      :
-        0,
-            "character"
-      :
-        8
+"error" : {
+  "code" : 2007,
+  "message" : "Evaluation of the visualisation expression failed [i is not defined]"
+  "data" : {
+    "kind" : "Error",
+    "message" : "i is not defined",
+    "path" : null,
+    "location" : {
+      "start" : {
+        "line" : 0,
+        "character" : 8
+      },
+      "end" : {
+        "line" : 0,
+        "character" : 9
       }
-    ,
-      "end"
-    :
-      {
-        "line"
-      :
-        0,
-            "character"
-      :
-        9
-      }
-    }
-  ,
-    "expressionId"
-  :
-    "aa1f75c4-8c4d-493d-a6a7-72123a52f084",
-        "stack"
-  :
-    []
+    },
+    "expressionId" : "aa1f75c4-8c4d-493d-a6a7-72123a52f084",
+    "stack" : []
   }
 }
 ```
@@ -4370,15 +4222,9 @@ cannot be evaluated. The error contains an optional `data` field of type
 Signals that a file wasn't opened.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  3001,
-      "message"
-:
-  "File not opened"
+"error" : {
+  "code" : 3001,
+  "message" : "File not opened"
 }
 ```
 
@@ -4387,15 +4233,9 @@ Signals that a file wasn't opened.
 Signals that validation has failed for a series of edits.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  3002,
-      "message"
-:
-  "The start position is after the end position"
+"error" : {
+  "code" : 3002,
+  "message" : "The start position is after the end position"
 }
 ```
 
@@ -4405,15 +4245,9 @@ Signals that version provided by a client doesn't match to the version computed
 by the server.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  3003,
-      "message"
-:
-  "Invalid version [client version: ade2967cab172183d1a67ea40cb8e92e23218764bc9934c3795fcea5, server version: 7602967cab172183d1a67ea40cb8e92e23218764bc9934c3795fcea5]"
+"error" : {
+  "code" : 3003,
+  "message" : "Invalid version [client version: ade2967cab172183d1a67ea40cb8e92e23218764bc9934c3795fcea5, server version: 7602967cab172183d1a67ea40cb8e92e23218764bc9934c3795fcea5]"
 }
 ```
 
@@ -4422,15 +4256,9 @@ by the server.
 Signals that the client doesn't hold write lock to the buffer.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  3004,
-      "message"
-:
-  "Write denied"
+"error" : {
+  "code" : 3004,
+  "message" : "Write denied"
 }
 ```
 
@@ -4439,15 +4267,9 @@ Signals that the client doesn't hold write lock to the buffer.
 Signals that requested capability is not acquired.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  5001,
-      "message"
-:
-  "Capability not acquired"
+"error" : {
+  "code" : 5001,
+  "message" : "Capability not acquired"
 }
 ```
 
@@ -4456,15 +4278,9 @@ Signals that requested capability is not acquired.
 Signals that requested cannot be proccessed, beacuse session is not initialised.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  6001,
-      "message"
-:
-  "Session not initialised"
+"error" : {
+  "code" : 6001,
+  "message" : "Session not initialised"
 }
 ```
 
@@ -4473,15 +4289,9 @@ Signals that requested cannot be proccessed, beacuse session is not initialised.
 Signals that session is already initialised.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  6002,
-      "message"
-:
-  "Session already initialised"
+"error" : {
+  "code" : 6002,
+  "message" : "Session already initialised"
 }
 ```
 
@@ -4490,15 +4300,9 @@ Signals that session is already initialised.
 Signals about the failure in the Language Server initialization process.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  6003,
-      "message"
-:
-  "Failed to initialize the Language Server resources"
+"error" : {
+  "code" : 6003,
+  "message" : "Failed to initialize the Language Server resources"
 }
 ```
 
@@ -4507,15 +4311,9 @@ Signals about the failure in the Language Server initialization process.
 Signals about an error accessing the suggestions database.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  7001,
-      "message"
-:
-  "Suggestions database error"
+"error" : {
+  "code" : 7001,
+  "message" : "Suggestions database error"
 }
 ```
 
@@ -4524,15 +4322,9 @@ Signals about an error accessing the suggestions database.
 Signals that the project not found in the root directory.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  7002,
-      "message"
-:
-  "Project not found in the root directory"
+"error" : {
+  "code" : 7002,
+  "message" : "Project not found in the root directory"
 }
 ```
 
@@ -4541,15 +4333,9 @@ Signals that the project not found in the root directory.
 Signals that the module name can not be resolved for the given file.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  7003,
-      "message"
-:
-  "Module name can't be resolved for the given file"
+"error" : {
+  "code" : 7003,
+  "message" : "Module name can't be resolved for the given file"
 }
 ```
 
@@ -4558,14 +4344,8 @@ Signals that the module name can not be resolved for the given file.
 Signals that the requested suggestion was not found.
 
 ```typescript
-"error"
-:
-{
-  "code"
-:
-  7004,
-      "message"
-:
-  "Requested suggestion was not found"
+"error" : {
+  "code" : 7004,
+  "message" : "Requested suggestion was not found"
 }
 ```

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -1,8 +1,6 @@
 ---
-layout: developer-doc
-title: Enso Protocol Language Server Message Specification
-category: language-server
-tags: [language-server, protocol, specification]
+layout: developer-doc title: Enso Protocol Language Server Message Specification category:
+language-server tags: [language-server, protocol, specification]
 order: 4
 ---
 
@@ -57,6 +55,8 @@ transport formats, please look [here](./protocol-architecture).
   - [`WorkspaceEdit`](#workspaceedit)
   - [`EnsoDigest`](#ensodigest)
   - [`FileSegment`](#filesegment)
+  - [`ContentRoot`](#contentroot)
+  - [`ContentRootType`](#contentroottype)
 - [Connection Management](#connection-management)
   - [`session/initProtocolConnection`](#sessioninitprotocolconnection)
   - [`session/initBinaryConnection`](#sessioninitbinaryconnection)
@@ -991,7 +991,8 @@ structure on the binary connection please see [`EnsoDigest`](#ensodigest)
 #### Format
 
 ```typescript
-type SHA3-224 = String;
+type SHA3
+-224 = String;
 ```
 
 ### `FileEdit`
@@ -1023,8 +1024,12 @@ applyEdits buffer (first : rest) = applyEdits (applyTextEdit buffer first) rest
 interface FileEdit {
   path: Path;
   edits: [TextEdit];
-  oldVersion: SHA3-224;
-  newVersion: SHA3-224;
+  oldVersion: SHA3
+  -
+  224;
+  newVersion: SHA3
+  -
+  224;
 }
 ```
 
@@ -1035,11 +1040,11 @@ A representation of the contents of a file.
 #### Format
 
 ```typescript
-interface FileContents[T] {
+interface FileContents<T> {
   contents: T;
 }
 
-class TextFileContents extends FileContents[String];
+class TextFileContents extends FileContents[String] {}
 ```
 
 ### `FileSystemObject`
@@ -1147,6 +1152,43 @@ table FileSegment {
 The `byteOffset` property is zero-indexed, so the last byte in the file is at
 index `file.length - 1`.
 
+### `ContentRoot`
+
+A representation of a content root for use in the IDE. A content root represents
+a location on a real file-system that has been virtualised for use in the Enso
+VFS.
+
+```typescript
+interface ContentRoot {
+  // A unique identifier for the content root.
+  id: UUID;
+
+  // The type of content root.
+  type: ContentRootType;
+  
+  // The name of the content root.
+  name: String;
+}
+```
+
+### `ContentRootType`
+
+The type of the annotated content root.
+
+```typescript
+type ContentRootType = Project | Root | Home | Library | Custom;
+```
+
+These represent:
+
+- `Project`: This content root points to the project home.
+- `Root`: This content root points to the system root (`/`) on unix systems,
+  or to a drive root on Windows. In Windows' case, there may be multiple
+  `Root` entries corresponding to the various drives.
+- `Home`: The user's home directory.
+- `Library`: An Enso library location.  
+- `Custom`: A content root that has been added by the IDE (unused for now).
+
 ## Connection Management
 
 In order to properly set-up and tear-down the language server connection, we
@@ -1175,7 +1217,7 @@ be correlated between the textual and data connections.
 
 ```typescript
 {
-  contentRoots: [UUID];
+  contentRoots: [ContentRoot];
 }
 ```
 
@@ -1247,7 +1289,7 @@ client.
 ```typescript
 {
   method: String;
-  registerOptions?: any;
+  registerOptions ? : any;
 }
 ```
 
@@ -1926,7 +1968,7 @@ directory tree starting at a given path.
 ```typescript
 {
   path: Path;
-  depth?: Number;
+  depth ? : Number;
 }
 ```
 
@@ -2041,7 +2083,9 @@ interface ChecksumRequest {
 ```typescript
 interface ChecksumResponse {
   // The checksum of the file at `path`.
-  checksum : SHA3-224;
+  checksum: SHA3
+  -
+  224;
 }
 ```
 
@@ -2257,9 +2301,9 @@ client that sent the `text/openFile` message.
 
 ```typescript
 {
-  writeCapability?: CapabilityRegistration;
+  writeCapability ? : CapabilityRegistration;
   content: String;
-  currentVersion: SHA3-224;
+  currentVersion: SHA3 - 224;
 }
 ```
 
@@ -2468,7 +2512,7 @@ server undoing that same action for all clients in the workspace.
 
 ```typescript
 {
-  requestID?: UUID; // If not specified, it undoes the latest request
+  requestID ? : UUID; // If not specified, it undoes the latest request
 }
 ```
 
@@ -2499,7 +2543,7 @@ server redoing that same action for all clients in the workspace.
 
 ```typescript
 {
-  requestID?: UUID; // If not specified, it redoes the latest request
+  requestID ? : UUID; // If not specified, it redoes the latest request
 }
 ```
 
@@ -2990,7 +3034,7 @@ May include a list of expressions for which caches should be invalidated.
 ```typescript
 {
   contextId: ContextId;
-  invalidatedExpressions?: "all" | [ExpressionId]
+  invalidatedExpressions ? : "all" | [ExpressionId]
 }
 ```
 
@@ -3066,7 +3110,7 @@ stack, an error location a method or a module when issuing a
   /**
    * The location of a file producing the error.
    */
-  path?: Path;
+  path ? : Path;
 }
 ```
 
@@ -3641,11 +3685,11 @@ Sent from client to the server to receive the autocomplete suggestion.
   // The cursor position
   position: Position;
   // Filter by methods with the provided self type
-  selfType?: string;
+  selfType ? : string;
   // Filter by the return type
-  returnType?: string;
+  returnType ? : string;
   // Filter by the suggestion types
-  tags?: [SuggestionEntryType];
+  tags ? : [SuggestionEntryType];
 }
 ```
 
@@ -3955,9 +3999,15 @@ Note:
 It signals that a user doesn't have access to a resource.
 
 ```typescript
-"error" : {
-  "code" : 100,
-  "message" : "Access denied"
+"error"
+:
+{
+  "code"
+:
+  100,
+      "message"
+:
+  "Access denied"
 }
 ```
 
@@ -3966,9 +4016,15 @@ It signals that a user doesn't have access to a resource.
 This error signals generic file system errors.
 
 ```typescript
-"error" : {
-  "code" : 1000,
-  "message" : String
+"error"
+:
+{
+  "code"
+:
+  1000,
+      "message"
+:
+  String
 }
 ```
 
@@ -3977,9 +4033,15 @@ This error signals generic file system errors.
 The error informs that the requested content root cannot be found.
 
 ```typescript
-"error" : {
-  "code" : 1001,
-  "message" : "Content root not found"
+"error"
+:
+{
+  "code"
+:
+  1001,
+      "message"
+:
+  "Content root not found"
 }
 ```
 
@@ -3988,9 +4050,15 @@ The error informs that the requested content root cannot be found.
 It signals that requested file doesn't exist.
 
 ```typescript
-"error" : {
-  "code" : 1003,
-  "message" : "File not found"
+"error"
+:
+{
+  "code"
+:
+  1003,
+      "message"
+:
+  "File not found"
 }
 ```
 
@@ -3999,9 +4067,15 @@ It signals that requested file doesn't exist.
 It signals that file already exists.
 
 ```typescript
-"error" : {
-  "code" : 1004,
-  "message" : "File already exists"
+"error"
+:
+{
+  "code"
+:
+  1004,
+      "message"
+:
+  "File already exists"
 }
 ```
 
@@ -4010,9 +4084,15 @@ It signals that file already exists.
 It signals that IO operation timed out.
 
 ```typescript
-"error" : {
-  "code" : 1005,
-  "message" : "IO operation timeout"
+"error"
+:
+{
+  "code"
+:
+  1005,
+      "message"
+:
+  "IO operation timeout"
 }
 ```
 
@@ -4021,9 +4101,15 @@ It signals that IO operation timed out.
 It signals that provided path is not a directory.
 
 ```typescript
-"error" : {
-  "code" : 1006,
-  "message" : "Path is not a directory"
+"error"
+:
+{
+  "code"
+:
+  1006,
+      "message"
+:
+  "Path is not a directory"
 }
 ```
 
@@ -4032,9 +4118,15 @@ It signals that provided path is not a directory.
 It signals that the provided path is not a file.
 
 ```typescript
-"error" : {
-  "code" : 1007,
-  "message" : "Path is not a file"
+"error"
+:
+{
+  "code"
+:
+  1007,
+      "message"
+:
+  "Path is not a file"
 }
 ```
 
@@ -4044,9 +4136,15 @@ Signals that a streaming file write cannot overwrite a portion of the requested
 file.
 
 ```typescript
-"error" : {
-  "code" : 1008,
-  "message" : "Cannot overwrite the file without `overwriteExisting` set"
+"error"
+:
+{
+  "code"
+:
+  1008,
+      "message"
+:
+  "Cannot overwrite the file without `overwriteExisting` set"
 }
 ```
 
@@ -4055,11 +4153,21 @@ file.
 Signals that the requested file read was out of bounds for the file's size.
 
 ```typescript
-"error" : {
-  "code" : 1009
-  "message" : "Read is out of bounds for the file"
-  "data" : {
-    "fileLength" : 0
+"error"
+:
+{
+  "code"
+:
+  1009
+  "message"
+:
+  "Read is out of bounds for the file"
+  "data"
+:
+  {
+    "fileLength"
+  :
+    0
   }
 }
 ```
@@ -4069,9 +4177,15 @@ Signals that the requested file read was out of bounds for the file's size.
 Signals that the project configuration cannot be decoded.
 
 ```typescript
-"error" : {
-  "code" : 1010
-  "message" : "Cannot decode the project configuration"
+"error"
+:
+{
+  "code"
+:
+  1010
+  "message"
+:
+  "Cannot decode the project configuration"
 }
 ```
 
@@ -4089,9 +4203,15 @@ table ReadOutOfBoundsError {
 It signals that provided stack item was not found.
 
 ```typescript
-"error" : {
-  "code" : 2001,
-  "message" : "Stack item not found"
+"error"
+:
+{
+  "code"
+:
+  2001,
+      "message"
+:
+  "Stack item not found"
 }
 
 ```
@@ -4101,9 +4221,15 @@ It signals that provided stack item was not found.
 It signals that provided context was not found.
 
 ```typescript
-"error" : {
-  "code" : 2002,
-  "message" : "Context not found"
+"error"
+:
+{
+  "code"
+:
+  2002,
+      "message"
+:
+  "Context not found"
 }
 ```
 
@@ -4112,9 +4238,15 @@ It signals that provided context was not found.
 It signals that stack is empty.
 
 ```typescript
-"error" : {
-  "code" : 2003,
-  "message" : "Stack is empty"
+"error"
+:
+{
+  "code"
+:
+  2003,
+      "message"
+:
+  "Stack is empty"
 }
 ```
 
@@ -4123,9 +4255,15 @@ It signals that stack is empty.
 It signals that stack is invalid in this context.
 
 ```typescript
-"error" : {
-  "code" : 2004,
-  "message" : "Invalid stack item"
+"error"
+:
+{
+  "code"
+:
+  2004,
+      "message"
+:
+  "Invalid stack item"
 }
 ```
 
@@ -4134,9 +4272,15 @@ It signals that stack is invalid in this context.
 It signals that the given module cannot be found.
 
 ```typescript
-"error" : {
-  "code" : 2005,
-  "message" : "Module not found [Foo.Bar.Baz]"
+"error"
+:
+{
+  "code"
+:
+  2005,
+      "message"
+:
+  "Module not found [Foo.Bar.Baz]"
 }
 ```
 
@@ -4145,9 +4289,15 @@ It signals that the given module cannot be found.
 It signals that the visualisation cannot be found.
 
 ```typescript
-"error" : {
-  "code" : 2006,
-  "message" : "Visualisation not found"
+"error"
+:
+{
+  "code"
+:
+  2006,
+      "message"
+:
+  "Visualisation not found"
 }
 ```
 
@@ -4158,25 +4308,59 @@ cannot be evaluated. The error contains an optional `data` field of type
 [`Diagnostic`](#diagnostic) providing error details.
 
 ```typescript
-"error" : {
-  "code" : 2007,
-  "message" : "Evaluation of the visualisation expression failed [i is not defined]"
-  "data" : {
-    "kind" : "Error",
-    "message" : "i is not defined",
-    "path" : null,
-    "location" : {
-      "start" : {
-        "line" : 0,
-        "character" : 8
-      },
-      "end" : {
-        "line" : 0,
-        "character" : 9
+"error"
+:
+{
+  "code"
+:
+  2007,
+      "message"
+:
+  "Evaluation of the visualisation expression failed [i is not defined]"
+  "data"
+:
+  {
+    "kind"
+  :
+    "Error",
+        "message"
+  :
+    "i is not defined",
+        "path"
+  :
+    null,
+        "location"
+  :
+    {
+      "start"
+    :
+      {
+        "line"
+      :
+        0,
+            "character"
+      :
+        8
       }
-    },
-    "expressionId" : "aa1f75c4-8c4d-493d-a6a7-72123a52f084",
-    "stack" : []
+    ,
+      "end"
+    :
+      {
+        "line"
+      :
+        0,
+            "character"
+      :
+        9
+      }
+    }
+  ,
+    "expressionId"
+  :
+    "aa1f75c4-8c4d-493d-a6a7-72123a52f084",
+        "stack"
+  :
+    []
   }
 }
 ```
@@ -4186,9 +4370,15 @@ cannot be evaluated. The error contains an optional `data` field of type
 Signals that a file wasn't opened.
 
 ```typescript
-"error" : {
-  "code" : 3001,
-  "message" : "File not opened"
+"error"
+:
+{
+  "code"
+:
+  3001,
+      "message"
+:
+  "File not opened"
 }
 ```
 
@@ -4197,9 +4387,15 @@ Signals that a file wasn't opened.
 Signals that validation has failed for a series of edits.
 
 ```typescript
-"error" : {
-  "code" : 3002,
-  "message" : "The start position is after the end position"
+"error"
+:
+{
+  "code"
+:
+  3002,
+      "message"
+:
+  "The start position is after the end position"
 }
 ```
 
@@ -4209,9 +4405,15 @@ Signals that version provided by a client doesn't match to the version computed
 by the server.
 
 ```typescript
-"error" : {
-  "code" : 3003,
-  "message" : "Invalid version [client version: ade2967cab172183d1a67ea40cb8e92e23218764bc9934c3795fcea5, server version: 7602967cab172183d1a67ea40cb8e92e23218764bc9934c3795fcea5]"
+"error"
+:
+{
+  "code"
+:
+  3003,
+      "message"
+:
+  "Invalid version [client version: ade2967cab172183d1a67ea40cb8e92e23218764bc9934c3795fcea5, server version: 7602967cab172183d1a67ea40cb8e92e23218764bc9934c3795fcea5]"
 }
 ```
 
@@ -4220,9 +4422,15 @@ by the server.
 Signals that the client doesn't hold write lock to the buffer.
 
 ```typescript
-"error" : {
-  "code" : 3004,
-  "message" : "Write denied"
+"error"
+:
+{
+  "code"
+:
+  3004,
+      "message"
+:
+  "Write denied"
 }
 ```
 
@@ -4231,9 +4439,15 @@ Signals that the client doesn't hold write lock to the buffer.
 Signals that requested capability is not acquired.
 
 ```typescript
-"error" : {
-  "code" : 5001,
-  "message" : "Capability not acquired"
+"error"
+:
+{
+  "code"
+:
+  5001,
+      "message"
+:
+  "Capability not acquired"
 }
 ```
 
@@ -4242,9 +4456,15 @@ Signals that requested capability is not acquired.
 Signals that requested cannot be proccessed, beacuse session is not initialised.
 
 ```typescript
-"error" : {
-  "code" : 6001,
-  "message" : "Session not initialised"
+"error"
+:
+{
+  "code"
+:
+  6001,
+      "message"
+:
+  "Session not initialised"
 }
 ```
 
@@ -4253,9 +4473,15 @@ Signals that requested cannot be proccessed, beacuse session is not initialised.
 Signals that session is already initialised.
 
 ```typescript
-"error" : {
-  "code" : 6002,
-  "message" : "Session already initialised"
+"error"
+:
+{
+  "code"
+:
+  6002,
+      "message"
+:
+  "Session already initialised"
 }
 ```
 
@@ -4264,9 +4490,15 @@ Signals that session is already initialised.
 Signals about the failure in the Language Server initialization process.
 
 ```typescript
-"error" : {
-  "code" : 6003,
-  "message" : "Failed to initialize the Language Server resources"
+"error"
+:
+{
+  "code"
+:
+  6003,
+      "message"
+:
+  "Failed to initialize the Language Server resources"
 }
 ```
 
@@ -4275,9 +4507,15 @@ Signals about the failure in the Language Server initialization process.
 Signals about an error accessing the suggestions database.
 
 ```typescript
-"error" : {
-  "code" : 7001,
-  "message" : "Suggestions database error"
+"error"
+:
+{
+  "code"
+:
+  7001,
+      "message"
+:
+  "Suggestions database error"
 }
 ```
 
@@ -4286,9 +4524,15 @@ Signals about an error accessing the suggestions database.
 Signals that the project not found in the root directory.
 
 ```typescript
-"error" : {
-  "code" : 7002,
-  "message" : "Project not found in the root directory"
+"error"
+:
+{
+  "code"
+:
+  7002,
+      "message"
+:
+  "Project not found in the root directory"
 }
 ```
 
@@ -4297,9 +4541,15 @@ Signals that the project not found in the root directory.
 Signals that the module name can not be resolved for the given file.
 
 ```typescript
-"error" : {
-  "code" : 7003,
-  "message" : "Module name can't be resolved for the given file"
+"error"
+:
+{
+  "code"
+:
+  7003,
+      "message"
+:
+  "Module name can't be resolved for the given file"
 }
 ```
 
@@ -4308,8 +4558,14 @@ Signals that the module name can not be resolved for the given file.
 Signals that the requested suggestion was not found.
 
 ```typescript
-"error" : {
-  "code" : 7004,
-  "message" : "Requested suggestion was not found"
+"error"
+:
+{
+  "code"
+:
+  7004,
+      "message"
+:
+  "Requested suggestion was not found"
 }
 ```

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -2,7 +2,6 @@ package org.enso.languageserver.boot
 
 import java.io.File
 import java.net.URI
-
 import akka.actor.ActorSystem
 import org.enso.jsonrpc.JsonRpcServer
 import org.enso.languageserver.boot.DeploymentType.{Azure, Desktop}
@@ -10,6 +9,8 @@ import org.enso.languageserver.capability.CapabilityRouter
 import org.enso.languageserver.data._
 import org.enso.languageserver.effect.ZioExec
 import org.enso.languageserver.filemanager.{
+  ContentRootType,
+  ContentRootWithFile,
   FileManager,
   FileSystem,
   ReceivesTreeUpdatesHandler
@@ -56,9 +57,15 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
     logLevel
   )
 
-  val directoriesConfig = DirectoriesConfig(serverConfig.contentRootPath)
+  private val contentRoot = ContentRootWithFile(
+    serverConfig.contentRootUuid,
+    ContentRootType.Project,
+    "Project",
+    new File(serverConfig.contentRootPath)
+  )
+  val directoriesConfig = ProjectDirectoriesConfig(contentRoot)
   val languageServerConfig = Config(
-    Map(serverConfig.contentRootUuid -> new File(serverConfig.contentRootPath)),
+    Map(serverConfig.contentRootUuid -> contentRoot),
     FileManagerConfig(timeout = 3.seconds),
     PathWatcherConfig(),
     ExecutionContextConfig(),

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -57,13 +57,13 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
     logLevel
   )
 
+  val directoriesConfig = ProjectDirectoriesConfig(serverConfig.contentRootPath)
   private val contentRoot = ContentRootWithFile(
     serverConfig.contentRootUuid,
     ContentRootType.Project,
     "Project",
     new File(serverConfig.contentRootPath)
   )
-  val directoriesConfig = ProjectDirectoriesConfig(contentRoot)
   val languageServerConfig = Config(
     Map(serverConfig.contentRootUuid -> contentRoot),
     FileManagerConfig(timeout = 3.seconds),

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/ResourcesInitialization.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/ResourcesInitialization.scala
@@ -8,7 +8,7 @@ import org.enso.languageserver.boot.resource.{
   SequentialResourcesInitialization,
   TruffleContextInitialization
 }
-import org.enso.languageserver.data.DirectoriesConfig
+import org.enso.languageserver.data.ProjectDirectoriesConfig
 import org.enso.searcher.sql.{SqlSuggestionsRepo, SqlVersionsRepo}
 import org.graalvm.polyglot.Context
 
@@ -29,11 +29,11 @@ object ResourcesInitialization {
     * @return the initialization component
     */
   def apply(
-    eventStream: EventStream,
-    directoriesConfig: DirectoriesConfig,
-    suggestionsRepo: SqlSuggestionsRepo,
-    versionsRepo: SqlVersionsRepo,
-    truffleContext: Context
+             eventStream: EventStream,
+             directoriesConfig: ProjectDirectoriesConfig,
+             suggestionsRepo: SqlSuggestionsRepo,
+             versionsRepo: SqlVersionsRepo,
+             truffleContext: Context
   )(implicit ec: ExecutionContext): InitializationComponent = {
     val resources = Seq(
       new DirectoriesInitialization(directoriesConfig),

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/DirectoriesInitialization.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/DirectoriesInitialization.scala
@@ -1,7 +1,7 @@
 package org.enso.languageserver.boot.resource
 
 import com.typesafe.scalalogging.LazyLogging
-import org.enso.languageserver.data.DirectoriesConfig
+import org.enso.languageserver.data.ProjectDirectoriesConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -9,8 +9,8 @@ import scala.concurrent.{ExecutionContext, Future}
   *
   * @param directoriesConfig the directories config
   */
-class DirectoriesInitialization(directoriesConfig: DirectoriesConfig)(implicit
-  ec: ExecutionContext
+class DirectoriesInitialization(directoriesConfig: ProjectDirectoriesConfig)(implicit
+                                                                             ec: ExecutionContext
 ) extends InitializationComponent
     with LazyLogging {
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/RepoInitialization.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/resource/RepoInitialization.scala
@@ -6,7 +6,7 @@ import java.nio.file.{FileSystemException, Files, NoSuchFileException}
 import akka.event.EventStream
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.io.FileUtils
-import org.enso.languageserver.data.DirectoriesConfig
+import org.enso.languageserver.data.ProjectDirectoriesConfig
 import org.enso.languageserver.event.InitializedEvent
 import org.enso.logger.masking.MaskedPath
 import org.enso.searcher.sql.{SqlDatabase, SqlSuggestionsRepo, SqlVersionsRepo}
@@ -23,10 +23,10 @@ import scala.util.{Failure, Success}
   * @param versionsRepo the versions repo
   */
 class RepoInitialization(
-  directoriesConfig: DirectoriesConfig,
-  eventStream: EventStream,
-  suggestionsRepo: SqlSuggestionsRepo,
-  versionsRepo: SqlVersionsRepo
+                          directoriesConfig: ProjectDirectoriesConfig,
+                          eventStream: EventStream,
+                          suggestionsRepo: SqlSuggestionsRepo,
+                          versionsRepo: SqlVersionsRepo
 )(implicit ec: ExecutionContext)
     extends InitializationComponent
     with LazyLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/data/Config.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/data/Config.scala
@@ -76,12 +76,9 @@ object ExecutionContextConfig {
 
 /** Configuration of directories for storing internal files.
   *
-  * @param projectRoot the content root for the root of the current project
+  * @param root the root directory path
   */
-case class ProjectDirectoriesConfig(projectRoot: ContentRootWithFile)
-    extends ToLogString {
-
-  val root: File = projectRoot.file
+case class ProjectDirectoriesConfig(root: File) extends ToLogString {
 
   /** The data directory path. */
   val dataDirectory: File =
@@ -109,12 +106,15 @@ object ProjectDirectoriesConfig {
   val DataDirectory: String           = ".enso"
   val SuggestionsDatabaseFile: String = "suggestions.db"
 
+  def apply(root: String): ProjectDirectoriesConfig =
+    new ProjectDirectoriesConfig(new File(root))
+
   /** Create default data directory config, creating directories if not exist.
     *
-    * @param root the root directory content root
+    * @param root the root directory path
     * @return data directory config
     */
-  def initialize(root: ContentRootWithFile): ProjectDirectoriesConfig = {
+  def initialize(root: File): ProjectDirectoriesConfig = {
     val config = new ProjectDirectoriesConfig(root)
     config.createDirectories()
     config

--- a/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/ContentRoot.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/ContentRoot.scala
@@ -1,0 +1,69 @@
+package org.enso.languageserver.filemanager
+
+import enumeratum._
+
+import java.io.File
+import java.util.UUID
+
+/** A representation of a content root.
+  *
+  * @param id the unique identifier of the content root
+  * @param type the type of the content root
+  * @param name The name of the content root
+  */
+case class ContentRoot(id: UUID, `type`: ContentRootType, name: String)
+
+/** The type of entity that the content root represents.
+  */
+sealed trait ContentRootType extends EnumEntry
+object ContentRootType extends Enum[ContentRootType] with CirceEnum[ContentRootType] {
+
+  /** The content root represents the root of the current Enso project.
+    */
+  case object Project extends ContentRootType
+
+  /** The content root represents a system root (`/` on unix, drives on
+    * windows).
+    *
+    * There may be multiple of this type of root sent by default.
+    */
+  case object Root extends ContentRootType
+
+  /** The content root represents the user's home directory.
+    */
+  case object Home extends ContentRootType
+
+  /** The content root represents an Enso library.
+    */
+  case object Library extends ContentRootType
+
+  /** The content root was a custom location added by the IDE.
+    */
+  case object Custom extends ContentRootType
+
+  /** Necessary for Enumeratum and Circe. */
+  override val values = findValues
+}
+
+/** A representation of a content root.
+  *
+  * @param id the unique identifier of the content root
+  * @param `type` the type of the content root
+  * @param name The name of the content root
+  * @param file the file on the filesystem that is the content root
+  */
+case class ContentRootWithFile(
+  id: UUID,
+  `type`: ContentRootType,
+  name: String,
+  file: File
+) {
+
+  /** Convert this to a content root for use in the protocol.
+    *
+    * @return a protocol content root
+    */
+  def toContentRoot: ContentRoot = {
+    ContentRoot(id, `type`, name)
+  }
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerProtocol.scala
@@ -1,7 +1,6 @@
 package org.enso.languageserver.filemanager
 
 import java.io.File
-import java.util.UUID
 
 object FileManagerProtocol {
 
@@ -27,7 +26,7 @@ object FileManagerProtocol {
     *
     * @param contentRoots content roots
     */
-  case class ContentRootsResult(contentRoots: Set[UUID])
+  case class ContentRootsResult(contentRoots: Set[ContentRoot])
 
   /** Requests the Language Server write textual content to an arbitrary file.
     *

--- a/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/PathWatcher.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/PathWatcher.scala
@@ -58,7 +58,7 @@ final class PathWatcher(
   private def uninitializedStage: Receive = { case WatchPath(path, clients) =>
     val pathToWatchResult = config
       .findContentRoot(path.rootId)
-      .map(path.toFile)
+      .map(x => path.toFile(x.file))
     val result: BlockingIO[FileSystemFailure, Unit] =
       for {
         pathToWatch <- IO.fromEither(pathToWatchResult)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
@@ -113,7 +113,7 @@ final class SuggestionsHandler(
 
     config.contentRoots.foreach { case (_, contentRoot) =>
       PackageManager.Default
-        .fromDirectory(contentRoot)
+        .fromDirectory(contentRoot.file)
         .foreach(pkg => self ! ProjectNameUpdated(pkg.config.name))
     }
   }
@@ -539,10 +539,10 @@ final class SuggestionsHandler(
     path: Path
   ): Either[SearchFailure, String] =
     for {
-      rootFile <- config.findContentRoot(path.rootId).left.map(FileSystemError)
+      root <- config.findContentRoot(path.rootId).left.map(FileSystemError)
       module <-
         ModuleNameBuilder
-          .build(projectName, rootFile.toPath, path.toFile(rootFile).toPath)
+          .build(projectName, root.file.toPath, path.toFile(root.file).toPath)
           .toRight(ModuleNameNotResolvedError(path))
     } yield module
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
@@ -1,7 +1,6 @@
 package org.enso.languageserver.search
 
 import java.util.UUID
-
 import akka.actor.{Actor, ActorRef, Props, Stash}
 import akka.pattern.{ask, pipe}
 import com.typesafe.scalalogging.LazyLogging
@@ -18,7 +17,11 @@ import org.enso.languageserver.data.{
   ReceivesSuggestionsDatabaseUpdates
 }
 import org.enso.languageserver.event.InitializedEvent
-import org.enso.languageserver.filemanager.{FileDeletedEvent, Path}
+import org.enso.languageserver.filemanager.{
+  ContentRootType,
+  FileDeletedEvent,
+  Path
+}
 import org.enso.languageserver.refactoring.ProjectNameChangedEvent
 import org.enso.languageserver.search.SearchProtocol._
 import org.enso.languageserver.search.handler.{
@@ -111,10 +114,12 @@ final class SuggestionsHandler(
     context.system.eventStream
       .subscribe(self, InitializedEvent.TruffleContextInitialized.getClass)
 
-    config.contentRoots.foreach { case (_, contentRoot) =>
-      PackageManager.Default
-        .fromDirectory(contentRoot.file)
-        .foreach(pkg => self ! ProjectNameUpdated(pkg.config.name))
+    config.contentRoots.foreach {
+      case (_, root) if root.`type` == ContentRootType.Project =>
+        PackageManager.Default
+          .fromDirectory(root.file)
+          .foreach(pkg => self ! ProjectNameUpdated(pkg.config.name))
+      case _ =>
     }
   }
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/session/SessionApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/session/SessionApi.scala
@@ -1,8 +1,9 @@
 package org.enso.languageserver.session
 
-import java.util.UUID
-
 import org.enso.jsonrpc.{Error, HasParams, HasResult, Method}
+import org.enso.languageserver.filemanager.ContentRoot
+
+import java.util.UUID
 
 /** The connection management JSON RPC API provided by the language server.
   * See [[https://github.com/enso-org/enso/blob/main/docs/language-server/protocol-language-server.md#connection-management]]
@@ -15,7 +16,7 @@ object SessionApi {
 
     case class Params(clientId: UUID)
 
-    case class Result(contentRoots: Set[UUID])
+    case class Result(contentRoots: Set[ContentRoot])
 
     implicit val hasParams = new HasParams[this.type] {
       type Params = InitProtocolConnection.Params

--- a/engine/language-server/src/test/scala/org/enso/languageserver/boot/resource/RepoInitializationSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/boot/resource/RepoInitializationSpec.scala
@@ -213,7 +213,7 @@ class RepoInitializationSpec
       FileManagerConfig(timeout = 3.seconds.dilated),
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds.dilated),
-      ProjectDirectoriesConfig.initialize(root)
+      ProjectDirectoriesConfig.initialize(root.file)
     )
   }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/boot/resource/RepoInitializationSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/boot/resource/RepoInitializationSpec.scala
@@ -1,14 +1,14 @@
 package org.enso.languageserver.boot.resource
 
-import java.io.File
-import java.nio.file.{Files, StandardOpenOption}
-import java.util.UUID
-
 import akka.actor.ActorSystem
 import akka.testkit._
 import org.apache.commons.io.FileUtils
 import org.enso.languageserver.data._
 import org.enso.languageserver.event.InitializedEvent
+import org.enso.languageserver.filemanager.{
+  ContentRootType,
+  ContentRootWithFile
+}
 import org.enso.searcher.sql.{
   SchemaVersion,
   SqlDatabase,
@@ -21,6 +21,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.sqlite.SQLiteException
 
+import java.nio.file.{Files, StandardOpenOption}
+import java.util.UUID
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -205,20 +207,27 @@ class RepoInitializationSpec
 
   }
 
-  def newConfig(root: File): Config = {
+  def newConfig(root: ContentRootWithFile): Config = {
     Config(
-      Map(UUID.randomUUID() -> root),
+      Map(root.id -> root),
       FileManagerConfig(timeout = 3.seconds.dilated),
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds.dilated),
-      DirectoriesConfig.initialize(root)
+      ProjectDirectoriesConfig.initialize(root)
     )
   }
 
   def withConfig(test: Config => Any): Unit = {
     val testContentRoot = Files.createTempDirectory(null).toRealPath()
     sys.addShutdownHook(FileUtils.deleteQuietly(testContentRoot.toFile))
-    val config = newConfig(testContentRoot.toFile)
+    val config = newConfig(
+      ContentRootWithFile(
+        UUID.randomUUID(),
+        ContentRootType.Project,
+        "Project",
+        testContentRoot.toFile
+      )
+    )
 
     test(config)
   }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
@@ -1,33 +1,15 @@
 package org.enso.languageserver.runtime
 
-import java.io.File
-import java.nio.file.Files
-import java.util.UUID
-
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import org.apache.commons.io.FileUtils
-import org.enso.languageserver.data.{
-  Config,
-  DirectoriesConfig,
-  ExecutionContextConfig,
-  FileManagerConfig,
-  PathWatcherConfig
-}
+import org.enso.languageserver.data._
 import org.enso.languageserver.event.InitializedEvent
-import org.enso.languageserver.runtime.ContextRegistryProtocol.{
-  DetachVisualisation,
-  ExecutionDiagnostic,
-  ExecutionDiagnosticKind,
-  ExecutionDiagnosticNotification,
-  ExecutionFailedNotification,
-  ExecutionFailure,
-  ExpressionUpdatesNotification,
-  RegisterOneshotVisualisation,
-  VisualisationContext,
-  VisualisationEvaluationFailed,
-  VisualisationUpdate
+import org.enso.languageserver.filemanager.{
+  ContentRootType,
+  ContentRootWithFile
 }
+import org.enso.languageserver.runtime.ContextRegistryProtocol._
 import org.enso.languageserver.search.Suggestions
 import org.enso.languageserver.session.JsonSession
 import org.enso.languageserver.session.SessionRouter.{
@@ -42,8 +24,10 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import scala.concurrent.{Await, Future}
+import java.nio.file.Files
+import java.util.UUID
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
 
 class ContextEventsListenerSpec
@@ -448,13 +432,13 @@ class ContextEventsListenerSpec
     }
   }
 
-  def newConfig(root: File): Config = {
+  def newConfig(root: ContentRootWithFile): Config = {
     Config(
-      Map(UUID.randomUUID() -> root),
+      Map(root.id -> root),
       FileManagerConfig(timeout = 3.seconds),
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
-      DirectoriesConfig.initialize(root)
+      ProjectDirectoriesConfig.initialize(root)
     )
   }
 
@@ -485,7 +469,14 @@ class ContextEventsListenerSpec
   ): Unit = {
     val testContentRoot = Files.createTempDirectory(null).toRealPath()
     sys.addShutdownHook(FileUtils.deleteQuietly(testContentRoot.toFile))
-    val config          = newConfig(testContentRoot.toFile)
+    val config = newConfig(
+      ContentRootWithFile(
+        UUID.randomUUID(),
+        ContentRootType.Project,
+        "Project",
+        testContentRoot.toFile
+      )
+    )
     val clientId        = UUID.randomUUID()
     val contextId       = UUID.randomUUID()
     val router          = TestProbe("session-router")

--- a/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
@@ -438,7 +438,7 @@ class ContextEventsListenerSpec
       FileManagerConfig(timeout = 3.seconds),
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
-      ProjectDirectoriesConfig.initialize(root)
+      ProjectDirectoriesConfig.initialize(root.file)
     )
   }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -805,7 +805,7 @@ class SuggestionsHandlerSpec
       FileManagerConfig(timeout = 3.seconds),
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
-      ProjectDirectoriesConfig.initialize(root)
+      ProjectDirectoriesConfig.initialize(root.file)
     )
   }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -3,7 +3,6 @@ package org.enso.languageserver.search
 import java.io.File
 import java.nio.file.Files
 import java.util.UUID
-
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import org.apache.commons.io.FileUtils
@@ -13,7 +12,11 @@ import org.enso.languageserver.capability.CapabilityProtocol.{
 }
 import org.enso.languageserver.data._
 import org.enso.languageserver.event.InitializedEvent
-import org.enso.languageserver.filemanager.Path
+import org.enso.languageserver.filemanager.{
+  ContentRootType,
+  ContentRootWithFile,
+  Path
+}
 import org.enso.languageserver.refactoring.ProjectNameChangedEvent
 import org.enso.languageserver.search.SearchProtocol.SuggestionDatabaseEntry
 import org.enso.languageserver.session.JsonSession
@@ -796,13 +799,13 @@ class SuggestionsHandlerSpec
     graph
   }
 
-  def newConfig(root: File): Config = {
+  def newConfig(root: ContentRootWithFile): Config = {
     Config(
-      Map(UUID.randomUUID() -> root),
+      Map(root.id -> root),
       FileManagerConfig(timeout = 3.seconds),
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
-      DirectoriesConfig.initialize(root)
+      ProjectDirectoriesConfig.initialize(root)
     )
   }
 
@@ -825,7 +828,14 @@ class SuggestionsHandlerSpec
   ): Unit = {
     val testContentRoot = Files.createTempDirectory(null).toRealPath()
     sys.addShutdownHook(FileUtils.deleteQuietly(testContentRoot.toFile))
-    val config    = newConfig(testContentRoot.toFile)
+    val config = newConfig(
+      ContentRootWithFile(
+        UUID.randomUUID(),
+        ContentRootType.Project,
+        "Project",
+        testContentRoot.toFile
+      )
+    )
     val router    = TestProbe("session-router")
     val connector = TestProbe("runtime-connector")
     val sqlDatabase = SqlDatabase(

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BaseBinaryServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BaseBinaryServerTest.scala
@@ -2,20 +2,24 @@ package org.enso.languageserver.websocket.binary
 import java.nio.ByteBuffer
 import java.nio.file.Files
 import java.util.UUID
-
 import akka.actor.{ActorRef, Props}
 import akka.http.scaladsl.model.RemoteAddress
 import com.google.flatbuffers.FlatBufferBuilder
 import org.apache.commons.io.FileUtils
 import org.enso.languageserver.data.{
   Config,
-  DirectoriesConfig,
+  ProjectDirectoriesConfig,
   ExecutionContextConfig,
   FileManagerConfig,
   PathWatcherConfig
 }
 import org.enso.languageserver.effect.ZioExec
-import org.enso.languageserver.filemanager.{FileManager, FileSystem}
+import org.enso.languageserver.filemanager.{
+  ContentRootType,
+  ContentRootWithFile,
+  FileManager,
+  FileSystem
+}
 import org.enso.languageserver.http.server.ConnectionControllerFactory
 import org.enso.languageserver.protocol.binary.BinaryConnectionController
 import org.enso.languageserver.protocol.binary.InboundPayload
@@ -28,17 +32,22 @@ import scala.concurrent.duration._
 
 class BaseBinaryServerTest extends BinaryServerTestKit {
 
-  val testContentRoot   = Files.createTempDirectory(null).toRealPath()
   val testContentRootId = UUID.randomUUID()
+  val testContentRoot = ContentRootWithFile(
+    testContentRootId,
+    ContentRootType.Project,
+    "Project",
+    Files.createTempDirectory(null).toRealPath().toFile
+  )
   val config = Config(
-    Map(testContentRootId -> testContentRoot.toFile),
+    Map(testContentRootId -> testContentRoot),
     FileManagerConfig(timeout = 3.seconds),
     PathWatcherConfig(),
     ExecutionContextConfig(requestTimeout = 3.seconds),
-    DirectoriesConfig.initialize(testContentRoot.toFile)
+    ProjectDirectoriesConfig.initialize(testContentRoot)
   )
 
-  sys.addShutdownHook(FileUtils.deleteQuietly(testContentRoot.toFile))
+  sys.addShutdownHook(FileUtils.deleteQuietly(testContentRoot.file))
 
   @volatile
   protected var lastConnectionController: ActorRef = _

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BaseBinaryServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BaseBinaryServerTest.scala
@@ -44,7 +44,7 @@ class BaseBinaryServerTest extends BinaryServerTestKit {
     FileManagerConfig(timeout = 3.seconds),
     PathWatcherConfig(),
     ExecutionContextConfig(requestTimeout = 3.seconds),
-    ProjectDirectoriesConfig.initialize(testContentRoot)
+    ProjectDirectoriesConfig.initialize(testContentRoot.file)
   )
 
   sys.addShutdownHook(FileUtils.deleteQuietly(testContentRoot.file))

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BinaryFileManipulationTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BinaryFileManipulationTest.scala
@@ -23,7 +23,7 @@ class BinaryFileManipulationTest extends BaseBinaryServerTest with FlakySpec {
       //given
       val requestId = UUID.randomUUID()
       val filename  = "foo.bin"
-      val fooFile   = new File(testContentRoot.toFile, filename)
+      val fooFile   = new File(testContentRoot.file, filename)
       val contents  = Array[Byte](65, 66, 67) //ABC
       val client    = newWsClient()
       client.send(createSessionInitCmd())
@@ -55,7 +55,7 @@ class BinaryFileManipulationTest extends BaseBinaryServerTest with FlakySpec {
       //given
       val requestId = UUID.randomUUID()
       val filename  = "bar.bin"
-      val barFile   = new File(testContentRoot.toFile, filename)
+      val barFile   = new File(testContentRoot.file, filename)
       val contents  = Array[Byte](65, 66, 67) //ABC
       FileUtils.writeByteArrayToFile(barFile, contents)
       val client = newWsClient()
@@ -88,7 +88,7 @@ class BinaryFileManipulationTest extends BaseBinaryServerTest with FlakySpec {
     "Return the checksum for the provided byte range" in {
       val requestId = UUID.randomUUID()
       val filename  = "bar.bin"
-      val barFile   = new File(testContentRoot.toFile, filename)
+      val barFile   = new File(testContentRoot.file, filename)
       val contents  = Array[Byte](65, 66, 67) //ABC
       FileUtils.writeByteArrayToFile(barFile, contents)
 
@@ -153,7 +153,7 @@ class BinaryFileManipulationTest extends BaseBinaryServerTest with FlakySpec {
     "Return a `ReadOutOfBounds` error if the byte range is out of bounds" in {
       val requestId = UUID.randomUUID()
       val filename  = "bar.bin"
-      val barFile   = new File(testContentRoot.toFile, filename)
+      val barFile   = new File(testContentRoot.file, filename)
       val contents  = Array[Byte](65, 66, 67) //ABC
       FileUtils.writeByteArrayToFile(barFile, contents)
 
@@ -216,7 +216,7 @@ class BinaryFileManipulationTest extends BaseBinaryServerTest with FlakySpec {
     "Write the provided bytes to the specified file" in {
       val requestId = UUID.randomUUID()
       val filename  = "bar.bin"
-      val barFile   = new File(testContentRoot.toFile, filename)
+      val barFile   = new File(testContentRoot.file, filename)
       val contents  = Array[Byte](65, 66, 67) //ABC
       FileUtils.writeByteArrayToFile(barFile, contents)
 
@@ -260,7 +260,7 @@ class BinaryFileManipulationTest extends BaseBinaryServerTest with FlakySpec {
     "Create the file from scratch if it doesn't exist" in {
       val requestId = UUID.randomUUID()
       val filename  = "bar.bin"
-      val barFile   = new File(testContentRoot.toFile, filename)
+      val barFile   = new File(testContentRoot.file, filename)
 
       val newBytes = Array[Byte](65, 66, 67)
       val expectedChecksum =
@@ -304,7 +304,7 @@ class BinaryFileManipulationTest extends BaseBinaryServerTest with FlakySpec {
     "Return a `CannotOverwrite` error if `byteOffset < file.length`" in {
       val requestId = UUID.randomUUID()
       val filename  = "bar.bin"
-      val barFile   = new File(testContentRoot.toFile, filename)
+      val barFile   = new File(testContentRoot.file, filename)
       val contents  = Array[Byte](65, 66, 67) //ABC
       FileUtils.writeByteArrayToFile(barFile, contents)
 
@@ -373,7 +373,7 @@ class BinaryFileManipulationTest extends BaseBinaryServerTest with FlakySpec {
     "Read the specified bytes from the file" in {
       val requestId = UUID.randomUUID()
       val filename  = "bar.bin"
-      val barFile   = new File(testContentRoot.toFile, filename)
+      val barFile   = new File(testContentRoot.file, filename)
       val contents  = Array[Byte](65, 66, 67) //ABC
       FileUtils.writeByteArrayToFile(barFile, contents)
 
@@ -447,7 +447,7 @@ class BinaryFileManipulationTest extends BaseBinaryServerTest with FlakySpec {
     "Return a `ReadOutOfBounds` error if the byte range is out of bounds" in {
       val requestId = UUID.randomUUID()
       val filename  = "bar.bin"
-      val barFile   = new File(testContentRoot.toFile, filename)
+      val barFile   = new File(testContentRoot.file, filename)
       val contents  = Array[Byte](65, 66, 67) //ABC
       FileUtils.writeByteArrayToFile(barFile, contents)
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -15,6 +15,8 @@ import org.enso.languageserver.data._
 import org.enso.languageserver.effect.ZioExec
 import org.enso.languageserver.event.InitializedEvent
 import org.enso.languageserver.filemanager.{
+  ContentRootType,
+  ContentRootWithFile,
   FileManager,
   FileSystem,
   ReceivesTreeUpdatesHandler
@@ -45,8 +47,13 @@ class BaseServerTest extends JsonRpcServerTestKit {
 
   val timeout: FiniteDuration = 10.seconds
 
-  val testContentRoot       = Files.createTempDirectory(null).toRealPath()
-  val testContentRootId     = UUID.randomUUID()
+  val testContentRootId = UUID.randomUUID()
+  val testContentRoot = ContentRootWithFile(
+    testContentRootId,
+    ContentRootType.Project,
+    "Project",
+    Files.createTempDirectory(null).toRealPath().toFile
+  )
   val config                = mkConfig
   val runtimeConnectorProbe = TestProbe()
   val versionCalculator     = Sha3_224VersionCalculator
@@ -58,15 +65,15 @@ class BaseServerTest extends JsonRpcServerTestKit {
     graph
   }
 
-  sys.addShutdownHook(FileUtils.deleteQuietly(testContentRoot.toFile))
+  sys.addShutdownHook(FileUtils.deleteQuietly(testContentRoot.file))
 
   def mkConfig: Config =
     Config(
-      Map(testContentRootId -> testContentRoot.toFile),
+      Map(testContentRootId -> testContentRoot),
       FileManagerConfig(timeout = 3.seconds),
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
-      DirectoriesConfig(testContentRoot.toFile)
+      ProjectDirectoriesConfig(testContentRoot)
     )
 
   override def protocol: Protocol = JsonRpc.protocol
@@ -211,7 +218,13 @@ class BaseServerTest extends JsonRpcServerTestKit {
             { "jsonrpc":"2.0",
               "id":1,
               "result":{
-                "contentRoots":[ $testContentRootId ]
+                "contentRoots" : [
+                  {
+                    "id" : $testContentRootId,
+                    "type" : "Project",
+                    "name" : "Project"
+                  }
+                ]
               }
             }
               """)

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -73,7 +73,7 @@ class BaseServerTest extends JsonRpcServerTestKit {
       FileManagerConfig(timeout = 3.seconds),
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
-      ProjectDirectoriesConfig(testContentRoot)
+      ProjectDirectoriesConfig(testContentRoot.file)
     )
 
   override def protocol: Protocol = JsonRpc.protocol

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileManagerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileManagerTest.scala
@@ -22,7 +22,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       FileManagerConfig(timeout = 3.seconds),
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
-      ProjectDirectoriesConfig.initialize(testContentRoot)
+      ProjectDirectoriesConfig.initialize(testContentRoot.file)
     )
   }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileManagerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileManagerTest.scala
@@ -18,11 +18,11 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
     val directoriesDir = Files.createTempDirectory(null).toRealPath()
     sys.addShutdownHook(FileUtils.deleteQuietly(directoriesDir.toFile))
     Config(
-      Map(testContentRootId -> testContentRoot.toFile),
+      Map(testContentRootId -> testContentRoot),
       FileManagerConfig(timeout = 3.seconds),
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
-      DirectoriesConfig.initialize(directoriesDir.toFile)
+      ProjectDirectoriesConfig.initialize(testContentRoot)
     )
   }
 
@@ -49,7 +49,8 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           }
           """)
 
-      val path = Paths.get(testContentRoot.toString, "foo", "bar", "baz.txt")
+      val path =
+        Paths.get(testContentRoot.file.toString, "foo", "bar", "baz.txt")
       Files.readAllLines(path).get(0) shouldBe "123456789"
     }
 
@@ -83,8 +84,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
   "Reading files" must {
     "read a file content" in {
       val client = getInitialisedWsClient()
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/write",
             "id": 4,
@@ -97,15 +97,13 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 4,
             "result": null
           }
           """)
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/read",
             "id": 5,
@@ -117,8 +115,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 5,
             "result": { "contents": "123456789" }
@@ -128,8 +125,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
 
     "return FileNotFoundError if a file doesn't exist" in {
       val client = getInitialisedWsClient()
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/read",
             "id": 6,
@@ -141,8 +137,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 6,
             "error" : {
@@ -157,8 +152,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
   "Creating file-system entities" must {
     "create a file" in {
       val client = getInitialisedWsClient()
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 7,
@@ -174,22 +168,21 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 7,
             "result": null
           }
           """)
 
-      val file = Paths.get(testContentRoot.toString, "foo1", "bar.txt").toFile
+      val file =
+        Paths.get(testContentRoot.file.toString, "foo1", "bar.txt").toFile
       file.isFile shouldBe true
     }
 
     "create a directory" in {
       val client = getInitialisedWsClient()
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 7,
@@ -205,15 +198,14 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 7,
             "result": null
           }
           """)
 
-      val file = Paths.get(testContentRoot.toString, "foo1", "baz").toFile
+      val file = Paths.get(testContentRoot.file.toString, "foo1", "baz").toFile
       file.isDirectory shouldBe true
     }
   }
@@ -222,8 +214,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
     "delete a file" in {
       val client = getInitialisedWsClient()
       // create a file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 8,
@@ -239,20 +230,19 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 8,
             "result": null
           }
           """)
 
-      val file = Paths.get(testContentRoot.toString, "foo1", "bar.txt").toFile
+      val file =
+        Paths.get(testContentRoot.file.toString, "foo1", "bar.txt").toFile
       file.isFile shouldBe true
 
       // delete a file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/delete",
             "id": 9,
@@ -264,8 +254,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 9,
             "result": null
@@ -279,8 +268,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
     "delete a directory" in {
       val client = getInitialisedWsClient()
       // create a directory
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 10,
@@ -296,20 +284,18 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 10,
             "result": null
           }
           """)
 
-      val file = Paths.get(testContentRoot.toString, "foo1", "baz").toFile
+      val file = Paths.get(testContentRoot.file.toString, "foo1", "baz").toFile
       file.isDirectory shouldBe true
 
       // delete a directory
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/delete",
             "id": 11,
@@ -321,8 +307,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 11,
             "result": null
@@ -335,10 +320,10 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
 
     "return FileNotFound when deleting nonexistent file" in {
       val client = getInitialisedWsClient()
-      val file = Paths.get(testContentRoot.toString, "foo1", "bar.txt").toFile
+      val file =
+        Paths.get(testContentRoot.file.toString, "foo1", "bar.txt").toFile
       file.isFile shouldBe false
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/delete",
             "id": 12,
@@ -350,8 +335,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 12,
             "error": {
@@ -367,10 +351,9 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
 
     "return FileNotFound when deleting nonexistent directory" in {
       val client = getInitialisedWsClient()
-      val file = Paths.get(testContentRoot.toString, "foo1", "baz").toFile
+      val file   = Paths.get(testContentRoot.file.toString, "foo1", "baz").toFile
       file.isDirectory shouldBe false
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/delete",
             "id": 13,
@@ -382,8 +365,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 13,
             "error": {
@@ -400,8 +382,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
     "copy a file" in {
       val client = getInitialisedWsClient()
       // create a file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 14,
@@ -417,19 +398,17 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 14,
             "result": null
           }
           """)
-      val from = Paths.get(testContentRoot.toString, "a", "test.txt")
+      val from = Paths.get(testContentRoot.file.toString, "a", "test.txt")
       from.toFile.isFile shouldBe true
 
       // copy a file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/copy",
             "id": 15,
@@ -445,23 +424,21 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 15,
             "result": null
           }
           """)
 
-      val to = Paths.get(testContentRoot.toString, "a", "test1.txt")
+      val to = Paths.get(testContentRoot.file.toString, "a", "test1.txt")
       to.toFile.isFile shouldBe true
     }
 
     "copy a directory" in {
       val client = getInitialisedWsClient()
       // create a file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 16,
@@ -477,19 +454,17 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 16,
             "result": null
           }
           """)
-      val from = Paths.get(testContentRoot.toString, "b", "test.txt")
+      val from = Paths.get(testContentRoot.file.toString, "b", "test.txt")
       from.toFile.isFile shouldBe true
 
       // copy a directory
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/copy",
             "id": 17,
@@ -505,22 +480,20 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 17,
             "result": null
           }
           """)
 
-      val to = Paths.get(testContentRoot.toString, "c", "test.txt")
+      val to = Paths.get(testContentRoot.file.toString, "c", "test.txt")
       to.toFile.isFile shouldBe true
     }
 
     "return failure when copying nonexistent file" in {
       val client = getInitialisedWsClient()
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/copy",
             "id": 18,
@@ -536,8 +509,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 18,
             "error": {
@@ -547,15 +519,14 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           }
           """)
 
-      val to = Paths.get(testContentRoot.toString, "some", "test.txt")
+      val to = Paths.get(testContentRoot.file.toString, "some", "test.txt")
       to.toFile.isFile shouldBe false
     }
 
     "move a file" in {
       val client = getInitialisedWsClient()
       // create a file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 19,
@@ -571,19 +542,17 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 19,
             "result": null
           }
           """)
-      val from = Paths.get(testContentRoot.toString, "move", "test.txt")
+      val from = Paths.get(testContentRoot.file.toString, "move", "test.txt")
       from.toFile.isFile shouldBe true
 
       // move a file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/move",
             "id": 20,
@@ -599,15 +568,14 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 20,
             "result": null
           }
           """)
 
-      val to = Paths.get(testContentRoot.toString, "move", "test1.txt")
+      val to = Paths.get(testContentRoot.file.toString, "move", "test1.txt")
       to.toFile.isFile shouldBe true
       from.toFile.exists shouldBe false
     }
@@ -615,8 +583,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
     "move a directory" in {
       val client = getInitialisedWsClient()
       // create a file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 21,
@@ -632,22 +599,20 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 21,
             "result": null
           }
           """)
 
-      val path = Paths.get(testContentRoot.toString, "move", "test.txt")
+      val path = Paths.get(testContentRoot.file.toString, "move", "test.txt")
       path.toFile.isFile shouldBe true
-      val from = path.getParent()
+      val from = path.getParent
       from.toFile.isDirectory shouldBe true
 
       // move a directory
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/move",
             "id": 22,
@@ -663,23 +628,21 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 22,
             "result": null
           }
           """)
 
-      val to = Paths.get(testContentRoot.toString, "move_to", "test1.txt")
+      val to = Paths.get(testContentRoot.file.toString, "move_to", "test1.txt")
       to.toFile.isFile shouldBe true
       from.toFile.exists shouldBe false
     }
 
     "return failure when moving nonexistent file" in {
       val client = getInitialisedWsClient()
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/move",
             "id": 23,
@@ -695,8 +658,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 23,
             "error": {
@@ -706,15 +668,14 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           }
           """)
 
-      val to = Paths.get(testContentRoot.toString, "some", "test.txt")
+      val to = Paths.get(testContentRoot.file.toString, "some", "test.txt")
       to.toFile.exists shouldBe false
     }
 
     "return failure when target file exists" in {
       val client = getInitialisedWsClient()
       // create a source file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 24,
@@ -730,19 +691,17 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 24,
             "result": null
           }
           """)
-      val from = Paths.get(testContentRoot.toString, "move", "test.txt")
+      val from = Paths.get(testContentRoot.file.toString, "move", "test.txt")
       from.toFile.isFile shouldBe true
 
       // create a destination file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 25,
@@ -758,19 +717,17 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 25,
             "result": null
           }
           """)
-      val to = Paths.get(testContentRoot.toString, "move", "test1.txt")
+      val to = Paths.get(testContentRoot.file.toString, "move", "test1.txt")
       to.toFile.isFile shouldBe true
 
       // move to existing file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/move",
             "id": 26,
@@ -786,8 +743,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 26,
             "error": {
@@ -803,11 +759,10 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
 
     "check file existence" in {
       val client = getInitialisedWsClient()
-      val path = Paths.get(testContentRoot.toString, "nonexistent.txt")
+      val path   = Paths.get(testContentRoot.file.toString, "nonexistent.txt")
       path.toFile.exists shouldBe false
       // check file exists
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/exists",
             "id": 27,
@@ -819,8 +774,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 27,
             "result": {
@@ -843,8 +797,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       //     └── b.txt
 
       // create base/a.txt
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 28,
@@ -860,8 +813,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 28,
             "result": null
@@ -869,8 +821,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           """)
 
       // create base/subdir/b.txt
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 29,
@@ -886,8 +837,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 29,
             "result": null
@@ -895,8 +845,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           """)
 
       // get a tree of a root
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/tree",
             "id": 30,
@@ -915,8 +864,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       //     ├── a.txt
       //     └── subdir
       //         └── b.txt
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 30,
             "result": {
@@ -927,10 +875,31 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
                     ".."
                   ]
                 },
-                "name": ${testContentRoot.getFileName.toString},
+                "name": ${testContentRoot.file.getName},
                 "files": [
                 ],
-                "directories": [
+                "directories": [{
+                    "path" : {
+                      "rootId" : $testContentRootId,
+                      "segments" : [
+                      ]
+                    },
+                    "name" : ".enso",
+                    "files" : [
+                      {
+                        "type" : "File",
+                        "name" : "suggestions.db",
+                        "path" : {
+                          "rootId" : $testContentRootId,
+                          "segments" : [
+                            ".enso"
+                          ]
+                        }
+                      }
+                    ],
+                    "directories" : [
+                    ]
+                  },
                   {
                     "path": {
                       "rootId": $testContentRootId,
@@ -994,8 +963,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       //     └── b.txt
 
       // create base/a.txt
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 31,
@@ -1011,8 +979,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 31,
             "result": null
@@ -1020,8 +987,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           """)
 
       // create base/subdir/b.txt
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 32,
@@ -1037,8 +1003,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 32,
             "result": null
@@ -1046,8 +1011,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           """)
 
       // get a tree of 'base'
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/tree",
             "id": 33,
@@ -1065,8 +1029,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       // ├── a.txt
       // └── subdir
       //     └── b.txt
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 33,
             "result": {
@@ -1131,8 +1094,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       //     └── b.txt
 
       // create base/a.txt
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 34,
@@ -1148,8 +1110,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 34,
             "result": null
@@ -1157,8 +1118,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           """)
 
       // create base/subdir/b.txt
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 35,
@@ -1174,8 +1134,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 35,
             "result": null
@@ -1183,8 +1142,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           """)
 
       // get a tree of 'base'
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/tree",
             "id": 36,
@@ -1202,8 +1160,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       // base
       // ├── a.txt
       // └── subdir
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 36,
             "result": {
@@ -1247,8 +1204,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
     "get a subdirectory tree" in {
       val client = getInitialisedWsClient()
       // create base/a.txt
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 37,
@@ -1264,8 +1220,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 37,
             "result": null
@@ -1273,8 +1228,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           """)
 
       // create base/subdir/b.txt
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 38,
@@ -1290,8 +1244,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 38,
             "result": null
@@ -1299,8 +1252,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           """)
 
       // get a tree of 'base/subdir'
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/tree",
             "id": 39,
@@ -1316,8 +1268,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       //
       // subdir
       // └── b.txt
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 39,
             "result": {
@@ -1360,8 +1311,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       //     └── b.txt
 
       // create base2/subdir/b.txt
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 40,
@@ -1377,8 +1327,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 40,
             "result": null
@@ -1386,14 +1335,13 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           """)
 
       // create symlink base/link -> base/subdir
-      val symlink = Paths.get(testContentRoot.toString, "base2", "link")
-      val subdir = Paths.get(testContentRoot.toString, "base2", "subdir")
+      val symlink = Paths.get(testContentRoot.file.toString, "base2", "link")
+      val subdir  = Paths.get(testContentRoot.file.toString, "base2", "subdir")
       Files.createSymbolicLink(symlink, subdir)
       Files.isSymbolicLink(symlink) shouldBe true
 
       // get a tree of 'base'
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/tree",
             "id": 41,
@@ -1412,8 +1360,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       //     └── b.txt
       // └── subdir
       //     └── b.txt
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 41,
             "result": {
@@ -1485,8 +1432,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
     "get a directory tree with symlink outside of root" in {
       val client = getInitialisedWsClient()
       // create base3
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 42,
@@ -1502,8 +1448,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 42,
             "result": null
@@ -1513,13 +1458,12 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       // create symlink base3/link -> $testOtherRoot
       val testOtherRoot = Files.createTempDirectory(null)
       sys.addShutdownHook(FileUtils.deleteQuietly(testOtherRoot.toFile))
-      val symlink = Paths.get(testContentRoot.toString, "base3", "link")
+      val symlink = Paths.get(testContentRoot.file.toString, "base3", "link")
       Files.createSymbolicLink(symlink, testOtherRoot)
       Files.isSymbolicLink(symlink) shouldBe true
 
       // get a tree of 'base3'
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/tree",
             "id": 43,
@@ -1535,8 +1479,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       //
       // base3
       // └── link
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 43,
             "result": {
@@ -1580,8 +1523,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       //  └── b.txt
 
       // create subdir/b.txt
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 44,
@@ -1597,8 +1539,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 44,
             "result": null
@@ -1606,8 +1547,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           """)
 
       // get a tree of subdir
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/list",
             "id": 45,
@@ -1620,8 +1560,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
           }
       """)
       // expect: b.txt
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 45,
             "result" : {
@@ -1647,8 +1586,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
     "get file info" in {
       val client = getInitialisedWsClient()
       // create a file
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/create",
             "id": 46,
@@ -1664,20 +1602,18 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
           """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 46,
             "result": null
           }
           """)
-      val path = Paths.get(testContentRoot.toString, "info", "test.txt")
+      val path = Paths.get(testContentRoot.file.toString, "info", "test.txt")
       path.toFile.isFile shouldBe true
       val attrs = Files.readAttributes(path, classOf[BasicFileAttributes])
 
       // get file info
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/info",
             "id": 47,
@@ -1689,8 +1625,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 47,
             "result" : {
@@ -1717,10 +1652,9 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
 
     "return FileNotFound when getting info of nonexistent file" in {
       val client = getInitialisedWsClient()
-      val file = Paths.get(testContentRoot.toString, "nonexistent.txt").toFile
+      val file   = Paths.get(testContentRoot.file.toString, "nonexistent.txt").toFile
       file.exists shouldBe false
-      client.send(
-        json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/info",
             "id": 48,
@@ -1732,8 +1666,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             }
           }
       """)
-      client.expectJson(
-        json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 48,
             "error": {
@@ -1771,7 +1704,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
             "result": null
           }
           """)
-      val path = Paths.get(testContentRoot.toString, "info", "test.txt")
+      val path = Paths.get(testContentRoot.file.toString, "info", "test.txt")
       path.toFile.isFile shouldBe true
       val sum = Hex.toHexString(
         MessageDigest.getInstance("SHA3-224").digest(Files.readAllBytes(path))
@@ -1851,7 +1784,7 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
   }
 
   def withCleanRoot[T](test: => T): T = {
-    FileUtils.cleanDirectory(testContentRoot.toFile)
+    FileUtils.cleanDirectory(testContentRoot.file)
     test
   }
 }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileNotificationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileNotificationsTest.scala
@@ -9,7 +9,7 @@ import org.enso.text.editing.model.{Position, Range, TextEdit}
 
 class FileNotificationsTest extends BaseServerTest with FlakySpec {
 
-  def file(name: String): File = new File(testContentRoot.toFile, name)
+  def file(name: String): File = new File(testContentRoot.file, name)
 
   "text operations" should {
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/ReceivesTreeUpdatesHandlerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/ReceivesTreeUpdatesHandlerTest.scala
@@ -74,7 +74,7 @@ class ReceivesTreeUpdatesHandlerTest extends BaseServerTest {
       client2.expectJson(jsonrpc.ok(1))
 
       // create file
-      val path = Paths.get(testContentRoot.toString, "oneone.txt")
+      val path = Paths.get(testContentRoot.file.toString, "oneone.txt")
       Files.createFile(path)
       client1.expectJson(json"""
           { "jsonrpc": "2.0",

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/SessionManagementTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/SessionManagementTest.scala
@@ -24,7 +24,13 @@ class SessionManagementTest extends BaseServerTest {
             { "jsonrpc":"2.0",
               "id":1,
               "result":{
-                "contentRoots":[ $testContentRootId ]
+                "contentRoots": [
+                  {
+                    "id": $testContentRootId,
+                    "type": "Project",
+                    "name": "Project"
+                  }
+                ]
               }
             }
               """)

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/WorkspaceOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/WorkspaceOperationsTest.scala
@@ -11,7 +11,7 @@ class WorkspaceOperationsTest extends BaseServerTest with FlakySpec {
 
   "workspace/projectInfo" must {
     val packageConfigName = Config.ensoPackageConfigName
-    val testYamlPath      = new File(testContentRoot.toFile, packageConfigName)
+    val testYamlPath      = new File(testContentRoot.file, packageConfigName)
 
     "return the project info" taggedAs Flaky in {
       testYamlPath.delete()


### PR DESCRIPTION
### Pull Request Description
Does what it says on the tin.

### Important Notes

This introduces a _breaking change_ for the IDE as the "content root" is now a rich structure instead of just a UUID.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
