### PR TITLE
Update Dockerfile for Integrating Editions with Cloud

### DIFF
--- a/docs/libraries/editions.md
+++ b/docs/libraries/editions.md
@@ -157,10 +157,17 @@ names, but it can refer to other editions by their names (when extending them).
 These editions are resolved using the logic below:
 
 1. Each `<edition-name>` corresponds to a file `<edition-name>.yaml`.
-2. First, the directory `<ENSO_HOME>/editions` is scanned for a matching edition
-   file.
-3. If none is found above, the directory `$ENSO_DATA_DIRECTORY/editions` is
-   checked.
+2. First, the custom edition search paths are scanned for a matching edition
+   file. These paths can be defined by the `ENSO_EDITION_PATH` environment
+   variable. If it is not defined, it defaults to `<ENSO_HOME>/editions`.
+3. If none is found above, the cached/bundled edition search paths are checked.
+   These consist of the directory `$ENSO_DATA_DIRECTORY/editions`, `editions`
+   directories in installed engines and the `editions` directory in the
+   currently running engine.
+
+By default, downloaded editions are downloaded to
+`$ENSO_DATA_DIRECTORY/editions`, but also editions bundled with any available
+engines can be loaded.
 
 See [The Enso Distribution](../distribution/distribution.md) for definitions of
 the directories.

--- a/tools/ci/docker/Dockerfile
+++ b/tools/ci/docker/Dockerfile
@@ -6,14 +6,33 @@ ENV LOG_LEVEL=INFO
 
 RUN useradd -u 2000 -c 'Enso Developer' -U -M ensodev
 
+# /opt/enso is the present engine distribution.
+# /opt/workdir is a directory for temporary runtime files and logs.
+# /volumes/workspace is the root of the mounted workspace which contains all data that must persist when the project is reopened.
+# /volumes/workspace/project_root contains the project package.
+# /volumes/workspace/data_root contains the data root of the Enso distribution, this is where cached libraries will be located.
+# /volumes/workspace/config contains configuration files, currently these are not really used in the Cloud.
+# /volumes/workspace/home contains the ENSO_HOME directory, where locally created libraries will be placed.
+# Currently, only the /volumes/workspace/project_root needs to be initialized with the project structure when the project is created.
+# All other directories are created on-demand.
+
 ADD bin /opt/enso/bin
 ADD component /opt/enso/component
 ADD lib /opt/enso/lib
 ADD editions /opt/enso/editions
 
+ENV ENSO_DATA_DIRECTORY=/volumes/workspace/data_root
+ENV ENSO_CONFIG_DIRECTORY=/volumes/workspace/config
+ENV ENSO_RUNTIME_DIRECTORY=/opt/workdir/runtime
+ENV ENSO_LOG_DIRECTORY=/opt/workdir/log
+ENV ENSO_HOME=/volumes/workspace/home
+
 RUN chown -hR ensodev:ensodev /opt/enso
 RUN chmod -R u=rX,g=rX /opt/enso
 RUN chmod a+x /opt/enso/bin/*
+
+RUN chown -hR ensodev:ensodev /opt/workdir
+RUN chmod -R u=rX,g=rX /opt/workdir
 
 RUN mkdir -p /volumes
 RUN chown -hR ensodev:ensodev /volumes
@@ -28,4 +47,4 @@ ENTRYPOINT [ "/opt/enso/bin/docker-entrypoint.sh" ]
 EXPOSE 30001
 EXPOSE 30002
 
-CMD ["--server", "--daemon", "--rpc-port", "30001", "--data-port", "30002", "--root-id", "00000000-0000-0000-0000-000000000001", "--path", "/volumes/workspace", "--interface", "0.0.0.0"]
+CMD ["--server", "--daemon", "--rpc-port", "30001", "--data-port", "30002", "--root-id", "00000000-0000-0000-0000-000000000001", "--path", "/volumes/workspace/project_root", "--interface", "0.0.0.0"]

--- a/tools/ci/docker/Dockerfile
+++ b/tools/ci/docker/Dockerfile
@@ -21,18 +21,18 @@ ADD component /opt/enso/component
 ADD lib /opt/enso/lib
 ADD editions /opt/enso/editions
 
+RUN mkdir /opt/enso/work
+RUN mkdir /opt/enso/logs
+
 ENV ENSO_DATA_DIRECTORY=/volumes/workspace/data_root
 ENV ENSO_CONFIG_DIRECTORY=/volumes/workspace/config
-ENV ENSO_RUNTIME_DIRECTORY=/opt/workdir/runtime
-ENV ENSO_LOG_DIRECTORY=/opt/workdir/log
+ENV ENSO_RUNTIME_DIRECTORY=/opt/enso/work
+ENV ENSO_LOG_DIRECTORY=/opt/enso/logs
 ENV ENSO_HOME=/volumes/workspace/home
 
 RUN chown -hR ensodev:ensodev /opt/enso
 RUN chmod -R u=rX,g=rX /opt/enso
 RUN chmod a+x /opt/enso/bin/*
-
-RUN chown -hR ensodev:ensodev /opt/workdir
-RUN chmod -R u=rX,g=rX /opt/workdir
 
 RUN mkdir -p /volumes
 RUN chown -hR ensodev:ensodev /volumes

--- a/tools/ci/docker/Dockerfile
+++ b/tools/ci/docker/Dockerfile
@@ -33,6 +33,8 @@ ENV ENSO_HOME=/volumes/workspace/home
 RUN chown -hR ensodev:ensodev /opt/enso
 RUN chmod -R u=rX,g=rX /opt/enso
 RUN chmod a+x /opt/enso/bin/*
+RUN chmod a+rw /opt/enso/work
+RUN chmod a+rw /opt/enso/logs
 
 RUN mkdir -p /volumes
 RUN chown -hR ensodev:ensodev /volumes


### PR DESCRIPTION
### Pull Request Description

Updates the Dockerfile, setting paths in such a way that the library cache (not currently implemented) and local libraries created from the IDE will persist when the cloud project is reopened.

### Important Notes

- It is a breaking change for the cloud, in the sense that it modifies the layout of the workspace tied to a project. When the cloud starts using an image from a release that contains these changes, it needs to adapt the location of where the new project package is created, instead of creating it in the root of the workspace, it has to be created inside of a subdirectory called `project_root`. That is because other directories need to be placed next to it within the workspace.
- A task has been created regarding the cloud integration https://github.com/enso-org/cloud/issues/267

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
