### PR TITLE
Fix visualization interrupts

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,9 +2,8 @@
 
 ## Interpreter/Runtime
 
-- Fixed a bug where visualizations would sometimes randomly fail to compute,
-  due to thread interrupts
-  ([#1939](https://github.com/enso-org/enso/pull/1939)).
+- Fixed a bug where visualizations would sometimes randomly fail to compute, due
+  to thread interrupts ([#1939](https://github.com/enso-org/enso/pull/1939)).
 
 ## Tooling
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Enso Next
 
+## Interpreter/Runtime
+
+- Fixed a bug where visualizations would sometimes randomly fail to compute,
+  due to thread interrupts
+  ([#1939](https://github.com/enso-org/enso/pull/1939)).
+
 ## Tooling
 
 - Implemented a basic library uploader

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ResourceManager.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ResourceManager.java
@@ -233,13 +233,13 @@ public class ResourceManager {
      * @param context current execution context
      */
     public void doFinalize(Context context) {
-      context.getThreadManager().enter();
+      Object p = context.getThreadManager().enter();
       try {
         InteropLibrary.getUncached(finalizer).execute(finalizer, underlying);
       } catch (Exception e) {
         context.getErr().println("Exception in finalizer: " + e.getMessage());
       } finally {
-        context.getThreadManager().leave();
+        context.getThreadManager().leave(p);
       }
     }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -151,9 +151,11 @@ public class ExecutionService {
             onComputedCallback,
             onCachedCallback,
             onExceptionalCallback);
+    Object p = context.getThreadManager().enter();
     try {
       interopLibrary.execute(call);
     } finally {
+      context.getThreadManager().leave(p);
       listener.dispose();
     }
   }
@@ -215,7 +217,12 @@ public class ExecutionService {
   public Object evaluateExpression(Module module, String expression)
       throws UnsupportedMessageException, ArityException, UnknownIdentifierException,
           UnsupportedTypeException {
-    return interopLibrary.invokeMember(module, MethodNames.Module.EVAL_EXPRESSION, expression);
+    Object p = context.getThreadManager().enter();
+    try {
+      return interopLibrary.invokeMember(module, MethodNames.Module.EVAL_EXPRESSION, expression);
+    } finally {
+      context.getThreadManager().leave(p);
+    }
   }
 
   /**
@@ -227,7 +234,12 @@ public class ExecutionService {
    */
   public Object callFunction(Object fn, Object argument)
       throws UnsupportedTypeException, ArityException, UnsupportedMessageException {
-    return interopLibrary.execute(fn, argument);
+    Object p = context.getThreadManager().enter();
+    try {
+      return interopLibrary.execute(fn, argument);
+    } finally {
+      context.getThreadManager().leave(p);
+    }
   }
 
   /**
@@ -341,6 +353,7 @@ public class ExecutionService {
    * @return a human-readable version of its contents.
    */
   public String getExceptionMessage(PanicException panic) {
+    Object p = context.getThreadManager().enter();
     try {
       return interopLibrary.asString(
           interopLibrary.invokeMember(panic.getPayload(), "to_display_text"));
@@ -355,6 +368,8 @@ public class ExecutionService {
       } else {
         throw e;
       }
+    } finally {
+      context.getThreadManager().leave(p);
     }
   }
 }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
@@ -29,7 +29,6 @@ class ExecuteJob(
   override def run(implicit ctx: RuntimeContext): Unit = {
     ctx.locking.acquireContextLock(contextId)
     ctx.locking.acquireReadCompilationLock()
-    ctx.executionService.getContext.getThreadManager.enter()
     try {
       val outcome = ProgramExecutionSupport.runProgram(contextId, stack)
       outcome.foreach {
@@ -46,7 +45,6 @@ class ExecuteJob(
         Api.Response(Api.ExecutionComplete(contextId))
       )
     } finally {
-      ctx.executionService.getContext.getThreadManager.leave()
       ctx.locking.releaseReadCompilationLock()
       ctx.locking.releaseContextLock(contextId)
     }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualisationJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualisationJob.scala
@@ -58,6 +58,7 @@ class UpsertVisualisationJob(
           val stack = ctx.contextManager.getStack(config.executionContextId)
           val cachedValue = stack.headOption
             .flatMap(frame => Option(frame.cache.get(expressionId)))
+          requireVisualisationSynchronization(stack, expressionId)
           cachedValue match {
             case Some(value) =>
               ProgramExecutionSupport.sendVisualisationUpdate(
@@ -69,8 +70,6 @@ class UpsertVisualisationJob(
               )
               None
             case None =>
-              val stack = ctx.contextManager.getStack(config.executionContextId)
-              requireVisualisationSynchronization(stack, expressionId)
               Some(Executable(config.executionContextId, stack))
           }
       }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
@@ -34,11 +34,11 @@ class RuntimeManagementTest extends InterpreterTest {
       val main = getMain(code)
 
       val runnable: Runnable = { () =>
-        langCtx.getThreadManager.enter()
+        val p = langCtx.getThreadManager.enter()
         try {
           Try(main.execute())
         } finally {
-          langCtx.getThreadManager.leave()
+          langCtx.getThreadManager.leave(p)
         }
       }
 


### PR DESCRIPTION
### Pull Request Description
1. Fixes the way visualizations are called, making sure they are always registered with the thread manager.
2. Fixes an issue where an interrupted visualization would not recompute later.

Fixes #1895 

### Important Notes


### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
