### PR TITLE
Getting and Setting Library Metadata

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Enso Next
 
+## Tooling
+
+- Implement Language Server endpoints for getting and setting library metadata
+  ([#1967](https://github.com/enso-org/enso/pull/1967)).
+
 # Enso 0.2.26 (2021-08-19)
 
 ## Libraries

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -60,6 +60,7 @@ transport formats, please look [here](./protocol-architecture).
   - [`ContentRoot`](#contentroot)
   - [`LibraryEntry`](#libraryentry)
   - [`LibraryVersion`](#libraryversion)
+  - [`Contact`](#contact)
   - [`EditionReference`](#editionreference)
 - [Connection Management](#connection-management)
   - [`session/initProtocolConnection`](#sessioninitprotocolconnection)
@@ -1355,6 +1356,20 @@ interface PublishedLibraryVersion {
 
 // A library version that references a locally editable version of the library.
 interface LocalLibraryVersion {}
+```
+
+### `Contact`
+
+Represents contact information of authors or maintainers.
+
+Both fields are optional, but for the contact to be valid, at least one of them
+must be defined.
+
+```typescript
+interface Contact {
+  name?: String;
+  email?: String;
+}
 ```
 
 ### `EditionReference`
@@ -4354,8 +4369,8 @@ added, the library will be loaded and its content root will be sent in a
 {
   namespace: String;
   name: String;
-  authors: [String];
-  maintainers: [String];
+  authors: [Contact];
+  maintainers: [Contact];
   license: String;
 }
 ```

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -59,6 +59,7 @@ transport formats, please look [here](./protocol-architecture).
   - [`FileSegment`](#filesegment)
   - [`ContentRoot`](#contentroot)
   - [`LibraryEntry`](#libraryentry)
+  - [`LibraryVersion`](#libraryversion)
   - [`EditionReference`](#editionreference)
 - [Connection Management](#connection-management)
   - [`session/initProtocolConnection`](#sessioninitprotocolconnection)
@@ -161,7 +162,7 @@ transport formats, please look [here](./protocol-architecture).
   - [`library/setMetadata`](#librarysetmetadata)
   - [`library/publish`](#librarypublish)
   - [`library/preinstall`](#librarypreinstall)
-- [Errors](#errors-74)
+- [Errors](#errors-75)
   - [`Error`](#error)
   - [`AccessDeniedError`](#accessdeniederror)
   - [`FileSystemError`](#filesystemerror)
@@ -1334,6 +1335,10 @@ interface LibraryEntry {
 }
 ```
 
+### `LibraryVersion`
+
+Represents a library version, as returned in `LibraryEntry`.
+
 ```typescript
 type LibraryVersion = LocalLibraryVersion | PublishedLibraryVersion;
 
@@ -1351,13 +1356,6 @@ interface PublishedLibraryVersion {
 // A library version that references a locally editable version of the library.
 interface LocalLibraryVersion {}
 ```
-
-The local libraries do not have metadata associated with them by default, as for
-the published libraries, the canonical way to access the metadata is to download
-the manifest, as described in the
-[library repository structure](../libraries/repositories.md#libraries-repository).
-So the manifest URL can be found by combining the repository URL and library
-name and version: `<repositoryUrl>/<namespace>/<name>/<version>/manifest.yaml`.
 
 ### `EditionReference`
 
@@ -4379,7 +4377,13 @@ null;
 
 ### `library/getMetadata`
 
-Gets metadata associated with a local library that will be used for publishing.
+Gets metadata associated with a specific library version.
+
+If the version is `LocalLibraryVersion`, it will try to read the manifest file
+of the local library and return an empty result if the manifest does not exist.
+
+If the version is `PublishedLibraryVersion`, it will fetch the manifest from the
+library repository. A cached manifest may also be used, if it is available.
 
 All returned fields are optional, as they may be missing.
 
@@ -4389,6 +4393,7 @@ All returned fields are optional, as they may be missing.
 {
   namespace: String;
   name: String;
+  version: LibraryVersion;
 }
 ```
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LibraryApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LibraryApi.scala
@@ -4,6 +4,7 @@ import io.circe.Json
 import io.circe.literal.JsonStringContext
 import org.enso.editions.{LibraryName, LibraryVersion}
 import org.enso.jsonrpc.{Error, HasParams, HasResult, Method, Unused}
+import org.enso.pkg.Contact
 
 object LibraryApi {
   case object EditionsListAvailable extends Method("editions/listAvailable") {
@@ -114,8 +115,8 @@ object LibraryApi {
     case class Params(
       namespace: String,
       name: String,
-      authors: Seq[String],
-      maintainers: Seq[String],
+      authors: Seq[Contact],
+      maintainers: Seq[Contact],
       license: String
     )
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LibraryApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LibraryApi.scala
@@ -129,7 +129,11 @@ object LibraryApi {
 
   case object LibraryGetMetadata extends Method("library/getMetadata") { self =>
 
-    case class Params(namespace: String, name: String)
+    case class Params(
+      namespace: String,
+      name: String,
+      version: LibraryEntry.LibraryVersion
+    )
 
     case class Result(description: Option[String], tagLine: Option[String])
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LibraryEntry.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LibraryEntry.scala
@@ -10,8 +10,8 @@ import org.enso.editions
   * @param namespace namespace of the library
   * @param name name of the library
   * @param version version of the library
-  * @param isCached indicates whether the library is available in one of local
-  *                 caches
+  * @param isCached indicates whether the library is available in one of the
+  *                 local caches
   */
 case class LibraryEntry(
   namespace: String,

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LocalLibraryManager.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LocalLibraryManager.scala
@@ -11,7 +11,7 @@ import org.enso.librarymanager.local.{
   LocalLibraryProvider
 }
 import org.enso.librarymanager.published.repository.LibraryManifest
-import org.enso.pkg.PackageManager
+import org.enso.pkg.{Contact, PackageManager}
 import org.enso.pkg.validation.NameValidation
 import org.enso.yaml.YamlHelper
 
@@ -65,13 +65,10 @@ class LocalLibraryManager(
     */
   private def createLibrary(
     libraryName: LibraryName,
-    authors: Seq[String],
-    maintainers: Seq[String],
+    authors: Seq[Contact],
+    maintainers: Seq[Contact],
     license: String
   ): Try[Unit] = Try {
-    // TODO [RW] modify protocol to be able to create Contact instances
-    val _ = (authors, maintainers)
-
     validateLibraryName(libraryName)
 
     // TODO [RW] make the exceptions more relevant
@@ -95,10 +92,12 @@ class LocalLibraryManager(
 
     PackageManager.Default.create(
       libraryPath.toFile,
-      name      = libraryName.name,
-      namespace = libraryName.namespace,
-      edition   = findCurrentProjectEdition(),
-      license   = license
+      name        = libraryName.name,
+      namespace   = libraryName.namespace,
+      edition     = findCurrentProjectEdition(),
+      authors     = authors.toList,
+      maintainers = maintainers.toList,
+      license     = license
     )
   }
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LocalLibraryManagerProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LocalLibraryManagerProtocol.scala
@@ -44,4 +44,9 @@ object LocalLibraryManagerProtocol {
 
   /** A response to [[FindLibrary]]. */
   case class FindLibraryResponse(libraryRoot: Option[Path])
+
+  case class LocalLibraryNotFoundError(libraryName: LibraryName)
+      extends RuntimeException(
+        s"Local library [$libraryName] has not been found."
+      )
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LocalLibraryManagerProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LocalLibraryManagerProtocol.scala
@@ -45,6 +45,9 @@ object LocalLibraryManagerProtocol {
   /** A response to [[FindLibrary]]. */
   case class FindLibraryResponse(libraryRoot: Option[Path])
 
+  /** Indicates that a library with the given name was not found among local
+    * libraries.
+    */
   case class LocalLibraryNotFoundError(libraryName: LibraryName)
       extends RuntimeException(
         s"Local library [$libraryName] has not been found."

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LocalLibraryManagerProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/LocalLibraryManagerProtocol.scala
@@ -1,6 +1,7 @@
 package org.enso.languageserver.libraries
 
 import org.enso.editions.LibraryName
+import org.enso.pkg.Contact
 
 import java.nio.file.Path
 
@@ -34,8 +35,8 @@ object LocalLibraryManagerProtocol {
   /** A request to create a new library project. */
   case class Create(
     libraryName: LibraryName,
-    authors: Seq[String],
-    maintainers: Seq[String],
+    authors: Seq[Contact],
+    maintainers: Seq[Contact],
     license: String
   ) extends Request
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/EditionsGetProjectSettingsHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/EditionsGetProjectSettingsHandler.scala
@@ -2,7 +2,7 @@ package org.enso.languageserver.libraries.handler
 
 import akka.actor.{Actor, ActorRef, Cancellable, Props}
 import com.typesafe.scalalogging.LazyLogging
-import org.enso.jsonrpc.{Id, Request, ResponseError, ResponseResult}
+import org.enso.jsonrpc.{Errors, Id, Request, ResponseError, ResponseResult}
 import org.enso.languageserver.filemanager.FileManagerApi.FileSystemError
 import org.enso.languageserver.libraries.LibraryApi._
 import org.enso.languageserver.libraries.ProjectSettingsManager
@@ -42,7 +42,8 @@ class EditionsGetProjectSettingsHandler(
     cancellable: Cancellable
   ): Receive = {
     case RequestTimeout =>
-      replyTo ! RequestTimeout
+      logger.error("Request [{}] timed out.", id)
+      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
       context.stop(self)
 
     case Success(settings: ProjectSettingsManager.SettingsResponse) =>

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/EditionsSetParentEditionHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/EditionsSetParentEditionHandler.scala
@@ -2,7 +2,7 @@ package org.enso.languageserver.libraries.handler
 
 import akka.actor.{Actor, ActorRef, Cancellable, Props}
 import com.typesafe.scalalogging.LazyLogging
-import org.enso.jsonrpc.{Id, Request, ResponseError, ResponseResult}
+import org.enso.jsonrpc.{Errors, Id, Request, ResponseError, ResponseResult}
 import org.enso.languageserver.filemanager.FileManagerApi.FileSystemError
 import org.enso.languageserver.libraries.LibraryApi._
 import org.enso.languageserver.libraries.ProjectSettingsManager
@@ -48,7 +48,8 @@ class EditionsSetParentEditionHandler(
     cancellable: Cancellable
   ): Receive = {
     case RequestTimeout =>
-      replyTo ! RequestTimeout
+      logger.error("Request [{}] timed out.", id)
+      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
       context.stop(self)
 
     case Success(_) =>

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/EditionsSetProjectLocalLibrariesPreferenceHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/EditionsSetProjectLocalLibrariesPreferenceHandler.scala
@@ -2,7 +2,7 @@ package org.enso.languageserver.libraries.handler
 
 import akka.actor.{Actor, ActorRef, Cancellable, Props}
 import com.typesafe.scalalogging.LazyLogging
-import org.enso.jsonrpc.{Id, Request, ResponseError, ResponseResult}
+import org.enso.jsonrpc.{Errors, Id, Request, ResponseError, ResponseResult}
 import org.enso.languageserver.filemanager.FileManagerApi.FileSystemError
 import org.enso.languageserver.libraries.LibraryApi._
 import org.enso.languageserver.libraries.ProjectSettingsManager
@@ -49,7 +49,8 @@ class EditionsSetProjectLocalLibrariesPreferenceHandler(
     cancellable: Cancellable
   ): Receive = {
     case RequestTimeout =>
-      replyTo ! RequestTimeout
+      logger.error("Request [{}] timed out.", id)
+      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
       context.stop(self)
 
     case Success(_) =>

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryCreateHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryCreateHandler.scala
@@ -51,7 +51,8 @@ class LibraryCreateHandler(
     cancellable: Cancellable
   ): Receive = {
     case RequestTimeout =>
-      replyTo ! RequestTimeout
+      logger.error("Request [{}] timed out.", id)
+      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
       context.stop(self)
 
     case Success(_) =>

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryGetMetadataHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryGetMetadataHandler.scala
@@ -1,32 +1,126 @@
 package org.enso.languageserver.libraries.handler
 
-import akka.actor.{Actor, Props}
+import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.pattern.pipe
 import com.typesafe.scalalogging.LazyLogging
-import org.enso.jsonrpc.{Request, ResponseResult}
+import nl.gn0s1s.bump.SemVer
+import org.enso.editions.Editions.Repository
+import org.enso.editions.LibraryName
+import org.enso.jsonrpc.{Id, Request, ResponseError, ResponseResult}
+import org.enso.languageserver.filemanager.FileManagerApi.FileSystemError
 import org.enso.languageserver.libraries.LibraryApi._
+import org.enso.languageserver.libraries.{
+  LibraryEntry,
+  LocalLibraryManagerProtocol
+}
+import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.util.UnhandledLogging
+import org.enso.librarymanager.published.repository.RepositoryHelper.RepositoryMethods
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{Failure, Success}
 
 /** A request handler for the `library/create` endpoint.
   *
-  * It is currently a stub implementation which will be refined later on.
+  * @param timeout request timeout
+  * @param localLibraryManager reference to the local library manager actor
   */
-class LibraryGetMetadataHandler
-    extends Actor
+class LibraryGetMetadataHandler(
+  timeout: FiniteDuration,
+  localLibraryManager: ActorRef
+) extends Actor
     with LazyLogging
     with UnhandledLogging {
-  override def receive: Receive = {
-    case Request(LibraryGetMetadata, id, _: LibraryGetMetadata.Params) =>
-      // TODO [RW] actual implementation
-      sender() ! ResponseResult(
+  import context.dispatcher
+
+  override def receive: Receive = requestStage
+
+  private def requestStage: Receive = {
+    case Request(
+          LibraryGetMetadata,
+          id,
+          LibraryGetMetadata.Params(namespace, name, version)
+        ) =>
+      val libraryName = LibraryName(namespace, name)
+      version match {
+        case LibraryEntry.LocalLibraryVersion =>
+          localLibraryManager ! LocalLibraryManagerProtocol.GetMetadata(
+            libraryName
+          )
+        case LibraryEntry.PublishedLibraryVersion(version, repositoryUrl) =>
+          fetchPublishedMetadata(
+            libraryName,
+            version,
+            repositoryUrl
+          ) pipeTo self
+      }
+
+      val cancellable =
+        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+      context.become(responseStage(id, sender(), cancellable))
+  }
+
+  private def responseStage(
+    id: Id,
+    replyTo: ActorRef,
+    cancellable: Cancellable
+  ): Receive = {
+    case RequestTimeout =>
+      replyTo ! RequestTimeout
+      context.stop(self)
+
+    case Success(
+          LocalLibraryManagerProtocol.GetMetadataResponse(description, tagLine)
+        ) =>
+      replyTo ! ResponseResult(
         LibraryGetMetadata,
         id,
-        LibraryGetMetadata.Result(None, None)
+        LibraryGetMetadata.Result(description, tagLine)
       )
+      cancellable.cancel()
+      context.stop(self)
+
+    case Failure(exception) =>
+      replyTo ! ResponseError(Some(id), FileSystemError(exception.getMessage))
+      cancellable.cancel()
+      context.stop(self)
   }
+
+  // TODO [RW] Once the manifests of downloaded libraries are being cached,
+  //  it may be worth to try resolving the local cache first to avoid
+  //  downloading the manifest again.
+  private def fetchPublishedMetadata(
+    libraryName: LibraryName,
+    version: String,
+    repositoryUrl: String
+  ): Future[LocalLibraryManagerProtocol.GetMetadataResponse] = for {
+    semver <- Future.fromTry(
+      SemVer(version)
+        .toRight(
+          new IllegalStateException(
+            s"Library version [$version] is not a valid semver string."
+          )
+        )
+        .toTry
+    )
+    manifest <- Repository(repositoryUrl)
+      .accessLibrary(libraryName, semver)
+      .downloadManifest()
+      .toFuture
+  } yield LocalLibraryManagerProtocol.GetMetadataResponse(
+    description = manifest.description,
+    tagLine     = manifest.tagLine
+  )
 }
 
 object LibraryGetMetadataHandler {
 
-  /** Creates a configuration object to create [[LibraryGetMetadataHandler]]. */
-  def props(): Props = Props(new LibraryGetMetadataHandler)
+  /** Creates a configuration object to create [[LibraryGetMetadataHandler]].
+    *
+    * @param timeout request timeout
+    * @param localLibraryManager reference to the local library manager actor
+    */
+  def props(timeout: FiniteDuration, localLibraryManager: ActorRef): Props =
+    Props(new LibraryGetMetadataHandler(timeout, localLibraryManager))
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryGetMetadataHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryGetMetadataHandler.scala
@@ -89,7 +89,8 @@ class LibraryGetMetadataHandler(
 
   // TODO [RW] Once the manifests of downloaded libraries are being cached,
   //  it may be worth to try resolving the local cache first to avoid
-  //  downloading the manifest again.
+  //  downloading the manifest again. This should be done before the issues
+  //  #1772 or #1775 are completed.
   private def fetchPublishedMetadata(
     libraryName: LibraryName,
     version: String,

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryListLocalHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryListLocalHandler.scala
@@ -40,7 +40,8 @@ class LibraryListLocalHandler(
     cancellable: Cancellable
   ): Receive = {
     case RequestTimeout =>
-      replyTo ! RequestTimeout
+      logger.error("Request [{}] timed out.", id)
+      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
       context.stop(self)
 
     case Success(

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryPublishHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryPublishHandler.scala
@@ -4,7 +4,14 @@ import akka.actor.{Actor, ActorRef, Cancellable, Props}
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.cli.task.notifications.ActorProgressNotificationForwarder
 import org.enso.editions.LibraryName
-import org.enso.jsonrpc.{Id, Request, ResponseError, ResponseResult, Unused}
+import org.enso.jsonrpc.{
+  Errors,
+  Id,
+  Request,
+  ResponseError,
+  ResponseResult,
+  Unused
+}
 import org.enso.languageserver.filemanager.FileManagerApi.FileSystemError
 import org.enso.languageserver.libraries.LibraryApi._
 import org.enso.languageserver.libraries.LocalLibraryManagerProtocol.{
@@ -84,7 +91,8 @@ class LibraryPublishHandler(
     shouldBumpAfterPublishing: Boolean
   ): Receive = {
     case RequestTimeout =>
-      replyTo ! RequestTimeout
+      logger.error("Request [{}] timed out.", id)
+      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
       context.stop(self)
 
     case Success(FindLibraryResponse(Some(libraryRoot))) =>

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibrarySetMetadataHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibrarySetMetadataHandler.scala
@@ -1,32 +1,83 @@
 package org.enso.languageserver.libraries.handler
 
-import akka.actor.{Actor, Props}
+import akka.actor.{Actor, ActorRef, Cancellable, Props}
 import com.typesafe.scalalogging.LazyLogging
-import org.enso.jsonrpc.{Request, ResponseError}
+import org.enso.editions.LibraryName
+import org.enso.jsonrpc.{Id, Request, ResponseError, ResponseResult, Unused}
 import org.enso.languageserver.filemanager.FileManagerApi.FileSystemError
 import org.enso.languageserver.libraries.LibraryApi._
+import org.enso.languageserver.libraries.LocalLibraryManagerProtocol
+import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.util.UnhandledLogging
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{Failure, Success}
 
 /** A request handler for the `library/setMetadata` endpoint.
   *
-  * It is currently a stub implementation which will be refined later on.
+  * @param timeout request timeout
+  * @param localLibraryManager a reference to the LocalLibraryManager
   */
-class LibrarySetMetadataHandler
-    extends Actor
+class LibrarySetMetadataHandler(
+  timeout: FiniteDuration,
+  localLibraryManager: ActorRef
+) extends Actor
     with LazyLogging
     with UnhandledLogging {
-  override def receive: Receive = {
-    case Request(LibrarySetMetadata, id, _: LibrarySetMetadata.Params) =>
-      // TODO [RW] actual implementation
-      sender() ! ResponseError(
-        Some(id),
-        FileSystemError("Feature not implemented")
+  import context.dispatcher
+
+  override def receive: Receive = requestStage
+
+  private def requestStage: Receive = {
+    case Request(
+          LibrarySetMetadata,
+          id,
+          LibrarySetMetadata.Params(namespace, name, description, tagLine)
+        ) =>
+      val libraryName = LibraryName(namespace, name)
+      localLibraryManager ! LocalLibraryManagerProtocol.SetMetadata(
+        libraryName,
+        description = description,
+        tagLine     = tagLine
       )
+
+      val cancellable =
+        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+      context.become(responseStage(id, sender(), cancellable))
+  }
+
+  private def responseStage(
+    id: Id,
+    replyTo: ActorRef,
+    cancellable: Cancellable
+  ): Receive = {
+    case RequestTimeout =>
+      replyTo ! RequestTimeout
+      context.stop(self)
+
+    case Success(_) =>
+      replyTo ! ResponseResult(
+        LibrarySetMetadata,
+        id,
+        Unused
+      )
+      cancellable.cancel()
+      context.stop(self)
+
+    case Failure(exception) =>
+      replyTo ! ResponseError(Some(id), FileSystemError(exception.getMessage))
+      cancellable.cancel()
+      context.stop(self)
   }
 }
 
 object LibrarySetMetadataHandler {
 
-  /** Creates a configuration object to create [[LibrarySetMetadataHandler]]. */
-  def props(): Props = Props(new LibrarySetMetadataHandler)
+  /** Creates a configuration object to create [[LibrarySetMetadataHandler]].
+    *
+    * @param timeout request timeout
+    * @param localLibraryManager a reference to the LocalLibraryManager
+    */
+  def props(timeout: FiniteDuration, localLibraryManager: ActorRef): Props =
+    Props(new LibrarySetMetadataHandler(timeout, localLibraryManager))
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibrarySetMetadataHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibrarySetMetadataHandler.scala
@@ -3,7 +3,14 @@ package org.enso.languageserver.libraries.handler
 import akka.actor.{Actor, ActorRef, Cancellable, Props}
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.editions.LibraryName
-import org.enso.jsonrpc.{Id, Request, ResponseError, ResponseResult, Unused}
+import org.enso.jsonrpc.{
+  Errors,
+  Id,
+  Request,
+  ResponseError,
+  ResponseResult,
+  Unused
+}
 import org.enso.languageserver.filemanager.FileManagerApi.FileSystemError
 import org.enso.languageserver.libraries.LibraryApi._
 import org.enso.languageserver.libraries.LocalLibraryManagerProtocol
@@ -52,7 +59,8 @@ class LibrarySetMetadataHandler(
     cancellable: Cancellable
   ): Receive = {
     case RequestTimeout =>
-      replyTo ! RequestTimeout
+      logger.error("Request [{}] timed out.", id)
+      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
       context.stop(self)
 
     case Success(_) =>

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
@@ -511,8 +511,9 @@ class JsonConnectionController(
         .props(requestTimeout, libraryConfig.localLibraryManager),
       LibraryListLocal -> LibraryListLocalHandler
         .props(requestTimeout, libraryConfig.localLibraryManager),
-      LibraryGetMetadata -> LibraryGetMetadataHandler.props(),
-      LibraryPreinstall  -> LibraryPreinstallHandler.props(),
+      LibraryGetMetadata -> LibraryGetMetadataHandler
+        .props(requestTimeout, libraryConfig.localLibraryManager),
+      LibraryPreinstall -> LibraryPreinstallHandler.props(),
       LibraryPublish -> LibraryPublishHandler
         .props(requestTimeout, libraryConfig.localLibraryManager),
       LibrarySetMetadata -> LibrarySetMetadataHandler.props()

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
@@ -516,7 +516,8 @@ class JsonConnectionController(
       LibraryPreinstall -> LibraryPreinstallHandler.props(),
       LibraryPublish -> LibraryPublishHandler
         .props(requestTimeout, libraryConfig.localLibraryManager),
-      LibrarySetMetadata -> LibrarySetMetadataHandler.props()
+      LibrarySetMetadata -> LibrarySetMetadataHandler
+        .props(requestTimeout, libraryConfig.localLibraryManager)
     )
   }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
@@ -101,12 +101,96 @@ class LibrariesTest extends BaseServerTest {
     }
 
     "get and set the metadata" in {
-      ???
+      val client = getInitialisedWsClient()
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "library/create",
+            "id": 0,
+            "params": {
+              "namespace": "user",
+              "name": "Metadata_Test_Lib",
+              "authors": [],
+              "maintainers": [],
+              "license": ""
+            }
+          }
+          """)
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 0,
+            "result": null
+          }
+          """)
+
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "library/getMetadata",
+            "id": 1,
+            "params": {
+              "namespace": "user",
+              "name": "Metadata_Test_Lib",
+              "version": {
+                "type": "LocalLibraryVersion"
+              }
+            }
+          }
+          """)
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+              "description": null,
+              "tagLine": null
+            }
+          }
+          """)
+
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "library/setMetadata",
+            "id": 2,
+            "params": {
+              "namespace": "user",
+              "name": "Metadata_Test_Lib",
+              "description": "The description...",
+              "tagLine": "tag-line"
+            }
+          }
+          """)
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 2,
+            "result": null
+          }
+          """)
+
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "library/getMetadata",
+            "id": 3,
+            "params": {
+              "namespace": "user",
+              "name": "Metadata_Test_Lib",
+              "version": {
+                "type": "LocalLibraryVersion"
+              }
+            }
+          }
+          """)
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 3,
+            "result": {
+              "description": "The description...",
+              "tagLine": "tag-line"
+            }
+          }
+          """)
     }
 
     def port: Int = 47308
 
-    "create, publish a library and fetch its manifest" in {
+    "create, publish a library and fetch its manifest from the server" in {
       val client = getInitialisedWsClient()
       client.send(json"""
           { "jsonrpc": "2.0",
@@ -171,6 +255,9 @@ class LibrariesTest extends BaseServerTest {
         val mainPackage = libraryRoot.resolve("main.tgz")
         assert(Files.exists(mainPackage))
       }
+
+      // Once the server is down, the metadata request should fail, especially as the published version is not cached.
+      // TODO
     }
   }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
@@ -10,6 +10,7 @@ import org.enso.librarymanager.published.repository.{
   EmptyRepository,
   ExampleRepository
 }
+import org.enso.pkg.{Contact, PackageManager}
 
 import java.nio.file.Files
 
@@ -53,8 +54,20 @@ class LibrariesTest extends BaseServerTest {
             "params": {
               "namespace": "user",
               "name": "My_Local_Lib",
-              "authors": [],
-              "maintainers": [],
+              "authors": [
+                {
+                  "name": "user",
+                  "email": "example@example.com"
+                }
+              ],
+              "maintainers": [
+                {
+                  "name": "only-name"
+                },
+                {
+                  "email": "foo@example.com"
+                }
+              ],
               "license": ""
             }
           }
@@ -199,8 +212,20 @@ class LibrariesTest extends BaseServerTest {
             "params": {
               "namespace": "user",
               "name": "Publishable_Lib",
-              "authors": [],
-              "maintainers": [],
+              "authors": [
+                {
+                  "name": "user",
+                  "email": "example@example.com"
+                }
+              ],
+              "maintainers": [
+                {
+                  "name": "only-name"
+                },
+                {
+                  "email": "foo@example.com"
+                }
+              ],
               "license": ""
             }
           }
@@ -278,6 +303,14 @@ class LibrariesTest extends BaseServerTest {
           .resolve("0.0.1")
         val mainPackage = libraryRoot.resolve("main.tgz")
         assert(Files.exists(mainPackage))
+        val pkg = PackageManager.Default.loadPackage(libraryRoot.toFile).get
+        pkg.config.authors should contain theSameElementsAs Seq(
+          Contact(name = Some("user"), email = Some("example@example.com"))
+        )
+        pkg.config.maintainers should contain theSameElementsAs Seq(
+          Contact(name = Some("only-name"), email = None),
+          Contact(name = None, email              = Some("foo@example.com"))
+        )
 
         client.send(json"""
           { "jsonrpc": "2.0",

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
@@ -100,9 +100,13 @@ class LibrariesTest extends BaseServerTest {
       // TODO [RW] error handling (#1877)
     }
 
+    "get and set the metadata" in {
+      ???
+    }
+
     def port: Int = 47308
 
-    "create and publish a library" in {
+    "create, publish a library and fetch its manifest" in {
       val client = getInitialisedWsClient()
       client.send(json"""
           { "jsonrpc": "2.0",

--- a/lib/scala/cli/src/test/scala/org/enso/cli/task/TaskProgressSpec.scala
+++ b/lib/scala/cli/src/test/scala/org/enso/cli/task/TaskProgressSpec.scala
@@ -1,11 +1,11 @@
 package org.enso.cli.task
 
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.AsyncWordSpec
 
 import scala.util.{Success, Try}
 
-class MappedTaskSpec extends AnyWordSpec with Matchers {
+class TaskProgressSpec extends AsyncWordSpec with Matchers {
   "TaskProgress.map" should {
     "run only once even with multiple listeners" in {
       var runs  = 0
@@ -35,6 +35,17 @@ class MappedTaskSpec extends AnyWordSpec with Matchers {
 
       answer shouldEqual Some(Success("foobar"))
       runs shouldEqual 1
+    }
+  }
+
+  "TaskProgress.toFuture" should {
+    "return a future that is completed when the original task is" in {
+      val task1 = new TaskProgressImplementation[String]()
+      task1.setComplete(Success("foo"))
+
+      task1.toFuture.map { result =>
+        result shouldEqual "foo"
+      }
     }
   }
 }

--- a/lib/scala/editions/src/main/scala/org/enso/editions/Editions.scala
+++ b/lib/scala/editions/src/main/scala/org/enso/editions/Editions.scala
@@ -2,8 +2,6 @@ package org.enso.editions
 
 import nl.gn0s1s.bump.SemVer
 
-import scala.util.Try
-
 /** Defines the general edition structure.
   *
   * We split the data type into two categories: Raw and Resolved editions.
@@ -122,12 +120,11 @@ object Editions {
 
   object Repository {
 
-    /** A helper function that creates a Repository instance from a raw string
-      * URL.
+    /** An alternative constructor for unnamed repositories.
+      *
+      * The URL is used as the repository name.
       */
-    def make(name: String, url: String): Try[Repository] = Try {
-      Repository(name, url)
-    }
+    def apply(url: String): Repository = Repository(url, url)
   }
 
   /** Implements the Raw editions that can be directly parsed from a YAML


### PR DESCRIPTION
### Pull Request Description

Implements the endpoint for getting library metadata, extending it with the ability to also fetch metadata for published libraries.

As it was needed for better testing, the endpoint setting metadata is also implemented.

### Important Notes

- It changes the API, but since it was not yet being used, it is not marked as a breaking change.
- While such _possibility_ is advertised in the documentation, the endpoint does not look for cached manifests of published libraries. That is because manifest caching is not yet implemented - once caching is implemented (probably around #1772 when dependency downloading will be implemented), this should also be added.
- It also updates the API of `library/create` to use a `Contact` type for `authors` and `maintainers`, as the original API was not compatible with the config format - by mistake. Since this endpoint is not yet being used, the change also should not be breaking.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
