### PR TITLE
Add Aliases to the Standard Library

### DIFF
--- a/distribution/lib/Standard/Base/0.1.0/src/Data/Any/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Data/Any/Extensions.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 
 ## ALIAS Equality
 
-   Checks if `this` is equal to `that.`
+   Checks if `this` is equal to `that`.
 
    Arguments:
    - that: The object to compare `this` with.

--- a/distribution/lib/Standard/Base/0.1.0/src/Data/Any/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Data/Any/Extensions.enso
@@ -1,6 +1,8 @@
 from Standard.Base import all
 
-## Checks if `this` is equal to `that.`
+## ALIAS Equality
+
+   Checks if `this` is equal to `that.`
 
    Arguments:
    - that: The object to compare `this` with.
@@ -51,7 +53,9 @@ Any.== that = if Meta.is_same_object this that then True else
            Therefore, there are no more cases to handle in this method.
         _ -> False
 
-## Checks if `this` is not equal to `that`.
+## ALIAS Inequality
+
+   Checks if `this` is not equal to `that`.
 
    Arguments:
    - that: The object to compare `this` against.
@@ -72,7 +76,9 @@ Any.== that = if Meta.is_same_object this that then True else
 Any.!= : Any -> Boolean
 Any.!= that = (this == that).not
 
-## Checks if `this` is greater than `that`.
+## ALIAS Greater Than
+
+   Checks if `this` is greater than `that`.
 
    Arguments:
    - that: The value to compare `this` against.
@@ -95,7 +101,9 @@ Any.!= that = (this == that).not
 Any.> : Any -> Boolean
 Any.> that = this.compare_to that == Ordering.Greater
 
-## Checks if `this` is greater than or equal to `that`.
+## ALIAS Greater Than or Equal
+
+   Checks if `this` is greater than or equal to `that`.
 
    Arguments:
    - that: The value to compare `this` against.
@@ -119,7 +127,9 @@ Any.> that = this.compare_to that == Ordering.Greater
 Any.>= : Any -> Boolean
 Any.>= that = (this > that) || (this == that)
 
-## Checks if `this` is less than `that`.
+## ALIAS Less Than
+
+   Checks if `this` is less than `that`.
 
    Arguments:
    - that: The value to compare `this` against.
@@ -142,7 +152,9 @@ Any.>= that = (this > that) || (this == that)
 Any.< : Any -> Boolean
 Any.< that = this.compare_to that == Ordering.Less
 
-## Checks if `this` is less than or equal to `that`.
+## ALIAS Less Than or Equal
+
+   Checks if `this` is less than or equal to `that`.
 
    Arguments:
    - that: The value to compare `this` against.

--- a/distribution/lib/Standard/Base/0.1.0/src/Data/Json.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Data/Json.enso
@@ -231,7 +231,9 @@ type Marshalling_Error
         Missing_Field_Error _ field _ ->
             "Missing field in Json: the field `" + field.to_text "` was missing in the json."
 
-## Generically converts an atom into a JSON object.
+## ALIAS To JSON
+
+   Generically converts an atom into a JSON object.
 
    The input atom is converted into a JSON object, with a `"type"` field set to
    the atom's type name and all other fields serialized with their name as

--- a/distribution/lib/Standard/Base/0.1.0/src/Data/Number/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Data/Number/Extensions.enso
@@ -4,7 +4,9 @@ polyglot java import java.lang.Double
 polyglot java import java.lang.Math
 polyglot java import java.lang.String
 
-## Computes the inverse of the sine function
+## ALIAS Inverse Sine
+
+   Computes the inverse of the sine function
 
    Selects a value in the -pi/2 through pi/2 range.
 
@@ -15,7 +17,9 @@ polyglot java import java.lang.String
 Number.asin : Decimal
 Number.asin = Math.asin this.to_decimal
 
-## Computes the inverse of the cosine function.
+## ALIAS Inverse Cosine
+
+   Computes the inverse of the cosine function.
 
    Selects a value in the -pi/2 through pi/2 range.
 
@@ -26,7 +30,9 @@ Number.asin = Math.asin this.to_decimal
 Number.acos : Decimal
 Number.acos = Math.acos this.to_decimal
 
-## Computes the inverse of the tangent function.
+## ALIAS Inverse Tangent
+
+   Computes the inverse of the tangent function.
 
    Selects a value in the -pi/2 through pi/2 range.
 
@@ -52,7 +58,9 @@ Number.atan = Math.atan this.to_decimal
 Number.atan_2 : Number -> Decimal
 Number.atan_2 y = Math.atan2 this.to_decimal y.to_decimal
 
-## Computes the sine function.
+## ALIAS Sine
+
+   Computes the sine function.
 
    > Example
      Calculate the sine of 2.
@@ -61,7 +69,9 @@ Number.atan_2 y = Math.atan2 this.to_decimal y.to_decimal
 Number.sin : Decimal
 Number.sin = Math.sin this.to_decimal
 
-## Computes the cosine function.
+## ALIAS Cosine
+
+   Computes the cosine function.
 
    > Example
      Calculate the cosine of 2.
@@ -70,7 +80,9 @@ Number.sin = Math.sin this.to_decimal
 Number.cos : Decimal
 Number.cos = Math.cos this.to_decimal
 
-## Computes the tangent function.
+## ALIAS Tangent
+
+   Computes the tangent function.
 
    > Example
      Calculate the tangent of 2.
@@ -106,7 +118,9 @@ Number.cosh = Math.cosh this.to_decimal
 Number.tanh : Decimal
 Number.tanh = Math.tanh this.to_decimal
 
-## Computes the exponential function, raising Euler's number `r` to the power of
+## ALIAS Exponential
+
+   Computes the exponential function, raising Euler's number `r` to the power of
    `this`.
 
    > Example
@@ -116,7 +130,9 @@ Number.tanh = Math.tanh this.to_decimal
 Number.exp : Decimal
 Number.exp = Math.exp this.to_decimal
 
-## Computes the natural logarithm function.
+## ALIAS Natural Logarithm
+
+   Computes the natural logarithm function.
 
    > Example
      Calculate the natural logarithm of 2.
@@ -125,7 +141,9 @@ Number.exp = Math.exp this.to_decimal
 Number.ln : Decimal
 Number.ln = Math.log this.to_decimal
 
-## Computes the square root of `this`.
+## ALIAS Square Root
+
+   Computes the square root of `this`.
 
    > Example
      Calculate the square root of 8.
@@ -134,7 +152,9 @@ Number.ln = Math.log this.to_decimal
 Number.sqrt : Decimal
 Number.sqrt = Math.sqrt this.to_decimal
 
-## Computes the `base`-log of `this`.
+## ALIAS Logarithm
+
+   Computes the `base`-log of `this`.
 
    Arguments:
    - base: The base for the logarithm.
@@ -161,7 +181,9 @@ Number.log base = this.ln / base.ln
 Number.format : Text -> Text
 Number.format fmt = String.format fmt this
 
-## Creates a new right-exclusive range of integers from `this` to `n`.
+## ALIAS Range
+
+   Creates a new right-exclusive range of integers from `this` to `n`.
 
    Arguments:
    - n: The end of the range.
@@ -230,7 +252,9 @@ Number.max that = if this > that then this else that
 Number.to_json : Json.Number
 Number.to_json = Json.Number this
 
-## Parses a textual representation of a decimal into a decimal number, returning
+## ALIAS From Text
+
+   Parses a textual representation of a decimal into a decimal number, returning
    a `Parse_Error` if the text does not represent a valid decimal.
 
    Arguments:

--- a/distribution/lib/Standard/Base/0.1.0/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Data/Text/Extensions.enso
@@ -15,7 +15,9 @@ polyglot java import com.ibm.icu.lang.UCharacter
 polyglot java import com.ibm.icu.text.BreakIterator
 polyglot java import org.enso.base.Text_Utils
 
-## Computes the number of characters in the text.
+## ALIAS Length
+
+   Computes the number of characters in the text.
 
    ! What is a Character?
      A character is defined as an Extended Grapheme Cluster, see Unicode
@@ -67,7 +69,9 @@ Text.each function =
     iterate fst nxt
     Nothing
 
-## Returns a vector containing all characters in the given text.
+## ALIAS Get Characters
+
+   Returns a vector containing all characters in the given text.
 
    ! What is a Character?
      A character is defined as an Extended Grapheme Cluster, see Unicode
@@ -84,7 +88,9 @@ Text.characters =
     this.each bldr.append
     bldr.to_vector
 
-## Takes a separator string and returns a vector resulting from splitting
+## ALIAS Split Text
+
+   Takes a separator string and returns a vector resulting from splitting
    `this` on each occurence of `separator`.
 
    Arguments:
@@ -108,7 +114,9 @@ Text.split (separator = Split_Kind.Whitespace) =
         Text -> Text_Utils.split_by_literal this separator
     Vector.from_array result
 
-## Returns a vector containing all words in the given text.
+## ALIAS Get Words
+
+   Returns a vector containing all words in the given text.
 
    Arguments:
    - keep_whitespace: Whether or not the whitespace around the words should be
@@ -205,7 +213,9 @@ Text.compare_to : Text -> Ordering
 Text.compare_to that = if this == that then Ordering.Equal else
     if Text_Utils.lt this that then Ordering.Less else Ordering.Greater
 
-## Check if `this` is empty.
+## ALIAS Check Emptiness
+
+   Check if `this` is empty.
 
    ! What is Empty?
      Text is considered to be empty when its length is zero.
@@ -217,7 +227,9 @@ Text.compare_to that = if this == that then Ordering.Equal else
 Text.is_empty : Boolean
 Text.is_empty = this == ""
 
-## Check if `this` is not empty.
+## ALIAS Check Non-Emptiness
+
+   Check if `this` is not empty.
 
    ! What is Not Empty?
      Text is considered to be not empty when its length is greater than zero.
@@ -282,7 +294,9 @@ Text.codepoints = Vector.from_array (Text_Utils.get_codepoints this)
 Text.from_codepoints : Vector.Vector Integer -> Text
 Text.from_codepoints codepoints = Text_Utils.from_codepoints codepoints.to_array
 
-## Checks whether `this` starts with `prefix`.
+## ALIAS Check Prefix
+
+   Checks whether `this` starts with `prefix`.
 
    Arguments:
    - prefix: The prefix to see if `this` starts with.
@@ -300,7 +314,9 @@ Text.from_codepoints codepoints = Text_Utils.from_codepoints codepoints.to_array
 Text.starts_with : Text -> Boolean
 Text.starts_with prefix = Text_Utils.starts_with this prefix
 
-## Checks whether `this` ends with `suffix`.
+## ALIAS Check Suffix
+
+   Checks whether `this` ends with `suffix`.
 
    Arguments:
    - suffix: The suffix to see if `this` ends with.
@@ -317,7 +333,9 @@ Text.starts_with prefix = Text_Utils.starts_with this prefix
 Text.ends_with : Text -> Boolean
 Text.ends_with suffix = Text_Utils.ends_with this suffix
 
-## Checks whether `this` contains `sequence` as its substring.
+## ALIAS Contains
+
+   Checks whether `this` contains `sequence` as its substring.
 
    Arguments:
    - sequence: The text to see if it is contained in `this`.
@@ -335,7 +353,9 @@ Text.ends_with suffix = Text_Utils.ends_with this suffix
 Text.contains : Text -> Boolean
 Text.contains sequence = Text_Utils.contains this sequence
 
-## Replaces each occurrences of `old_sequence` within `this` with `new_sequence`.
+## ALIAS Replace Text
+
+   Replaces each occurrences of `old_sequence` within `this` with `new_sequence`.
 
    Arguments:
    - old_sequence: The text to search for in `this`.
@@ -469,7 +489,9 @@ Text.take_last count =
     boundary = iterator.next -count
     if boundary == -1 then this else Text_Utils.drop_first this boundary
 
-## Converts each character in `this` to lower case.
+## ALIAS Lower Case
+
+   Converts each character in `this` to lower case.
 
    Arguments:
    - locale: specifies the locale for charater case mapping. Defaults to the
@@ -496,7 +518,9 @@ Text.to_lower_case : Locale.Locale -> Text
 Text.to_lower_case locale=Locale.default =
     UCharacter.toLowerCase locale.java_locale this
 
-## Converts each character in `this` to upper case.
+## ALIAS Upper Case
+
+   Converts each character in `this` to upper case.
 
    Arguments:
    - locale: specifies the locale for charater case mapping. Defaults to
@@ -510,7 +534,7 @@ Text.to_lower_case locale=Locale.default =
    > Example
      Converting a text to upper case in the default locale:
 
-         "My TeXt!".to_lower_case == "my text!"
+         "My TeXt!".to_upper_case == "MY TEXT!"
 
    > Example
      Converting a text to upper case in a specified locale:

--- a/distribution/lib/Standard/Base/0.1.0/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Data/Text/Extensions.enso
@@ -88,7 +88,7 @@ Text.characters =
     this.each bldr.append
     bldr.to_vector
 
-## ALIAS Split Text
+## ALIAS Split
 
    Takes a separator string and returns a vector resulting from splitting
    `this` on each occurence of `separator`.

--- a/distribution/lib/Standard/Base/0.1.0/src/Data/Time.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Data/Time.enso
@@ -10,7 +10,9 @@ polyglot java import java.time.format.DateTimeFormatter
 polyglot java import java.time.ZonedDateTime
 polyglot java import org.enso.base.Time_Utils
 
-## Obtains the current date-time from the system clock in the system timezone.
+## ALIAS Current Time
+
+   Obtains the current date-time from the system clock in the system timezone.
 
    > Example
      Get the current time
@@ -57,7 +59,9 @@ new year (month = 1) (day = 1) (hour = 0) (minute = 0) (second = 0) (nanosecond 
         Polyglot_Error err -> Error.throw (Time_Error err.getMessage)
         x -> x
 
-## Obtains an instance of `Time` from a text such as
+## ALIAS Time from Text
+
+   Obtains an instance of `Time` from a text such as
    "2007-12-03T10:15:30+01:00 Europe/Paris".
 
    Arguments:
@@ -285,7 +289,9 @@ type Time
     time_of_day : Time_Of_Day
     time_of_day = Time_Of_Day.time_of_day this.internal_zoned_date_time.toLocalTime
 
-    ## Convert this point in time to date, discarding the time of day
+    ## ALIAS Time to Date
+
+       Convert this point in time to date, discarding the time of day
        information.
 
        > Example
@@ -297,7 +303,9 @@ type Time
     date : Date
     date = Date.date this.internal_zoned_date_time.toLocalDate
 
-    ## Convert the time instant to the same instant in the provided time zone.
+    ## ALIAS Change Time Zone
+
+       Convert the time instant to the same instant in the provided time zone.
 
        Arguments:
        - zone: The time-zone to convert the time instant into.

--- a/distribution/lib/Standard/Base/0.1.0/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Data/Time/Date.enso
@@ -21,7 +21,9 @@ polyglot java import org.enso.base.Time_Utils
 now : Date
 now = Date LocalDate.now
 
-## Alias for `now`.
+## ALIAS Current Date
+
+   Obtains the current date from the system clock in the system timezone.
 
    > Example
      Get the current date.
@@ -61,7 +63,9 @@ new year (month = 1) (day = 1) =
         Polyglot_Error err -> Error.throw (Time.Time_Error err.getMessage)
         x -> x
 
-## Converts text containing a date into a Date object.
+## ALIAS Date from Text
+
+   Converts text containing a date into a Date object.
 
    Arguments:
    - text: The text to try and parse as a date.
@@ -180,7 +184,9 @@ type Date
     day : Integer
     day = this . internal_local_date . getDayOfMonth
 
-    ## Combine this date with time of day to create a point in time.
+    ## ALIAS Date to Time
+
+       Combine this date with time of day to create a point in time.
 
        Arguments:
        - time_of_day: The time to combine with the date to create a time.

--- a/distribution/lib/Standard/Base/0.1.0/src/Data/Time/Zone.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Data/Time/Zone.enso
@@ -14,7 +14,9 @@ polyglot java import java.time.ZoneOffset
 system : Zone
 system = Zone ZoneId.systemDefault
 
-## The system's local timezone.
+## ALIAS Current Time Zone
+
+   The system's local timezone.
 
    > Example
      Get the system's local timezone.
@@ -25,7 +27,9 @@ system = Zone ZoneId.systemDefault
 local : Zone
 local = here.system
 
-## The UTC timezone.
+## ALIAS UTC Time Zone
+
+   The UTC timezone.
 
    > Example
      Get the UTC timezone.
@@ -56,7 +60,9 @@ new : Integer -> Integer -> Integer -> Zone
 new (hours = 0) (minutes = 0) (seconds = 0) =
     Zone (ZoneOffset.ofHoursMinutesSeconds hours minutes seconds . normalized)
 
-## This method parses the ID producing a `Zone`.
+## ALIAS Time Zone from Text
+
+   This method parses the ID producing a `Zone`.
 
    Arguments:
    - text: The text representing a zone identifier.

--- a/distribution/lib/Standard/Base/0.1.0/src/Math.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Math.enso
@@ -1,6 +1,8 @@
 from Standard.Base import all
 
-## The mathematical constant pi, equal to the ratio of a circle circumference
+## Alias Pi (Constant)
+
+   The mathematical constant pi, equal to the ratio of a circle circumference
    to its diameter.
 
    > Example
@@ -10,7 +12,9 @@ from Standard.Base import all
 pi : Decimal
 pi = 3.1415926535897932385
 
-## The mathematical constant e, the base of the natural logarithm.
+## ALIAS e (Constant)
+
+   The mathematical constant e, the base of the natural logarithm.
 
    > Example
      Calculating the natural logarithm of 3.
@@ -19,7 +23,9 @@ pi = 3.1415926535897932385
 e : Decimal
 e = 2.718281828459045235360
 
-## Returns the smaller value of `a` and `b`.
+## ALIAS Minimum
+
+   Returns the smaller value of `a` and `b`.
 
    Arguments:
    - a: The first number.
@@ -37,7 +43,9 @@ e = 2.718281828459045235360
 min : Number -> Number -> Number
 min a b = if a <= b then a else b
 
-## Returns the larger value of `a` and `b`.
+## ALIAS Maximum
+
+   Returns the larger value of `a` and `b`.
 
    Arguments:
    - a: The first number.

--- a/distribution/lib/Standard/Base/0.1.0/src/Network/Http.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Network/Http.enso
@@ -68,7 +68,9 @@ new (timeout = 10.seconds) (follow_redirects = True) (proxy = Proxy.System) (ver
 options : (Text | Uri) -> Vector.Vector -> Response ! Request_Error
 options uri (headers = []) = here.new.options uri headers
 
-## Send a Get request.
+## ALIAS GET Request
+
+   Send a Get request.
 
    Arguments:
    - uri: The address to which the request will be sent.
@@ -105,7 +107,9 @@ options uri (headers = []) = here.new.options uri headers
 get : (Text | Uri) -> Vector.Vector -> Response ! Request_Error
 get uri (headers = []) = here.new.get uri headers
 
-## Send the Get request and return the body.
+## ALIAS Fetch Data
+
+   Send the Get request and return the body.
 
    Arguments:
    - uri: The address to which the request will be sent.
@@ -158,7 +162,9 @@ fetch uri (headers = []) =
 head : (Text | Uri) -> Vector.Vector -> Response ! Request_Error
 head uri (headers = []) = here.new.options uri headers
 
-## Send a Post request.
+## ALIAS POST Request
+
+   Send a Post request.
 
    Arguments:
    - uri: The address to which the request will be sent.

--- a/distribution/lib/Standard/Base/0.1.0/src/Network/Http/Header.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Network/Http/Header.enso
@@ -2,7 +2,9 @@ from Standard.Base import all
 
 polyglot java import org.enso.base.Http_Utils
 
-## Create a new Header.
+## ALIAS Build a Header
+
+   Create a new Header.
 
    Arguments:
    - name: The name of the header.
@@ -44,9 +46,9 @@ accept value = Header "Accept" value
 accept_all : Header
 accept_all = here.accept "*/*"
 
-# Authorization
+## ALIAS Build an Auth Header
 
-## Create "Authorization" header.
+   Create an "Authorization" header.
 
    Arguments:
    - value: The value for the authorization header.

--- a/distribution/lib/Standard/Base/0.1.0/src/Network/Uri.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/Network/Uri.enso
@@ -5,7 +5,9 @@ import Standard.Base.Network.Uri.Internal
 polyglot java import java.net.URI as Java_URI
 polyglot java import java.util.Optional
 
-## Parse a Uri from text.
+## ALIAS Get URI
+
+   Parse a Uri from text.
 
    Arguments:
    - text: The text to parse as a URI.

--- a/distribution/lib/Standard/Base/0.1.0/src/System/Environment.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/System/Environment.enso
@@ -2,7 +2,8 @@ from Standard.Base import all
 
 polyglot java import java.lang.System
 
-## UNSTABLE
+## ALIAS Read Environment
+   UNSTABLE
 
    Returns a value of a specified environment variable or Nothing if such
    variable is not defined.

--- a/distribution/lib/Standard/Base/0.1.0/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/System/File.enso
@@ -9,7 +9,9 @@ polyglot java import java.io.IOException
 polyglot java import java.nio.file.AccessDeniedException
 polyglot java import java.nio.file.NoSuchFileException
 
-## Creates a new file object, pointing to the given path.
+## ALIAS New File
+
+   Creates a new file object, pointing to the given path.
 
    Arguments:
    - path: The path to the file that you want to create, or a file itself. The
@@ -27,7 +29,9 @@ new path = case path of
     Text -> File (Prim_Io.get_file path)
     _ -> path
 
-## Open and read the file at the provided `path`.
+## ALIAS Read Text File
+
+   Open and read the file at the provided `path`.
 
    Arguments:
    - path: The path of the file to open and read the contents of. It will
@@ -51,7 +55,9 @@ read path = .read <| case path of
     Text -> (here.new path)
     File _ -> path
 
-## Returns the current working directory (CWD) of the current program.
+## ALIAS Current Directory
+
+   Returns the current working directory (CWD) of the current program.
 
    > Example
      Get the program's current working directory.
@@ -62,7 +68,9 @@ read path = .read <| case path of
 current_directory : File
 current_directory = File (Prim_Io.get_cwd)
 
-## Returns the home directory of the current user.
+## ALIAS Home Directory
+
+   Returns the home directory of the current user.
 
    > Example
      Get the current user's home directory.
@@ -210,7 +218,9 @@ type File
         this.with_output_stream opts (_.write_bytes contents)
         Nothing
 
-    ## Writes a UTF-8 encoded `Text` into this file, replacing any existing
+    ## ALIAS Write Text File
+
+       Writes a UTF-8 encoded `Text` into this file, replacing any existing
        contents.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.1.0/src/System/Process.enso
+++ b/distribution/lib/Standard/Base/0.1.0/src/System/Process.enso
@@ -5,7 +5,8 @@ import Standard.Base.System.Process.Exit_Code
 from Standard.Base.Data.Vector import Vector
 from Standard.Builtins import Array, System, True, False
 
-## UNSTABLE
+## ALIAS Run a Command
+   UNSTABLE
 
    Call a command with a list of arguments.
 

--- a/distribution/lib/Standard/Searcher/package.yaml
+++ b/distribution/lib/Standard/Searcher/package.yaml
@@ -1,0 +1,7 @@
+license: APLv2
+name: Base
+namespace: Standard
+enso-version: default
+version: "0.1.0"
+author: "Enso Team <contact@enso.org>"
+maintainer: "Enso Team <contact@enso.org>"

--- a/distribution/lib/Standard/Searcher/src/Main.enso
+++ b/distribution/lib/Standard/Searcher/src/Main.enso
@@ -1,0 +1,57 @@
+## A library that defines the documentation for the hand-curated searcher
+   categories.
+
+   Note that there is _no functional code_ in these modules, and they should
+   never be imported directly. They are used only to provide a consistent and
+   simple mechanism for placing documentation for these categories within the
+   suggestions database.
+
+from Standard.Base import all
+import Standard.Base.Error.Extensions as Error
+
+## ALIAS Text Input
+
+   Creating text in Enso is as simple as adding a node that contains the text
+   that you would like to create.
+
+   > Example
+     Creating a node containing the text "Hello, Enso!".
+
+         "Hello, Enso!"
+text_input = Error.unimplemented "This function should not be called."
+
+## ALIAS Number Input
+
+   Creating a number in Enso is as simple as adding a node that contains the
+   number that you would like to create.
+
+   Enso supports both integer and decimal literals.
+
+   > Example
+     Creating a node containing the integer 0.
+
+         0
+
+   > Example
+     Creating a node containing the decimal 0.0.
+
+         0.0
+number_input = Error.unimplemented "This function should not be called."
+
+## ALIAS Table Input
+
+   Creating a table in Enso is usually done directly from data. Nevertheless, it
+   can be useful to create tables manually.
+
+   > Example
+     Creating a node containing a table with two columns, one titled "name", and
+     the other titled "stars".
+
+         import Standard.Table
+
+         example_table_input =
+             column_1 = ["name", "Enso"]
+             column_2 = ["stars", 5000]
+             table = Table.new [column_1, column_2]
+table_input = Error.unimplemented "This function should not be called."
+

--- a/distribution/lib/Standard/Table/0.1.0/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.1.0/src/Data/Column.enso
@@ -240,7 +240,9 @@ type Column
     < : Column | Any -> Column
     < other = here.run_vectorized_binary_op this "<" (<) other
 
-    ## Element-wise addition.
+    ## ALIAS Add Columns
+
+       Element-wise addition.
 
        Arguments:
        - other: The value to add to `this`. If `other` is a column, the addition
@@ -266,7 +268,9 @@ type Column
     + : Column | Any -> Column
     + other = here.run_vectorized_binary_op this '+' (+) other
 
-    ## Element-wise subtraction.
+    ## ALIAS Subtract Columns
+
+       Element-wise subtraction.
 
        Arguments:
        - other: The value to subtract from `this`. If `other` is a column, the
@@ -292,7 +296,9 @@ type Column
     - : Column | Any -> Column
     - other = here.run_vectorized_binary_op this '-' (-) other
 
-    ## Element-wise multiplication.
+    ## ALIAS Multiply Columns
+
+       Element-wise multiplication.
 
        Arguments:
        - other: The value to multiply `this` by. If `other` is a column, the
@@ -318,7 +324,9 @@ type Column
     * : Column | Any -> Column
     * other = here.run_vectorized_binary_op this '*' (*) other
 
-    ## Element-wise division.
+    ## ALIAS Divide Columns
+
+       Element-wise division.
 
        Arguments:
        - other: The value to divide `this` by. If `other` is a column, the
@@ -344,7 +352,9 @@ type Column
     / : Column | Any -> Column
     / other = here.run_vectorized_binary_op this '/' (/) other
 
-    ## Element-wise boolean conjunction.
+    ## ALIAS AND Columns
+
+       Element-wise boolean conjunction.
 
        Arguments:
        - other: The value to compute the conjunction of `this` with. If `other`
@@ -372,7 +382,9 @@ type Column
     && other =
         here.run_vectorized_binary_op this "&&" (&&) other
 
-    ## Element-wise boolean disjunction.
+    ## ALIAS OR Columns
+
+       Element-wise boolean disjunction.
 
        Arguments:
        - other: The value to compute the disjunction of `this` with. If `other`
@@ -400,7 +412,9 @@ type Column
     || other =
         here.run_vectorized_binary_op this "||" (||) other
 
-    ## Boolean negation of each element in this column.
+    ## ALIAS NOT Columns
+
+       Boolean negation of each element in this column.
 
        > Example
          Negate the elements of a column.
@@ -435,7 +449,9 @@ type Column
     is_present : Column
     is_present = this.is_missing.not
 
-    ## Returns a new column where missing values have been replaced with the
+    ## ALIAS Fill Missing
+
+       Returns a new column where missing values have been replaced with the
        provided default.
 
        Arguments:
@@ -456,7 +472,9 @@ type Column
         col = Java_Column.new name index new_st
         Column col
 
-    ## Returns a new column without rows that had missing values.
+    ## ALIAS Drop Missing
+
+       Returns a new column without rows that had missing values.
 
        > Example
          Drop missing values from a column.
@@ -546,7 +564,9 @@ type Column
     contains other =
         here.run_vectorized_binary_op this "contains" (a -> b -> a.contains b) other
 
-    ## Applies `function` to each item in this column and returns the column
+    ## ALIAS Transform Column
+
+       Applies `function` to each item in this column and returns the column
        of results.
 
        Arguments:
@@ -566,7 +586,9 @@ type Column
         col = Java_Column.new "Result" index new_st
         Column col
 
-    ## Applies `function` to consecutive pairs of elements of `this` and `that`
+    ## ALIAS Transform Columns
+
+       Applies `function` to consecutive pairs of elements of `this` and `that`
        and returns a column of results.
 
        Arguments:
@@ -589,7 +611,9 @@ type Column
         rs = s1.zip Nothing function s2
         Column (Java_Column.new "Result" ix rs)
 
-    ## Returns a new column, containing the same elements as `this`, but with
+    ## ALIAS Rename Column
+
+       Returns a new column, containing the same elements as `this`, but with
        the given name.
 
        Arguments:
@@ -808,7 +832,9 @@ type Column
         data = ['data', this.to_vector.take_start max_data]
         Json.from_pairs [size, name, data] . to_text
 
-    ## Sums the values in this column.
+    ## ALIAS Sum Columns
+
+       Sums the values in this column.
 
        > Example
          Sum the values in a column.
@@ -819,7 +845,9 @@ type Column
     sum : Any
     sum = this.java_column.aggregate 'sum' (x-> Vector.Vector x . reduce (+)) True
 
-    ## Computes the maximum element of this column.
+    ## ALIAS Max Columns
+
+       Computes the maximum element of this column.
 
        > Example
          Compute the maximum value of a column.
@@ -831,7 +859,9 @@ type Column
     max =
         this.java_column.aggregate 'max' (x-> Vector.Vector x . reduce Math.max) True
 
-    ## Computes the minimum element of this column.
+    ## ALIAS Min Columns
+
+       Computes the minimum element of this column.
 
        > Example
          Compute the minimum value of a column.
@@ -843,7 +873,9 @@ type Column
     min =
         this.java_column.aggregate 'min' (x-> Vector.Vector x . reduce Math.min) True
 
-    ## Computes the mean of non-missing elements of this column.
+    ## ALIAS Mean Columns
+
+       Computes the mean of non-missing elements of this column.
 
        > Example
          Compute the mean value of a column.

--- a/distribution/lib/Standard/Table/0.1.0/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.1.0/src/Data/Table.enso
@@ -296,7 +296,7 @@ type Table
         Nothing -> Error.throw No_Index_Set_Error
         i -> Column.Column i
 
-    ## Alias Select
+    ## Alias Select Columns
 
        Selects a subset of columns from this table by name.
 

--- a/distribution/lib/Standard/Table/0.1.0/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.1.0/src/Data/Table.enso
@@ -56,7 +56,9 @@ from_rows header rows =
     columns = header.map_with_index i-> name-> [name, rows.map (_.at i)]
     here.new columns
 
-## Joins a vector of tables (or columns) into a single table, using each table's
+## ALIAS Join Tables
+
+   Joins a vector of tables (or columns) into a single table, using each table's
    index as the join key.
 
    Arguments:
@@ -196,7 +198,10 @@ type Table
         Nothing -> Error.throw (No_Such_Column_Error name)
         c -> Column.Column c
 
-    ## Selects only the rows of this table that correspond to `True` values in
+    ## ALIAS Filter Rows
+       ALIAS Mask Columns
+
+       Selects only the rows of this table that correspond to `True` values in
        `indexes`.
 
        Arguments:
@@ -219,7 +224,9 @@ type Table
     where indexes =
         Table (this.java_table.mask indexes.java_column)
 
-    ## Sets the column value at the given name.
+    ## ALIAS Add Column
+
+       Sets the column value at the given name.
 
        Arguments:
        - name: The name of the column to set the value of.
@@ -286,7 +293,9 @@ type Table
         Nothing -> Error.throw No_Index_Set_Error
         i -> Column.Column i
 
-    ## Selects a subset of columns from this table by name.
+    ## Alias Select
+
+       Selects a subset of columns from this table by name.
 
        > Example
          Get the item name and price columns from the shop inventory.
@@ -298,7 +307,9 @@ type Table
     select : Vector -> Table
     select columns = Table (this.java_table.selectColumns columns.to_array)
 
-    ## Efficiently joins two tables based on either the index or the specified
+    ## ALIAS Join Table
+
+       Efficiently joins two tables based on either the index or the specified
        key column.
 
        Arguments:
@@ -332,7 +343,9 @@ type Table
             Table t ->
                 Table (this.java_table.join t drop_unmatched on left_suffix right_suffix)
 
-    ## Returns a new Table without rows that contained missing values in any of
+    ## ALIAS Clean Rows
+
+       Returns a new Table without rows that contained missing values in any of
        the columns.
     drop_missing_rows : Table
     drop_missing_rows =
@@ -344,7 +357,9 @@ type Table
                 this.where non_missing_mask
             False -> this
 
-    ## Returns a new Table without columns that contained any missing values.
+    ## ALIAS Clean Columns
+
+       Returns a new Table without columns that contained any missing values.
 
        > Example
          Remove any columns that contain missing values from the table.
@@ -397,7 +412,9 @@ type Table
         cols = this.columns
         here.new [["Column", cols.map .name], ["Items Count", cols.map .count], ["Storage Type", cols.map .storage_type]] . set_index "Column"
 
-    ## Returns an aggregate table resulting from grouping the elements by the
+    ## ALIAS Group a Table
+
+       Returns an aggregate table resulting from grouping the elements by the
        value of the specified column.
 
        Arguments:
@@ -422,7 +439,8 @@ type Table
     group by=Nothing =
         Aggregate_Table (this.java_table.group by)
 
-    ## UNSTABLE
+    ## ALIAS Sort Table
+       UNSTABLE
 
        Sorts the table according to the specified rules.
 
@@ -592,7 +610,8 @@ type Table
     concat other =
         Table (this.java_table.concat other.java_table)
 
-    ## UNSTABLE
+    ## ALIAS First N Rows
+       UNSTABLE
 
        Returns a table containing the first `count` elements in this table.
 
@@ -611,7 +630,8 @@ type Table
     take_start : Integer -> Table
     take_start count = Table (this.java_table.slice 0 count)
 
-    ## UNSTABLE
+    ## ALIAS Last N Rows
+       UNSTABLE
 
        Returns a table containing the last `count` elements in this table.
 
@@ -632,7 +652,8 @@ type Table
         start_point = Math.max (this.row_count - count) 0
         Table (this.java_table.slice start_point count)
 
-    ## UNSTABLE
+    ## ALIAS First Row
+       UNSTABLE
 
        Returns the first row in the table, if it exists.
 
@@ -666,7 +687,8 @@ type Table
     head : Table ! Empty_Error
     head = this.first
 
-    ## UNSTABLE
+    ## ALIAS Last Row
+       UNSTABLE
 
        Returns the last row in the table, if it exists.
 
@@ -723,7 +745,8 @@ type Table
     to_csv include_header=True always_quote=False separator=',' line_ending=Line_Ending_Style.Unix =
         Csv_Writer.writeString this.java_table include_header always_quote line_ending.to_text separator .to_csv_field
 
-    ## UNSTABLE
+    ## ALIAS Write CSV
+       UNSTABLE
 
        Serializes this table into CSV and writes it to the specified file.
 
@@ -817,7 +840,9 @@ type Aggregate_Table
     count : Column
     count = Column.Column this.java_table.count
 
-    ## Returns an aggregate column with the given name, contained in this table.
+    ## ALIAS Get a Column
+       
+       Returns an aggregate column with the given name, contained in this table.
 
        Arguments:
        - name: The name of the aggregate column to get.

--- a/distribution/lib/Standard/Table/0.1.0/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.1.0/src/Data/Table.enso
@@ -841,7 +841,7 @@ type Aggregate_Table
     count = Column.Column this.java_table.count
 
     ## ALIAS Get a Column
-       
+
        Returns an aggregate column with the given name, contained in this table.
 
        Arguments:

--- a/distribution/lib/Standard/Table/0.1.0/src/Io/Csv.enso
+++ b/distribution/lib/Standard/Table/0.1.0/src/Io/Csv.enso
@@ -4,7 +4,9 @@ import Standard.Table
 polyglot java import org.enso.table.format.csv.Parser
 polyglot java import java.io.ByteArrayInputStream
 
-## Reads the contents of `this` and parses them as a CSV dataframe.
+## ALIAS Read CSV
+
+   Reads the contents of `this` and parses them as a CSV dataframe.
 
    Arguments
    - has_header: Specifies whether the first line of the file should be

--- a/distribution/lib/Standard/Table/0.1.0/src/Io/Spreadsheet.enso
+++ b/distribution/lib/Standard/Table/0.1.0/src/Io/Spreadsheet.enso
@@ -5,7 +5,9 @@ import Standard.Base.Data.Time.Date
 
 polyglot java import org.enso.table.format.xlsx.Reader
 
-## Reads the contents of `this` and parses them as an XLSX dataframe.
+## ALIAS Read Excel File
+
+   Reads the contents of `this` and parses them as an XLSX dataframe.
 
    Arguments
    - sheet: specifies which sheet should be read. If left unspecified, reads

--- a/distribution/lib/Standard/Table/0.1.0/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.1.0/src/Main.enso
@@ -15,7 +15,9 @@ export Standard.Table.Data.Column
 from Standard.Table.Data.Table export new, from_rows, join, No_Such_Column_Error, Table
 from Standard.Table.Data.Order_Rule export Order_Rule
 
-## Converts a JSON array into a dataframe, by looking up the requested keys
+## ALIAS To Table
+
+   Converts a JSON array into a dataframe, by looking up the requested keys
    from each item.
 
    Arguments:
@@ -58,7 +60,9 @@ Json.Array.to_table fields = case this of
             [n, rows.map (_.at i)]
         Table.new cols
 
-## Converts a JSON object into a dataframe, by looking up the requested keys
+## ALIAS To Table
+
+   Converts a JSON object into a dataframe, by looking up the requested keys
    from each item.
 
    Arguments:

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -975,8 +975,93 @@ type Ref
 
    If a Number is expected, then the program can provide either a Decimal or
    an Integer in its place.
-@Builtin_Type
 type Number
+
+    ## The root type of the Enso numeric hierarchy.
+
+       If a Number is expected, then the program can provide either a Decimal or
+       an Integer in its place.
+    @Builtin_Type
+    type Number
+
+    ## ALIAS Add
+
+       Adds two arbitrary numbers.
+
+       Arguments:
+       - that: The number to add to this.
+
+       Addition in Enso will undergo automatic conversions such that you need
+       not convert between Integer and Decimal manually.
+
+       > Example
+         Adding 10 and 15.
+
+             10 + 15
+    + : Number -> Number
+    + that = @Builtin_Method "Integer.+"
+
+    ## ALIAS Subtract
+
+       Subtract an arbitrary number from this.
+
+       Arguments:
+       - that: The number to subtract from this.
+
+       > Example
+         Subtract 5 from 2.
+
+             2 - 5
+    - : Number -> Number
+    - that = @Builtin_Method "Integer.-"
+
+    ## ALIAS Multiply
+
+       Multiply two arbitrary numbers.
+
+       Arguments:
+       - that: The number to multiply this by.
+
+       Multiplication in Enso will undergo automatic conversions such that you
+       need not convert between Integer and Decimal manually.
+
+       > Example
+         Multiplying 3 by 5.
+
+             3 * 5
+    * : Number -> Number
+    * that = @Builtin_Method "Integer.*"
+
+    ## ALIAS Divide
+
+       Divides an this by an arbitrary number.
+
+       Arguments:
+       - that: The number to divide this by.
+
+       Division in Enso will undergo automatic conversions such that you need
+       not convert between Integer and Decimal manually.
+
+       > Example
+         Dividing 10 by 4 to get 2.5.
+
+             10 / 4
+    / : Number -> Number
+    / that = @Builtin_Method "Integer./"
+
+    ## ALIAS Power
+
+       Compute the result of raising this to the power that.
+
+       Arguments:
+       - that: The exponent.
+
+       > Example
+         Computing 2 cubed.
+
+             2^3
+    ^ : Number -> Number
+    ^ that = @Builtin_Method "Integer.^"
 
 ## Integral numbers.
 type Integer


### PR DESCRIPTION
### Pull Request Description
In order to be consistent with the (currently hardcoded) categories in the new searcher, this PR adds aliases to the methods named in #1755 as part of the searcher categories.

Closes #1903.

### Important Notes
There are no functional changes as part of this PR.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
