### PR TITLE
Fix a bad heuristic for identifying module docs

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Enso Next
 
+## Compiler/Interpreter
+
+- Fixed a bug with module documentation where it would associate the wrong
+  doc-block with the module
+  ([#1919](https://github.com/enso-org/enso/pull/1919)).
+
 # Enso 0.2.18 (2021-08-02)
 
 ## Libraries

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -442,6 +442,10 @@ interface SuggestionEntryModule {
 
   /** The fully qualified module name re-exporting this module. */
   reexport?: string;
+
+  /** The rendered HTMl of the documentation string. */
+
+  documentationHtml?: string;
 }
 
 interface SuggestionEntryAtom {
@@ -465,6 +469,8 @@ interface SuggestionEntryAtom {
 
   /** The fully qualified module name re-exporting this module. */
   reexport?: string;
+
+  /** The rendered HTMl of the documentation string. */
 
   documentationHtml?: string;
 }
@@ -494,6 +500,8 @@ interface SuggestionEntryMethod {
   /** The fully qualified module name re-exporting this module. */
   reexport?: string;
 
+  /** The rendered HTMl of the documentation string. */
+
   documentationHtml?: string;
 }
 
@@ -515,6 +523,10 @@ interface SuggestionEntryFunction {
 
   /** The scope where the function is defined. */
   scope: SuggestionEntryScope;
+
+  /** The rendered HTMl of the documentation string. */
+
+  documentationHtml?: string;
 }
 
 interface SuggestionEntryLocal {
@@ -532,6 +544,10 @@ interface SuggestionEntryLocal {
 
   /** The scope where the value is defined. */
   scope: SuggestionEntryScope;
+
+  /** The rendered HTMl of the documentation string. */
+
+  documentationHtml?: string;
 }
 ```
 


### PR DESCRIPTION
### Pull Request Description
Does what it says on the tin. We should no longer be glueing non-module docs to modules.

### Important Notes
N/A

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
