### PR TITLE
Fix Nightly Workflows and Update Release Policy

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,6 +31,7 @@ jobs:
     outputs:
       proceed: ${{ steps.preparations.outputs.proceed }}
       nightly-version: ${{ steps.preparations.outputs.nightly-version }}
+      nightly-edition: ${{ steps.preparations.outputs.nightly-edition }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -140,12 +141,13 @@ jobs:
         run: |
           echo "ENSO_RELEASE_MODE=true" >> $GITHUB_ENV
           echo "ENSO_VERSION=${{ needs.preflight-check.outputs.nightly-version }}" >> $GITHUB_ENV
+          echo "ENSO_EDITION=${{ needs.preflight-check.outputs.nightly-edition }}" >> $GITHUB_ENV
 
       - name: Update the Version Number to the Nightly
         working-directory: repo
         shell: bash
         run: |
-          node tools/ci/nightly/bump-version.js $ENSO_VERSION
+          node tools/ci/nightly/bump-version.js $ENSO_VERSION $ENSO_EDITION
 
       - name: Bootstrap the Project
         working-directory: repo
@@ -351,13 +353,15 @@ jobs:
         shell: bash
         run: |
           DIST_VERSION=${{ needs.preflight-check.outputs.nightly-version }}
-          echo "Preparing release for $DIST_VERSION"
+          ENSO_EDITION=${{ needs.preflight-check.outputs.nightly-edition }}
+          echo "Preparing release for $DIST_VERSION, edition $ENSO_EDITION"
           echo "DIST_VERSION=$DIST_VERSION" >> $GITHUB_ENV
+          echo "ENSO_EDITION=$ENSO_EDITION" >> $GITHUB_ENV
       - name: Update the Version Number to the Nightly
         working-directory: repo
         shell: bash
         run: |
-          node tools/ci/nightly/bump-version.js $DIST_VERSION
+          node tools/ci/nightly/bump-version.js $DIST_VERSION $ENSO_EDITION
 
       - name: Prepare Packages
         shell: bash

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val rustVersion    = "1.54.0-nightly"
 val graalVersion   = "21.1.0"
 val javaVersion    = "11"
 val ensoVersion    = "0.2.14-SNAPSHOT" // Note [Engine And Launcher Version]
-val currentEdition = "2021.1"          // Note [Default Editions]
+val currentEdition = "2021.2-SNAPSHOT" // Note [Default Editions]
 val stdLibVersion  = "0.1.0"           // Note [Standard Library Version]
 
 /* Note [Engine And Launcher Version]

--- a/docs/distribution/nightly.md
+++ b/docs/distribution/nightly.md
@@ -54,12 +54,19 @@ differentiate between builds from a single day.
 For example, if `build.sbt` specifies the version to be `1.2.3` or
 `1.2.3-SNAPSHOT`, the nightly build based off of that version, triggered on 1st
 of February 2021 will result in version `1.2.3-SNAPSHOT.2021-02-01`. If a
-subsequent build based off of the same version is triggered on the same day it
-will be `1.2.3-SNAPSHOT.2021-02-01.1` etc.
+subsequent nightly build is triggered on the same day it will be
+`1.2.3-SNAPSHOT.2021-02-01.1` etc.
 
 Only the 3 most recent nightly builds are kept in the repository, any older
 builds are removed from the releases page and their corresponding tags are also
 removed.
+
+As each release has a default edition associated with it, so do the nightlies.
+For the first nightly released on a given date, the edition associated with it
+will be named `nightly-2021-02-01`. For subsequent nightly releases on the same
+day, a prefix will be added in the same way as with versions. So for example the
+second release on that day will be associated with edition
+`nightly-2021-02-01.1` etc.
 
 ## Release Notes
 

--- a/docs/distribution/release-policy.md
+++ b/docs/distribution/release-policy.md
@@ -82,15 +82,19 @@ Cutting a release for Enso proceeds as follows:
     created.
 2.  Create a branch called `wip/<initials/release-bump`. On this branch, ensure
     that the release notes are up to date in `RELEASES.md` (follow the existing
-    format), and that the new version number has been set in `build.sbt`. This
-    version should _not_ contain `SNAPSHOT`.
+    format), and that the new version number and edition name have been set in
+    `build.sbt`. This version and edition name should _not_ contain `SNAPSHOT`.
 3.  Open a PR for this branch into `main`.
 4.  Once the changes have been reviewed, merge the PR into main (getting commit
     hash `xxxxxxx`). The message should be `Prepare for the $version release`.
-5.  Immediately push a commit to `main` that updates the version in `build.sbt`
-    to the new snapshot version. If unclear, bump the patch version by one and
-    append `-SNAPSHOT` (e.g. `0.2.10` becomes `0.2.11-SNAPSHOT`). The message
-    should be `Bump the snapshot version`.
+5.  Immediately push a commit to `main` that updates the version and edition in
+    `build.sbt` to the new snapshot version. If unclear, bump the patch version
+    by one and append `-SNAPSHOT` (e.g. `0.2.10` becomes `0.2.11-SNAPSHOT`). The
+    edition name should have the number after the dot increased and `-SNAPSHOT`
+    appended, so that `2021.3` becomes `2021.4-SNAPSHOT`. The only exception is
+    when making the first release in a new year, where the first number should
+    be bumped to the next year and the second number should be set to 1, for
+    example `2022.1`. The message should be `Bump the snapshot version`.
 6.  Find the commit hash of the last "Bump the snapshot version" commit. Let's
     say this is `yyyyyyy`.
 7.  Run a `rebase --onto` the release branch from the `yyyyyyy` commit to the
@@ -168,7 +172,8 @@ git merge --ff-only release-update
 
 5.  On the release branch, ensure that the release notes are up to date in
     `RELEASES.md` (follow the existing format), and that the new version number
-    has been set in `build.sbt`. This version should _not_ contain `SNAPSHOT`.
+    and edition name have been set in `build.sbt`. This version and edition name
+    should _not_ contain `SNAPSHOT`.
 6.  Once this is done, create a tag for the commit at the HEAD of the release
     branch. It should be named as above. For example:
 
@@ -188,7 +193,9 @@ git tag --sign enso-0.2.11
     on the release branch with the changes on `main`.
 12. In the same commit, Update the build version number in `build.sbt` to the
     new snapshot version. If unclear, bump the patch version by one and append
-    `-SNAPSHOT` (e.g. `0.2.10` becomes `0.2.11-SNAPSHOT`). The message should be
+    `-SNAPSHOT` (e.g. `0.2.10` becomes `0.2.11-SNAPSHOT`). The edition name
+    should have the number after the dot increased and `-SNAPSHOT` appended, so
+    that `2021.3` becomes `2021.4-SNAPSHOT`. The message should be
     `Bump the snapshot version`.
 13. Push this commit into `origin/main`, or merge via PR if unable to directly
     push.

--- a/tools/ci/nightly/bump-version.js
+++ b/tools/ci/nightly/bump-version.js
@@ -2,12 +2,16 @@ const fs = require("fs");
 
 const path = "build.sbt";
 const version = process.argv[2];
+const edition = process.argv[3];
 
 const content = fs.readFileSync(path, { encoding: "utf-8" });
-const updated = content.replace(
-  /val ensoVersion.*= ".*"/g,
-  'val ensoVersion = "' + version + '"'
-);
+const updated = content
+  .replace(/val ensoVersion.*= ".*"/, 'val ensoVersion = "' + version + '"')
+  .replace(
+    /val currentEdition.*= ".*"/,
+    'val currentEdition = "' + edition + '"'
+  );
 fs.writeFileSync(path, updated);
 
 console.log("Updated build version to " + version);
+console.log("Updated build edition to " + edition);


### PR DESCRIPTION
### Pull Request Description

My previous PR that integrated the editions system (#1832) did introduce default editions tied to each engine version.

However I forgot to mention that after performing a release this edition number must be bumped and also that the nightly workflows should set this edition name to a nightly-specific name. Without this, editions from nightlies and releases could conflict leading to unexpected engine versions possibly being selected if multiple versions sharing the same edition name are installed.

This PR fixes that by updating the release policy, doing the overdue edition bump and adding automatic edition bumping to the nightly workflow.


### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
   - A [nightly build is running on staging](https://github.com/enso-org/enso-staging/actions/runs/1015176768) to verify that the bumping code works correctly.