### PR TITLE
Fix Artifact Upload Issue on CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -321,7 +321,7 @@ jobs:
       - name: Unpack Artifacts
         shell: bash
         working-directory: repo/built-distribution
-        run: 7z x "*.zip"
+        run: unzip *.zip
       # This jobs can be used to debug errors, it may be removed
       - name: Display Structure of Downloaded Files
         run: ls

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -286,7 +286,7 @@ jobs:
         shell: bash
         working-directory: repo/built-distribution
         run:
-          zip -q -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH
+          7z a -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH
           }}.zip *
       - name: Upload the Built Artifacts
         uses: actions/upload-artifact@v2
@@ -321,7 +321,7 @@ jobs:
       - name: Unpack Artifacts
         shell: bash
         working-directory: repo/built-distribution
-        run: unzip *.zip
+        run: 7z x "*.zip"
       # This jobs can be used to debug errors, it may be removed
       - name: Display Structure of Downloaded Files
         run: ls

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -281,26 +281,16 @@ jobs:
           sbt "enso/verifyGeneratedPackage Database ${{ env.ENGINE_DIST_DIR }}/lib/Standard/Database/0.1.0/THIRD-PARTY"
 
       # Publish
-      - name: Upload the Engine Artifact
+      - name: Compress the built artifacts for upload
+        # The artifacts are compressed before upload to work around an error with long path handling in the upload-artifact action on Windows.
+        shell: bash
+        working-directory: repo/built-distribution
+        run: zip -q -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip *
+      - name: Upload the Built Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.ENGINE_DIST_NAME }}
-          path: repo/${{ env.ENGINE_DIST_ROOT }}
-      - name: Upload the Launcher Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.LAUNCHER_DIST_NAME }}
-          path: repo/${{ env.LAUNCHER_DIST_ROOT }}
-      - name: Upload the Project Manager Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.PROJECTMANAGER_DIST_NAME }}
-          path: repo/${{ env.PROJECTMANAGER_DIST_ROOT }}
-      - name: Upload the GraalVM Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.GRAAL_DIST_NAME }}
-          path: repo/${{ env.GRAAL_DIST_ROOT }}
+          name: built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}
+          path: repo/built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip
       - name: Upload the Manifest Artifact
         uses: actions/upload-artifact@v2
         with:
@@ -325,16 +315,19 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           path: repo/built-distribution
-      - name: Prepare Nodejs
+      - name: Unpack Artifacts
         shell: bash
-        working-directory: repo/tools/ci/nightly
-        run: npm install
-
+        working-directory: repo/built-distribution
+        run: unzip *.zip
       # This jobs can be used to debug errors, it may be removed
       - name: Display Structure of Downloaded Files
         run: ls
         working-directory: repo/built-distribution
 
+      - name: Prepare Nodejs
+        shell: bash
+        working-directory: repo/tools/ci/nightly
+        run: npm install
       - name: Setup GraalVM Environment
         uses: ayltai/setup-graalvm@v1
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -285,12 +285,15 @@ jobs:
         # The artifacts are compressed before upload to work around an error with long path handling in the upload-artifact action on Windows.
         shell: bash
         working-directory: repo/built-distribution
-        run: zip -q -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip *
+        run:
+          zip -q -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH
+          }}.zip *
       - name: Upload the Built Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}
-          path: repo/built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip
+          path:
+            repo/built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip
       - name: Upload the Manifest Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -286,8 +286,8 @@ jobs:
         shell: bash
         working-directory: repo/built-distribution
         run:
-          7z a -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH
-          }}.zip *
+          7z a -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip
+          *
       - name: Upload the Built Artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -318,14 +318,13 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           path: repo/built-distribution
-      - name: Unpack Artifacts
-        shell: bash
-        working-directory: repo/built-distribution
-        run: unzip *.zip
-      # This jobs can be used to debug errors, it may be removed
       - name: Display Structure of Downloaded Files
         run: ls
         working-directory: repo/built-distribution
+      - name: Unpack Artifacts
+        shell: bash
+        working-directory: repo/built-distribution
+        run: for f in built-distribution-*; do unzip -n "$f/$f.zip"; done
 
       - name: Prepare Nodejs
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -293,7 +293,8 @@ jobs:
         with:
           name: built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}
           path:
-            repo/built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip
+            repo/built-distribution/built-distribution-${{ env.DIST_OS }}-${{
+            env.DIST_ARCH }}.zip
       - name: Upload the Manifest Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,8 +244,8 @@ jobs:
         shell: bash
         working-directory: repo/built-distribution
         run:
-          7z a -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH
-          }}.zip *
+          7z a -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip
+          *
       - name: Upload the Built Artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,26 +239,16 @@ jobs:
           sbt "enso/verifyGeneratedPackage Database ${{ env.ENGINE_DIST_DIR }}/lib/Standard/Database/0.1.0/THIRD-PARTY"
 
       # Publish
-      - name: Upload the Engine Artifact
+      - name: Compress the built artifacts for upload
+        # The artifacts are compressed before upload to work around an error with long path handling in the upload-artifact action on Windows.
+        shell: bash
+        working-directory: repo/built-distribution
+        run: zip -q -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip *
+      - name: Upload the Built Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.ENGINE_DIST_NAME }}
-          path: repo/${{ env.ENGINE_DIST_ROOT }}
-      - name: Upload the Launcher Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.LAUNCHER_DIST_NAME }}
-          path: repo/${{ env.LAUNCHER_DIST_ROOT }}
-      - name: Upload the Project Manager Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.PROJECTMANAGER_DIST_NAME }}
-          path: repo/${{ env.PROJECTMANAGER_DIST_ROOT }}
-      - name: Upload the GraalVM Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.GRAAL_DIST_NAME }}
-          path: repo/${{ env.GRAAL_DIST_ROOT }}
+          name: built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}
+          path: repo/built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip
       - name: Upload the Manifest Artifact
         uses: actions/upload-artifact@v2
         with:
@@ -283,6 +273,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           path: repo/built-distribution
+      - name: Unpack Artifacts
+        shell: bash
+        working-directory: repo/built-distribution
+        run: unzip *.zip
 
       - name: Setup GraalVM Environment
         uses: ayltai/setup-graalvm@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,8 +279,7 @@ jobs:
       - name: Unpack Artifacts
         shell: bash
         working-directory: repo/built-distribution
-        run: 7z x "*.zip"
-
+        run: unzip *.zip
       - name: Setup GraalVM Environment
         uses: ayltai/setup-graalvm@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,8 @@ jobs:
       - name: Unpack Artifacts
         shell: bash
         working-directory: repo/built-distribution
-        run: unzip *.zip
+        run: for f in built-distribution-*; do unzip -n "$f/$f.zip"; done
+
       - name: Setup GraalVM Environment
         uses: ayltai/setup-graalvm@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,7 @@ jobs:
         shell: bash
         working-directory: repo/built-distribution
         run:
-          zip -q -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH
+          7z a -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH
           }}.zip *
       - name: Upload the Built Artifacts
         uses: actions/upload-artifact@v2
@@ -279,7 +279,7 @@ jobs:
       - name: Unpack Artifacts
         shell: bash
         working-directory: repo/built-distribution
-        run: unzip *.zip
+        run: 7z x "*.zip"
 
       - name: Setup GraalVM Environment
         uses: ayltai/setup-graalvm@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,12 +243,15 @@ jobs:
         # The artifacts are compressed before upload to work around an error with long path handling in the upload-artifact action on Windows.
         shell: bash
         working-directory: repo/built-distribution
-        run: zip -q -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip *
+        run:
+          zip -q -r built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH
+          }}.zip *
       - name: Upload the Built Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}
-          path: repo/built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip
+          path:
+            repo/built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip
       - name: Upload the Manifest Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,7 +251,8 @@ jobs:
         with:
           name: built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}
           path:
-            repo/built-distribution-${{ env.DIST_OS }}-${{ env.DIST_ARCH }}.zip
+            repo/built-distribution/built-distribution-${{ env.DIST_OS }}-${{
+            env.DIST_ARCH }}.zip
       - name: Upload the Manifest Artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
### Pull Request Description

Fixes an issue where long paths (introduced by having to unpack a polyglot JAR included in the release due to a GraalVM bug) would fail the upload-artifact action on Windows.

This PR works around this limitation by uploading the artifacts as archives instead of loose files, so that the faulty upload-artifact action does not need to see these long paths.


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
