### PR TITLE
Fix the PM Not Checking To Preinstall the Graal Runtime if the Engine Was Already Installed

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,6 +12,9 @@
 
 - Added namespace information to project manager messages
   ([#1820](https://github.com/enso-org/enso/pull/1820)).
+- Fixed a bug where the Project Manager would not preinstall the Graal runtime
+  if the engine was already installed and only its runtime was missing
+  ([#1824](https://github.com/enso-org/enso/pull/1824)).
 
 # Enso 0.2.12 (2021-06-24)
 

--- a/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
@@ -38,8 +38,12 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
 
   private val logger = Logger[Launcher]
 
-  private lazy val componentsManager =
-    runtimeVersionManager(cliOptions, alwaysInstallMissing = false)
+  private lazy val componentsManager = {
+    val manager =
+      runtimeVersionManager(cliOptions, alwaysInstallMissing = false)
+    manager.logAvailableComponentsForDebugging()
+    manager
+  }
   private lazy val configurationManager =
     new GlobalConfigurationManager(componentsManager, distributionManager)
   private lazy val editionManager = EditionManager(distributionManager)

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
@@ -1,8 +1,5 @@
 package org.enso.projectmanager.infrastructure.languageserver
 
-import java.io.PrintWriter
-import java.lang.ProcessBuilder.Redirect
-import java.util.concurrent.Executors
 import akka.actor.ActorRef
 import com.typesafe.scalalogging.Logger
 import org.apache.commons.lang3.concurrent.BasicThreadFactory
@@ -12,9 +9,13 @@ import org.enso.projectmanager.service.versionmanagement.RuntimeVersionManagerFa
 import org.enso.runtimeversionmanager.config.GlobalConfigurationManager
 import org.enso.runtimeversionmanager.runner.{LanguageServerOptions, Runner}
 
+import java.io.PrintWriter
+import java.lang.ProcessBuilder.Redirect
+import java.util.concurrent.Executors
 import scala.util.Using
 
 object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
+  private lazy val logger = Logger[ExecutorWithUnlimitedPool.type]
 
   /** An executor that ensures each job runs in a separate thread.
     *
@@ -72,6 +73,8 @@ object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
     val versionManager = RuntimeVersionManagerFactory(distributionConfiguration)
       .makeRuntimeVersionManager(progressTracker)
 
+    versionManager.logAvailableComponentsForDebugging()
+
     val inheritedLogLevel =
       LoggingServiceManager.currentLogLevelForThisApplication()
     val options = LanguageServerOptions(
@@ -102,7 +105,7 @@ object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
       )
       .get
     runner.withCommand(runSettings, descriptor.jvmSettings) { command =>
-      Logger[ExecutorWithUnlimitedPool.type].trace(
+      logger.trace(
         "Starting Language Server Process [{}]",
         command
       )

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
@@ -37,6 +37,7 @@ class ProjectCreationService[
       val versionManager = RuntimeVersionManagerFactory(
         distributionConfiguration
       ).makeRuntimeVersionManager(progressTracker, missingComponentAction)
+      versionManager.logAvailableComponentsForDebugging()
       val configurationManager = new GlobalConfigurationManager(
         versionManager,
         distributionConfiguration.distributionManager

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
@@ -285,9 +285,11 @@ class ProjectService[
   ): F[ProjectServiceFailure, Unit] =
     Sync[F]
       .blockingOp {
-        RuntimeVersionManagerFactory(distributionConfiguration)
-          .makeRuntimeVersionManager(progressTracker, missingComponentAction)
-          .findOrInstallEngine(version)
+        val runtimeVersionManager =
+          RuntimeVersionManagerFactory(distributionConfiguration)
+            .makeRuntimeVersionManager(progressTracker, missingComponentAction)
+        val engine = runtimeVersionManager.findOrInstallEngine(version)
+        runtimeVersionManager.findOrInstallGraalRuntime(engine)
         ()
       }
       .mapRuntimeManagerErrors(th =>

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
@@ -288,8 +288,10 @@ class ProjectService[
         val runtimeVersionManager =
           RuntimeVersionManagerFactory(distributionConfiguration)
             .makeRuntimeVersionManager(progressTracker, missingComponentAction)
+        runtimeVersionManager.logAvailableComponentsForDebugging()
         val engine = runtimeVersionManager.findOrInstallEngine(version)
         runtimeVersionManager.findOrInstallGraalRuntime(engine)
+        runtimeVersionManager.logAvailableComponentsForDebugging()
         ()
       }
       .mapRuntimeManagerErrors(th =>

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/MissingComponentBehavior.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/MissingComponentBehavior.scala
@@ -4,6 +4,7 @@ import io.circe.Json
 import nl.gn0s1s.bump.SemVer
 import org.enso.projectmanager.BaseServerSpec
 import org.enso.projectmanager.data.MissingComponentAction
+import org.enso.runtimeversionmanager.components.GraalVMVersion
 import org.enso.testkit.RetrySpec
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -16,8 +17,8 @@ trait MissingComponentBehavior {
 
   def isSuccess(json: Json): Boolean
 
-  private val defaultVersion = SemVer(0, 0, 1)
-  private val brokenVersion  = SemVer(0, 999, 0, Some("broken"))
+  val defaultVersion = SemVer(0, 0, 1)
+  val brokenVersion  = SemVer(0, 999, 0, Some("broken"))
 
   def correctlyHandleMissingComponents(): Unit = {
     "fail if a missing version is requested with Fail" in {
@@ -52,6 +53,28 @@ trait MissingComponentBehavior {
       client.send(
         buildRequest(brokenVersion, MissingComponentAction.ForceInstallBroken)
       )
+      client.expectTaskStarted()
+    }
+  }
+
+  /** This behaviour should be tested in a separate test suite, as it affects
+    *  the test environment and if run together with other tests it could affect
+    *  their results.
+    */
+  def correctlyHandleMissingRuntimeInPresenceOfEngine(): Unit = {
+    "make sure to check if the runtime is installed even if the engine was " +
+    "already installed" in {
+      uninstallRuntime(GraalVMVersion("2.0.0", "11"))
+
+      val client = new WsTestClient(address)
+      client.send(
+        buildRequest(defaultVersion, MissingComponentAction.Install)
+      )
+
+      /** We do not check for success here as we are concerned onyl that the
+        * installation is attempted. Installation and creating/opening projects
+        * are tested elsewhere.
+        */
       client.expectTaskStarted()
     }
   }

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateDefaultToLatestSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateDefaultToLatestSpec.scala
@@ -4,7 +4,7 @@ import io.circe.literal.JsonStringContext
 import org.enso.projectmanager.BaseServerSpec
 
 class ProjectCreateDefaultToLatestSpec extends BaseServerSpec {
-  "project/open" should {
+  "project/create" should {
     "default to latest available engine version if none are installed" in {
       implicit val client = new WsTestClient(address)
       client.send(json"""

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateHandleMissingRuntimeSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateHandleMissingRuntimeSpec.scala
@@ -1,0 +1,26 @@
+package org.enso.projectmanager.protocol
+
+import org.enso.projectmanager.TestDistributionConfiguration
+import org.enso.runtimeversionmanager.runner.JVMSettings
+import org.enso.runtimeversionmanager.test.FakeReleases
+
+class ProjectCreateHandleMissingRuntimeSpec extends ProjectCreateSpecBase {
+  override val distributionConfiguration =
+    new TestDistributionConfiguration(
+      distributionRoot       = testDistributionRoot.toPath,
+      engineReleaseProvider  = FakeReleases.engineReleaseProvider,
+      runtimeReleaseProvider = FakeReleases.runtimeReleaseProvider,
+      discardChildOutput     = !debugChildLogs
+    ) {
+      override def defaultJVMSettings: JVMSettings = JVMSettings(
+        javaCommandOverride = None,
+        jvmOptions          = Seq()
+      )
+    }
+
+  override val engineToInstall = Some(defaultVersion)
+
+  "project/create" should {
+    behave like correctlyHandleMissingRuntimeInPresenceOfEngine()
+  }
+}

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateMissingComponentsSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateMissingComponentsSpec.scala
@@ -1,43 +1,6 @@
 package org.enso.projectmanager.protocol
 
-import io.circe.Json
-import io.circe.literal.JsonStringContext
-import nl.gn0s1s.bump.SemVer
-import org.enso.projectmanager.data.MissingComponentAction
-import org.enso.projectmanager.{BaseServerSpec, ProjectManagementOps}
-import org.enso.testkit.RetrySpec
-import org.enso.editions.SemVerJson._
-
-class ProjectCreateMissingComponentsSpec
-    extends BaseServerSpec
-    with RetrySpec
-    with ProjectManagementOps
-    with MissingComponentBehavior {
-  override def buildRequest(
-    version: SemVer,
-    missingComponentAction: MissingComponentAction
-  ): Json =
-    json"""
-        { "jsonrpc": "2.0",
-          "method": "project/create",
-          "id": 1,
-          "params": {
-            "name": "Testproj",
-            "missingComponentAction": $missingComponentAction,
-            "version": $version
-          }
-        }
-        """
-
-  override def isSuccess(json: Json): Boolean = {
-    val projectId = for {
-      obj    <- json.asObject
-      result <- obj("result").flatMap(_.asObject)
-      id     <- result("projectId")
-    } yield id
-    projectId.isDefined
-  }
-
+class ProjectCreateMissingComponentsSpec extends ProjectCreateSpecBase {
   "project/create" should {
     behave like correctlyHandleMissingComponents()
   }

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateSpecBase.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateSpecBase.scala
@@ -1,0 +1,40 @@
+package org.enso.projectmanager.protocol
+
+import io.circe.Json
+import io.circe.literal.JsonStringContext
+import nl.gn0s1s.bump.SemVer
+import org.enso.projectmanager.data.MissingComponentAction
+import org.enso.projectmanager.{BaseServerSpec, ProjectManagementOps}
+import org.enso.testkit.RetrySpec
+import org.enso.editions.SemVerJson._
+
+abstract class ProjectCreateSpecBase
+    extends BaseServerSpec
+    with RetrySpec
+    with ProjectManagementOps
+    with MissingComponentBehavior {
+  override def buildRequest(
+    version: SemVer,
+    missingComponentAction: MissingComponentAction
+  ): Json =
+    json"""
+        { "jsonrpc": "2.0",
+          "method": "project/create",
+          "id": 1,
+          "params": {
+            "name": "Testproj",
+            "missingComponentAction": $missingComponentAction,
+            "version": $version
+          }
+        }
+        """
+
+  override def isSuccess(json: Json): Boolean = {
+    val projectId = for {
+      obj    <- json.asObject
+      result <- obj("result").flatMap(_.asObject)
+      id     <- result("projectId")
+    } yield id
+    projectId.isDefined
+  }
+}

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectOpenHandleMissingRuntimeSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectOpenHandleMissingRuntimeSpec.scala
@@ -1,0 +1,8 @@
+package org.enso.projectmanager.protocol
+
+class ProjectOpenHandleMissingRuntimeSpec extends ProjectOpenSpecBase {
+
+  "project/open" should {
+    behave like correctlyHandleMissingRuntimeInPresenceOfEngine()
+  }
+}

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectOpenMissingComponentsSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectOpenMissingComponentsSpec.scala
@@ -1,90 +1,10 @@
 package org.enso.projectmanager.protocol
 
-import java.io.File
-import java.util.UUID
-import akka.testkit.TestActors.blackholeProps
-import io.circe.Json
-import io.circe.literal.JsonStringContext
-import nl.gn0s1s.bump.SemVer
-import org.enso.editions.SemVerEnsoVersion
-import org.enso.projectmanager.data.MissingComponentAction
-import org.enso.projectmanager.{BaseServerSpec, ProjectManagementOps}
-import org.enso.testkit.RetrySpec
-import zio.Runtime
+class ProjectOpenMissingComponentsSpec extends ProjectOpenSpecBase {
 
-class ProjectOpenMissingComponentsSpec
-    extends BaseServerSpec
-    with RetrySpec
-    with ProjectManagementOps
-    with MissingComponentBehavior {
-  val ordinaryVersion: SemVer  = SemVer(0, 0, 1)
-  override val engineToInstall = Some(ordinaryVersion)
-  var ordinaryProject: UUID    = _
-  var brokenProject: UUID      = _
-
-  override val deleteProjectsRootAfterEachTest = false
   override def beforeAll(): Unit = {
     super.beforeAll()
-
-    val blackhole = system.actorOf(blackholeProps)
-    val ordinaryAction = projectService.createUserProject(
-      blackhole,
-      "Proj_1",
-      ordinaryVersion,
-      MissingComponentAction.Fail
-    )
-    ordinaryProject = Runtime.default.unsafeRun(ordinaryAction)
-    val brokenName = "Projbroken"
-    val brokenAction = projectService.createUserProject(
-      blackhole,
-      brokenName,
-      ordinaryVersion,
-      MissingComponentAction.Fail
-    )
-    brokenProject = Runtime.default.unsafeRun(brokenAction)
-
-    // TODO [RW] this hack should not be necessary with #1273
-    val projectDir = new File(userProjectDir, brokenName)
-    val pkgManager = org.enso.pkg.PackageManager.Default
-    val pkg        = pkgManager.loadPackage(projectDir).get
-    pkg.updateConfig(config =>
-      config.copy(edition =
-        config.edition.copy(
-          engineVersion =
-            Some(SemVerEnsoVersion(SemVer(0, 999, 0, Some("broken"))))
-        )
-      )
-    )
-
-    uninstallEngine(ordinaryVersion)
-  }
-
-  override def buildRequest(
-    version: SemVer,
-    missingComponentAction: MissingComponentAction
-  ): Json = {
-    val projectId =
-      if (version.preRelease.contains("broken")) brokenProject
-      else ordinaryProject
-
-    json"""
-        { "jsonrpc": "2.0",
-          "method": "project/open",
-          "id": 1,
-          "params": {
-            "projectId": $projectId,
-            "missingComponentAction": $missingComponentAction
-          }
-        }
-        """
-  }
-
-  override def isSuccess(json: Json): Boolean = {
-    val result = for {
-      obj    <- json.asObject
-      result <- obj("result").flatMap(_.asObject)
-    } yield result
-    result.isDefined
+    uninstallEngine(defaultVersion)
   }
 
   "project/open" should {

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectOpenSpecBase.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectOpenSpecBase.scala
@@ -1,0 +1,85 @@
+package org.enso.projectmanager.protocol
+
+import java.io.File
+import java.util.UUID
+import akka.testkit.TestActors.blackholeProps
+import io.circe.Json
+import io.circe.literal.JsonStringContext
+import nl.gn0s1s.bump.SemVer
+import org.enso.editions.SemVerEnsoVersion
+import org.enso.projectmanager.data.MissingComponentAction
+import org.enso.projectmanager.{BaseServerSpec, ProjectManagementOps}
+import org.enso.testkit.RetrySpec
+import zio.Runtime
+
+abstract class ProjectOpenSpecBase
+    extends BaseServerSpec
+    with RetrySpec
+    with ProjectManagementOps
+    with MissingComponentBehavior {
+  override val engineToInstall = Some(defaultVersion)
+  var ordinaryProject: UUID    = _
+  var brokenProject: UUID      = _
+
+  override val deleteProjectsRootAfterEachTest = false
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val blackhole = system.actorOf(blackholeProps)
+    val ordinaryAction = projectService.createUserProject(
+      blackhole,
+      "Proj_1",
+      defaultVersion,
+      MissingComponentAction.Fail
+    )
+    ordinaryProject = Runtime.default.unsafeRun(ordinaryAction)
+    val brokenName = "Projbroken"
+    val brokenAction = projectService.createUserProject(
+      blackhole,
+      brokenName,
+      defaultVersion,
+      MissingComponentAction.Fail
+    )
+    brokenProject = Runtime.default.unsafeRun(brokenAction)
+
+    // TODO [RW] this hack should not be necessary with #1273
+    val projectDir = new File(userProjectDir, brokenName)
+    val pkgManager = org.enso.pkg.PackageManager.Default
+    val pkg        = pkgManager.loadPackage(projectDir).get
+    pkg.updateConfig(config =>
+      config.copy(edition =
+        config.edition.copy(engineVersion =
+          Some(SemVerEnsoVersion(brokenVersion))
+        )
+      )
+    )
+  }
+
+  override def buildRequest(
+    version: SemVer,
+    missingComponentAction: MissingComponentAction
+  ): Json = {
+    val projectId =
+      if (version.preRelease.contains("broken")) brokenProject
+      else ordinaryProject
+
+    json"""
+        { "jsonrpc": "2.0",
+          "method": "project/open",
+          "id": 1,
+          "params": {
+            "projectId": $projectId,
+            "missingComponentAction": $missingComponentAction
+          }
+        }
+        """
+  }
+
+  override def isSuccess(json: Json): Boolean = {
+    val result = for {
+      obj    <- json.asObject
+      result <- obj("result").flatMap(_.asObject)
+    } yield result
+    result.isDefined
+  }
+}

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
@@ -7,6 +7,7 @@ import org.enso.distribution.{DistributionManager, FileSystem, OS}
 import org.enso.distribution.locking.{LockType, ResourceManager}
 import org.enso.runtimeversionmanager.CurrentVersion
 import org.enso.distribution.FileSystem.PathSyntax
+import org.enso.logger.masking.MaskedPath
 import org.enso.runtimeversionmanager.archive.Archive
 import org.enso.runtimeversionmanager.distribution.TemporaryDirectoryManager
 import org.enso.runtimeversionmanager.locking.Resources
@@ -844,6 +845,32 @@ class RuntimeVersionManager(
       temporaryDirectoryManager.accessTemporaryDirectory() / path.getFileName
     FileSystem.atomicMove(path, temporaryPath)
     FileSystem.removeDirectory(temporaryPath)
+  }
+
+  /** Logs on trace level all installed engines and runtimes.
+    *
+    * Useful for debugging.
+    */
+  def logAvailableComponentsForDebugging(): Unit = logger.whenTraceEnabled {
+    logger.trace("Discovering available components...")
+    val engines = for (engine <- listInstalledEngines()) yield {
+      val runtime = findGraalRuntime(engine)
+      val runtimeName = runtime
+        .map(_.toString)
+        .getOrElse("no runtime found")
+      val broken = if (engine.isMarkedBroken) " (broken)" else ""
+      s" - Enso ${engine.version}$broken [runtime: $runtimeName] " +
+      s"[location: ${MaskedPath(engine.path)}]"
+    }
+
+    val runtimes =
+      for (runtime <- listInstalledGraalRuntimes())
+        yield s" - $runtime [location: ${MaskedPath(runtime.path)}]"
+
+    logger.trace(
+      s"Installed engines (${engines.length}):\n${engines.mkString("\n")}\n\n" +
+      s"Installed runtimes (${runtimes.length}):\n${runtimes.mkString("\n")}"
+    )
   }
 }
 

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
@@ -171,7 +171,7 @@ class RuntimeVersionManager(
     *
     * @param engine the engine for which the runtime is requested
     */
-  private def findOrInstallGraalRuntime(engine: Engine): GraalRuntime =
+  def findOrInstallGraalRuntime(engine: Engine): GraalRuntime =
     findGraalRuntime(engine) match {
       case Some(found) => found
       case None =>


### PR DESCRIPTION
### Pull Request Description

The PM only checks if engine was installed before starting the Language Server, assuming that if the engine is installed, the runtime should also be. This is not the case, there are valid situations, even excluding just manually removing the runtime directory, like installing just the engine having the runtime bundled and then switching to a different bundle that does not provide that runtime anymore.

So the PM should also make sure that the runtime is installed too before proceeding, this PR fixes that.


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
