### PR TITLE
Bump Minimal PM/Launcher Versions for New Engine

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -243,6 +243,9 @@ lazy val enso = (project in file("."))
     launcher,
     `runtime-version-manager`,
     `runtime-version-manager-test`,
+    editions,
+    `distribution-manager`,
+    `library-manager`,
     syntax.jvm,
     testkit
   )

--- a/distribution/manifest.template.yaml
+++ b/distribution/manifest.template.yaml
@@ -1,5 +1,5 @@
-minimum-launcher-version: 0.2.4-SNAPSHOT
-minimum-project-manager-version: 0.2.4-SNAPSHOT
+minimum-launcher-version: 0.2.13
+minimum-project-manager-version: 0.2.13
 jvm-options:
   - value: "-Dpolyglot.engine.IterativePartialEscape=true"
   - value: "-Dtruffle.class.path.append=$enginePackagePath\\component\\runtime.jar"

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectCreateHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectCreateHandler.scala
@@ -51,6 +51,8 @@ class ProjectCreateHandler[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
             s"Could not determine the default version: $error"
           )
         }
+      _ = logger.trace(s"Creating project using engine $actualVersion")
+      _ = println(s"Using $actualVersion")
       projectId <- projectService.createUserProject(
         progressTracker        = self,
         name                   = params.name,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectCreateHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectCreateHandler.scala
@@ -52,7 +52,6 @@ class ProjectCreateHandler[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
           )
         }
       _ = logger.trace(s"Creating project using engine $actualVersion")
-      _ = println(s"Using $actualVersion")
       projectId <- projectService.createUserProject(
         progressTracker        = self,
         name                   = params.name,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
@@ -1,6 +1,7 @@
 package org.enso.projectmanager.service
 
 import akka.actor.ActorRef
+import com.typesafe.scalalogging.Logger
 import nl.gn0s1s.bump.SemVer
 import org.enso.projectmanager.control.core.CovariantFlatMap
 import org.enso.projectmanager.control.core.syntax._
@@ -24,6 +25,8 @@ class ProjectCreationService[
   distributionConfiguration: DistributionConfiguration,
   loggingServiceDescriptor: LoggingServiceDescriptor
 ) extends ProjectCreationServiceApi[F] {
+
+  private lazy val logger = Logger[ProjectCreationService[F]]
 
   /** @inheritdoc */
   override def createProject(
@@ -56,6 +59,7 @@ class ProjectCreationService[
         runner.newProject(path, name, engineVersion, None, None, Seq()).get
       val jvmSettings = distributionConfiguration.defaultJVMSettings
       runner.withCommand(settings, jvmSettings) { command =>
+        logger.trace(s"Running engine $engineVersion to create project $path")
         command.run().get
       }
     }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
@@ -3,6 +3,7 @@ package org.enso.projectmanager.service
 import akka.actor.ActorRef
 import com.typesafe.scalalogging.Logger
 import nl.gn0s1s.bump.SemVer
+import org.enso.logger.masking.MaskedPath
 import org.enso.projectmanager.control.core.CovariantFlatMap
 import org.enso.projectmanager.control.core.syntax._
 import org.enso.projectmanager.control.effect.{ErrorChannel, Sync}
@@ -59,7 +60,10 @@ class ProjectCreationService[
         runner.newProject(path, name, engineVersion, None, None, Seq()).get
       val jvmSettings = distributionConfiguration.defaultJVMSettings
       runner.withCommand(settings, jvmSettings) { command =>
-        logger.trace(s"Running engine $engineVersion to create project $path")
+        logger.trace(
+          s"Running engine $engineVersion to create project $name at " +
+          s"[${MaskedPath(path).applyMasking()}]."
+        )
         command.run().get
       }
     }

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/ProjectManagementOps.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/ProjectManagementOps.scala
@@ -17,11 +17,9 @@ trait ProjectManagementOps { this: BaseServerSpec =>
 
   def createProject(
     name: String,
-    version: Option[SemVer]                                = None,
     missingComponentAction: Option[MissingComponentAction] = None
   )(implicit client: WsTestClient): UUID = {
     val fields = Seq("name" -> name.asJson) ++
-      version.map(v => "version" -> v.asJson).toSeq ++
       missingComponentAction
         .map(a => "missingComponentAction" -> a.asJson)
         .toSeq

--- a/project/Editions.scala
+++ b/project/Editions.scala
@@ -27,8 +27,8 @@ object Editions {
 
     for (file <- IO.listFiles(editions)) {
       if (file.getName != edition.getName) {
-        log.warn(s"Removed spurious file in editions directory: $file")
         IO.delete(file)
+        log.warn(s"Removed spurious file in editions directory: $file")
       }
     }
 

--- a/project/Editions.scala
+++ b/project/Editions.scala
@@ -23,8 +23,15 @@ object Editions {
   ): Unit = {
     val editions = file("distribution") / "editions"
     IO.createDirectory(editions)
-
     val edition = editions / (editionName + ".yaml")
+
+    for (file <- IO.listFiles(editions)) {
+      if (file.getName != edition.getName) {
+        log.warn(s"Removed spurious file in editions directory: $file")
+        IO.delete(file)
+      }
+    }
+
     if (!edition.exists()) {
       val librariesConfigs = standardLibraries.map { libName =>
         s"""  - name: $libName


### PR DESCRIPTION
### Pull Request Description

Bumps the minimal version of the launcher/project-manager that should be used with newer engines, due to an incompatible project settings change.

Additionally, fixes some minor things in `build.sbt`.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
