### PR TITLE
Increase Binary WebSocket Buffer

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -354,7 +354,11 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
     new BinaryWebSocketServer(
       InboundMessageDecoder,
       BinaryEncoder.empty,
-      new BinaryConnectionControllerFactory(fileManager)
+      new BinaryConnectionControllerFactory(fileManager),
+      BinaryWebSocketServer.Config(
+        outgoingBufferSize = 100,
+        lazyMessageTimeout = 10.seconds
+      )
     )
   log.trace("Created Binary WebSocket Server [{}].", binaryServer)
 


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Changelog:
- feat: increase buffer of the binary WebSocket connection from 10 to 100

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
