### PR TITLE
Add log.masking runtime option

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -46,6 +46,7 @@ import org.enso.librarymanager.LibraryLocations
 import org.enso.librarymanager.local.DefaultLocalLibraryProvider
 import org.enso.librarymanager.published.PublishedLibraryCache
 import org.enso.lockmanager.server.LockManagerService
+import org.enso.logger.masking.Masking
 import org.enso.loggingservice.{JavaLoggingLogHandler, LogLevel}
 import org.enso.polyglot.{RuntimeOptions, RuntimeServerInfo}
 import org.enso.searcher.sql.{SqlDatabase, SqlSuggestionsRepo, SqlVersionsRepo}
@@ -57,6 +58,7 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.net.URI
 import java.time.Clock
+
 import scala.concurrent.duration._
 
 /** A main module containing all components of the server.
@@ -245,6 +247,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
       RuntimeOptions.LOG_LEVEL,
       JavaLoggingLogHandler.getJavaLogLevelFor(logLevel).getName
     )
+    .option(RuntimeOptions.LOG_MASKING, Masking.isMaskingEnabled.toString)
     .option(
       RuntimeServerInfo.JOB_PARALLELISM_OPTION,
       Runtime.getRuntime.availableProcessors().toString

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -28,6 +28,11 @@ public class RuntimeOptions {
   private static final OptionDescriptor LOG_LEVEL_DESCRIPTOR =
       OptionDescriptor.newBuilder(LOG_LEVEL_KEY, LOG_LEVEL).build();
 
+  public static final String LOG_MASKING = optionName("log.masking");
+  public static final OptionKey<Boolean> LOG_MASKING_KEY = new OptionKey<>(true);
+  private static final OptionDescriptor LOG_MASKING_DESCRIPTOR =
+      OptionDescriptor.newBuilder(LOG_MASKING_KEY, LOG_MASKING).build();
+
   public static final String INTERACTIVE_MODE = interpreterOptionName("interactive");
   public static final OptionKey<Boolean> INTERACTIVE_MODE_KEY = new OptionKey<>(false);
   public static final OptionDescriptor INTERACTIVE_MODE_DESCRIPTOR =
@@ -79,6 +84,7 @@ public class RuntimeOptions {
               PROJECT_ROOT_DESCRIPTOR,
               STRICT_ERRORS_DESCRIPTOR,
               LOG_LEVEL_DESCRIPTOR,
+              LOG_MASKING_DESCRIPTOR,
               DISABLE_INLINE_CACHES_DESCRIPTOR,
               ENABLE_PROJECT_SUGGESTIONS_DESCRIPTOR,
               ENABLE_GLOBAL_SUGGESTIONS_DESCRIPTOR,

--- a/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
@@ -32,6 +32,7 @@ class ContextFactory {
     out: OutputStream,
     repl: Repl,
     logLevel: LogLevel,
+    logMasking: Boolean,
     strictErrors: Boolean = false
   ): PolyglotContext = {
     val context = Context
@@ -42,6 +43,7 @@ class ContextFactory {
       .option(RuntimeOptions.STRICT_ERRORS, strictErrors.toString)
       .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
       .option(DebugServerInfo.ENABLE_OPTION, "true")
+      .option(RuntimeOptions.LOG_MASKING, logMasking.toString)
       .option("js.foreign-object-prototype", "true")
       .out(out)
       .in(in)

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -341,11 +341,13 @@ object Main {
     * @param projectPath if specified, the script is run in context of a
     *                    project located at that path
     * @param logLevel log level to set for the engine runtime
+    * @param logMasking is the log masking enabled
     */
   private def run(
     path: String,
     projectPath: Option[String],
-    logLevel: LogLevel
+    logLevel: LogLevel,
+    logMasking: Boolean
   ): Unit = {
     val file = new File(path)
     if (!file.exists) {
@@ -372,8 +374,9 @@ object Main {
       System.in,
       System.out,
       Repl(TerminalIO()),
-      strictErrors = true,
-      logLevel     = logLevel
+      logLevel,
+      logMasking,
+      strictErrors = true
     )
     if (projectMode) {
       val pkg  = PackageManager.Default.fromDirectory(file)
@@ -400,29 +403,36 @@ object Main {
     * @param projectPath if specified, the docs is generated for a project
     *                    at the given path
     * @param logLevel log level to set for the engine runtime
+    * @param logMasking is the log masking enabled
     */
   private def genDocs(
     projectPath: Option[String],
-    logLevel: LogLevel
+    logLevel: LogLevel,
+    logMasking: Boolean
   ): Unit = {
     if (projectPath.isEmpty) {
       println("Path hasn't been provided.")
       exitFail()
     }
-    generateDocsFrom(projectPath.get, logLevel)
+    generateDocsFrom(projectPath.get, logLevel, logMasking)
     exitSuccess()
   }
 
   /** Subroutine of `genDocs` function.
     * Generates the documentation for given Enso project at given path.
     */
-  def generateDocsFrom(path: String, logLevel: LogLevel): Unit = {
+  def generateDocsFrom(
+    path: String,
+    logLevel: LogLevel,
+    logMasking: Boolean
+  ): Unit = {
     val executionContext = new ContextFactory().create(
       path,
       System.in,
       System.out,
       Repl(TerminalIO()),
-      logLevel = logLevel
+      logLevel,
+      logMasking
     )
 
     val file = new File(path)
@@ -539,8 +549,13 @@ object Main {
     * @param projectPath if specified, the REPL is run in context of a project
     *                    at the given path
     * @param logLevel log level to set for the engine runtime
+    * @param logMasking is the log masking enabled
     */
-  private def runRepl(projectPath: Option[String], logLevel: LogLevel): Unit = {
+  private def runRepl(
+    projectPath: Option[String],
+    logLevel: LogLevel,
+    logMasking: Boolean
+  ): Unit = {
     val mainMethodName = "internal_repl_entry_point___"
     val dummySourceToTriggerRepl =
       s"""from Standard.Base import all
@@ -555,7 +570,8 @@ object Main {
         System.in,
         System.out,
         Repl(TerminalIO()),
-        logLevel = logLevel
+        logLevel,
+        logMasking
       )
     val mainModule =
       context.evalModule(dummySourceToTriggerRepl, replModuleName)
@@ -723,14 +739,23 @@ object Main {
       run(
         line.getOptionValue(RUN_OPTION),
         Option(line.getOptionValue(IN_PROJECT_OPTION)),
-        logLevel
+        logLevel,
+        logMasking
       )
     }
     if (line.hasOption(REPL_OPTION)) {
-      runRepl(Option(line.getOptionValue(IN_PROJECT_OPTION)), logLevel)
+      runRepl(
+        Option(line.getOptionValue(IN_PROJECT_OPTION)),
+        logLevel,
+        logMasking
+      )
     }
     if (line.hasOption(DOCS_OPTION)) {
-      genDocs(Option(line.getOptionValue(IN_PROJECT_OPTION)), logLevel)
+      genDocs(
+        Option(line.getOptionValue(IN_PROJECT_OPTION)),
+        logLevel,
+        logMasking
+      )
     }
     if (line.hasOption(LANGUAGE_SERVER_OPTION)) {
       runLanguageServer(line, logLevel)

--- a/engine/runtime/src/main/java/org/enso/interpreter/Language.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/Language.java
@@ -23,7 +23,7 @@ import org.enso.interpreter.runtime.tag.IdentifiedTag;
 import org.enso.interpreter.service.ExecutionService;
 import org.enso.interpreter.util.FileDetector;
 import org.enso.lockmanager.client.ConnectedLockManager;
-import org.enso.logger.masking.Masking$;
+import org.enso.logger.masking.MaskingFactory;
 import org.enso.polyglot.LanguageInfo;
 import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.options.OptionDescriptors;
@@ -70,7 +70,7 @@ public final class Language extends TruffleLanguage<Context> {
   @Override
   protected Context createContext(Env env) {
     boolean logMasking = env.getOptions().get(RuntimeOptions.LOG_MASKING_KEY);
-    Masking$.MODULE$.setup(logMasking);
+    MaskingFactory.getInstance().setup(logMasking);
 
     var notificationHandler = new Forwarder();
     boolean isInteractiveMode = env.getOptions().get(RuntimeOptions.INTERACTIVE_MODE_KEY);

--- a/engine/runtime/src/main/java/org/enso/interpreter/Language.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/Language.java
@@ -23,6 +23,7 @@ import org.enso.interpreter.runtime.tag.IdentifiedTag;
 import org.enso.interpreter.service.ExecutionService;
 import org.enso.interpreter.util.FileDetector;
 import org.enso.lockmanager.client.ConnectedLockManager;
+import org.enso.logger.masking.Masking$;
 import org.enso.polyglot.LanguageInfo;
 import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.options.OptionDescriptors;
@@ -68,6 +69,9 @@ public final class Language extends TruffleLanguage<Context> {
    */
   @Override
   protected Context createContext(Env env) {
+    boolean logMasking = env.getOptions().get(RuntimeOptions.LOG_MASKING_KEY);
+    Masking$.MODULE$.setup(logMasking);
+
     var notificationHandler = new Forwarder();
     boolean isInteractiveMode = env.getOptions().get(RuntimeOptions.INTERACTIVE_MODE_KEY);
     boolean isTextMode = !isInteractiveMode;

--- a/lib/scala/logging-utils/src/main/java/org/enso/logger/masking/MaskingFactory.java
+++ b/lib/scala/logging-utils/src/main/java/org/enso/logger/masking/MaskingFactory.java
@@ -1,0 +1,10 @@
+package org.enso.logger.masking;
+
+/** Java API providing access to the masking module. */
+public class MaskingFactory {
+
+  /** @return the masking instance. */
+  public static Masking$ getInstance() {
+      return Masking$.MODULE$;
+  }
+}


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Setup log masking in the runtime. Due to the classpath separation, the runtime doesn't have an access to the configured `Masking` instance. And we need to configure the runtime explicitly through the context options.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
