### PR TITLE
Fix Nightly Builds on Windows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,13 +121,6 @@ jobs:
           graalvm-version: ${{ env.graalVersion }}
           java-version: ${{ env.javaVersion }}
           native-image: true
-      - name: Install Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ env.nodeVersion }}
-      # This is needed because npx is not available on Windows by default.
-      - name: Install npx
-        run: npm install -g npx
       - name: Download Project Template Files
         working-directory: repo
         shell: bash
@@ -182,7 +175,7 @@ jobs:
         shell: bash
         run: |
           sleep 1
-          sbt --no-colors "stdlib-version-updater/run update"
+          sbt --no-colors "stdlib-version-updater/run update --no-format"
 
       # Verify Legal Review
       - name: Verify Packages

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,8 @@ env:
   sbtVersion: 1.5.2
   # Please ensure that this is in sync with rustVersion in build.sbt
   rustToolchain: nightly-2021-05-12
+  # Please ensure that this is in sync with nodeVersion in scala.yml
+  nodeVersion: 14.17.2
   # Specifies how many nightly releases should be kept. Any older releases are removed.
   NIGHTLIES_TO_KEEP: 20
 
@@ -119,6 +121,13 @@ jobs:
           graalvm-version: ${{ env.graalVersion }}
           java-version: ${{ env.javaVersion }}
           native-image: true
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.nodeVersion }}
+      # This is needed because npx is not available on Windows by default.
+      - name: Install npx
+        run: npm install -g npx
       - name: Download Project Template Files
         working-directory: repo
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ env:
   sbtVersion: 1.5.2
   # Please ensure that this is in sync with rustVersion in build.sbt
   rustToolchain: nightly-2021-05-12
+  # Please ensure that this is in sync with nodeVersion in scala.yml
+  nodeVersion: 14.17.2
 
 concurrency: "releases"
 
@@ -83,6 +85,13 @@ jobs:
           graalvm-version: ${{ env.graalVersion }}
           java-version: ${{ env.javaVersion }}
           native-image: true
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.nodeVersion }}
+      # This is needed because npx is not available on Windows by default.
+      - name: Install npx
+        run: npm install -g npx
       - name: Download Project Template Files
         working-directory: repo
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,13 +85,6 @@ jobs:
           graalvm-version: ${{ env.graalVersion }}
           java-version: ${{ env.javaVersion }}
           native-image: true
-      - name: Install Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ env.nodeVersion }}
-      # This is needed because npx is not available on Windows by default.
-      - name: Install npx
-        run: npm install -g npx
       - name: Download Project Template Files
         working-directory: repo
         shell: bash

--- a/lib/scala/stdlib-version-updater/src/main/scala/org/enso/build/stdlibupdater/Main.scala
+++ b/lib/scala/stdlib-version-updater/src/main/scala/org/enso/build/stdlibupdater/Main.scala
@@ -5,6 +5,8 @@ import org.enso.cli.arguments.{Application, Command, Opts}
 
 import java.nio.file.Path
 import scala.util.control.NonFatal
+import cats.implicits._
+import org.enso.cli.arguments.Opts.implicits._
 
 object Main {
   private val commands: NonEmptyList[Command[Unit => Int]] = NonEmptyList.of(
@@ -18,8 +20,15 @@ object Main {
       }
     },
     Command[Unit => Int]("update", "Updates Standard Library versions.") {
-      Opts.pure { _ =>
-        run(UpdatingVisitor)
+      val noFormat = Opts.flag(
+        "no-format",
+        "If set, does not run prettier after updating the packages.",
+        showInUsage = true
+      )
+
+      noFormat map { disableFormatting => _ =>
+        val shouldFormat = !disableFormatting
+        run(new UpdatingVisitor(shouldFormat))
         0
       }
     }

--- a/lib/scala/stdlib-version-updater/src/main/scala/org/enso/build/stdlibupdater/Prettier.scala
+++ b/lib/scala/stdlib-version-updater/src/main/scala/org/enso/build/stdlibupdater/Prettier.scala
@@ -1,5 +1,7 @@
 package org.enso.build.stdlibupdater
 
+import org.enso.cli.OS
+
 import java.nio.file.Path
 import scala.sys.process._
 
@@ -9,10 +11,18 @@ object Prettier {
   /** Formats a specific file or directory. */
   def format(path: Path): Unit = {
     val command =
-      Seq("npx", "prettier", "--write", path.toAbsolutePath.normalize.toString)
+      Seq(
+        npxCommand,
+        "prettier",
+        "--write",
+        path.toAbsolutePath.normalize.toString
+      )
     val exitCode = command.!
     if (exitCode != 0) {
       throw new RuntimeException(s"$command failed with $exitCode exit code.")
     }
   }
+
+  /** The platform-specific command that is used to run the `npx` tool. */
+  def npxCommand: String = if (OS.isWindows) "npx.cmd" else "npx"
 }

--- a/lib/scala/stdlib-version-updater/src/main/scala/org/enso/build/stdlibupdater/StdlibVisitor.scala
+++ b/lib/scala/stdlib-version-updater/src/main/scala/org/enso/build/stdlibupdater/StdlibVisitor.scala
@@ -29,7 +29,7 @@ trait StdlibVisitor {
 /** A [[StdlibVisitor]] that updates the directories and configs to make sure
   * that the versions are correct.
   */
-object UpdatingVisitor extends StdlibVisitor {
+class UpdatingVisitor(shouldFormat: Boolean) extends StdlibVisitor {
 
   /** @inheritdoc */
   override def directoryMismatch(
@@ -52,7 +52,7 @@ object UpdatingVisitor extends StdlibVisitor {
     pkg: Package[File]
   ): Unit = {
     pkg.updateConfig(config => config.copy(version = targetVersion))
-    Prettier.format(pkg.configFile.toPath)
+    if (shouldFormat) { Prettier.format(pkg.configFile.toPath) }
     println(
       s"Updated config of [$libraryName] from [$currentVersion] to " +
       s"[$targetVersion]."


### PR DESCRIPTION
### Pull Request Description

The PR #1947 accidentally broke nightly builds on Windows due to an oversight that the correct `npx` command on Windows is actually `npx.cmd` and just using `npx` when starting a process leads to the command failing. ~~This fixes that issue.~~ Still there are some problems with starting `npx` on Windows, so this PR for now disables it in the nightly builds, as the only affected thing is the formatting of standard library's `package.yaml` files. So for now to fix nightlies, the formatting is disabled.

### Important Notes

- [x] A [nightly workflow is running](https://github.com/enso-org/enso-staging/runs/3339503585?check_suite_focus=true) on enso-staging to verify that the fix is enough.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
