### PR TITLE
Load Caches from Disk

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -301,12 +301,12 @@ jobs:
         shell: bash
         if: runner.os == 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Table_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Database_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Geo_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Visualization_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Image_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Table_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Database_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Image_Tests
 
       - name: Test Engine Distribution With Caches (Windows)
         shell: bash

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -22,7 +22,7 @@ jobs:
   test_and_publish:
     name: Build and Test
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    timeout-minutes: 100
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-18.04, windows-latest]
@@ -275,27 +275,49 @@ jobs:
           postgresql user: ${{ env.ENSO_DATABASE_TEST_DB_USER }}
           postgresql password: ${{ env.ENSO_DATABASE_TEST_DB_PASSWORD }}
 
-      - name: Test Engine Distribution (Unix)
+      - name: Test Engine Distribution Without Caches (Unix)
         shell: bash
         if: runner.os != 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso --run test/Tests
-          $ENGINE_DIST_DIR/bin/enso --run test/Table_Tests
-          $ENGINE_DIST_DIR/bin/enso --run test/Database_Tests
-          $ENGINE_DIST_DIR/bin/enso --run test/Geo_Tests
-          $ENGINE_DIST_DIR/bin/enso --run test/Visualization_Tests
-          $ENGINE_DIST_DIR/bin/enso --run test/Image_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Table_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Database_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Image_Tests
 
-      - name: Test Engine Distribution (Windows)
+      - name: Test Engine Distribution With Caches (Unix)
+        shell: bash
+        if: runner.os != 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Table_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Database_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Image_Tests
+
+      - name: Test Engine Distribution Without Caches (Windows)
         shell: bash
         if: runner.os == 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso.bat --run test/Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --run test/Table_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --run test/Database_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --run test/Geo_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --run test/Visualization_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --run test/Image_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Table_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Database_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Image_Tests
+
+      - name: Test Engine Distribution With Caches (Windows)
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Table_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Database_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Image_Tests
 
       # Publish
       - name: Compress the built artifacts for upload

--- a/Import_Test/package.yaml
+++ b/Import_Test/package.yaml
@@ -1,0 +1,8 @@
+name: Import_Test
+namespace: local
+version: 0.0.1
+license: ""
+authors: []
+maintainers: []
+edition: 2021.17-SNAPSHOT
+prefer-local-libraries: true

--- a/Import_Test/package.yaml
+++ b/Import_Test/package.yaml
@@ -1,8 +1,0 @@
-name: Import_Test
-namespace: local
-version: 0.0.1
-license: ""
-authors: []
-maintainers: []
-edition: 2021.17-SNAPSHOT
-prefer-local-libraries: true

--- a/Import_Test/src/Foo.enso
+++ b/Import_Test/src/Foo.enso
@@ -1,0 +1,4 @@
+from Standard.Builtins import IO
+
+do_print = IO.println "COMPLETED EXECUTION"
+

--- a/Import_Test/src/Foo.enso
+++ b/Import_Test/src/Foo.enso
@@ -1,4 +1,0 @@
-from Standard.Builtins import IO
-
-do_print = IO.println "COMPLETED EXECUTION"
-

--- a/Import_Test/src/Main.enso
+++ b/Import_Test/src/Main.enso
@@ -1,0 +1,5 @@
+import project.Foo
+
+# from Standard.Base import all
+
+main = Foo.do_print

--- a/Import_Test/src/Main.enso
+++ b/Import_Test/src/Main.enso
@@ -1,5 +1,0 @@
-import project.Foo
-
-# from Standard.Base import all
-
-main = Foo.do_print

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,13 @@
 # Enso Next
 
+## Interpreter/Runtime
+
+- Added support for reading the compiler's intermediate representation from
+  disk, as well as round-tripping that IR
+  ([#1996](https://github.com/enso-org/enso/pull/1996)). The compiler will now
+  take advantage of cached IR where available to drastically reduce start-up
+  time, and will write these caches if they do not exist or are invalid.
+
 ## Enso 0.2.29 (2021-09-16)
 
 ## Interpreter/Runtime

--- a/build.sbt
+++ b/build.sbt
@@ -953,6 +953,7 @@ lazy val `polyglot-api` = project
   .in(file("engine/polyglot-api"))
   .settings(
     Test / fork := true,
+    commands += WithDebugCommand.withDebug,
     Test / envVars ++= distributionEnvironmentOverrides,
     Test / javaOptions ++= {
       // Note [Classpath Separation]

--- a/docs/runtime/ir-caching.md
+++ b/docs/runtime/ir-caching.md
@@ -31,6 +31,7 @@ startup performance.
   - [Integrity Checking](#integrity-checking)
   - [Error Handling](#error-handling)
 - [Testing the Serialisation](#testing-the-serialisation)
+- [Future Directions](#future-directions)
 
 <!-- /MarkdownTOC -->
 
@@ -212,3 +213,17 @@ There are two main elements that need to be tested as part of this feature.
   should be disabled for existing tests. This will require adding additional
   runtime options for debugging, but also constructing the `DistributionManager`
   on context creation (removing `RuntimeDistributionManager`).
+
+## Future Directions
+
+Due to the less than ideal platform situation we're in, we're limited to using
+Java's `Serializable`. It is not as performant as other options.
+
+- [FST](https://github.com/RuedigerMoeller/fast-serialization) is around 10x
+  faster than the JVM's serialization, and is a drop-in replacement.
+- However, the version that supports Java 11 utilises reflection that trips
+  warnings that will be disallowed with Java 17 (the next LTS version for
+  GraalVM).
+- The version that fixes this relies on the foreign memory API which is
+  available in Java 17. I recommend that once we're on Java 17 builds the
+  serialization is updated to work using FST.

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -241,7 +241,6 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
     .allowExperimentalOptions(true)
     .option(RuntimeServerInfo.ENABLE_OPTION, "true")
     .option(RuntimeOptions.INTERACTIVE_MODE, "true")
-    .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
     .option(RuntimeOptions.PROJECT_ROOT, serverConfig.contentRootPath)
     .option(
       RuntimeOptions.LOG_LEVEL,

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -65,7 +65,7 @@ public class RuntimeOptions {
       OptionDescriptor.newBuilder(LANGUAGE_HOME_OVERRIDE_KEY, LANGUAGE_HOME_OVERRIDE).build();
 
   public static final String DISABLE_IR_CACHES = optionName("disableIrCaches");
-  public static final OptionKey<Boolean> DISABLE_IR_CACHES_KEY = new OptionKey<>(true);
+  public static final OptionKey<Boolean> DISABLE_IR_CACHES_KEY = new OptionKey<>(false);
   private static final OptionDescriptor DISABLE_IR_CACHES_DESCRIPTOR =
       OptionDescriptor.newBuilder(DISABLE_IR_CACHES_KEY, DISABLE_IR_CACHES).build();
 

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -73,10 +73,15 @@ public class RuntimeOptions {
       optionName("waitForPendingSerializationJobs");
   public static final OptionKey<Boolean> WAIT_FOR_PENDING_SERIALIZATION_JOBS_KEY =
       new OptionKey<>(false);
-  private static final OptionDescriptor WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESRIPTOR =
+  private static final OptionDescriptor WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESCRIPTOR =
       OptionDescriptor.newBuilder(
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_KEY, WAIT_FOR_PENDING_SERIALIZATION_JOBS)
           .build();
+
+  public static final String NO_READ_IR_CACHES = optionName("onlyGenerateIrCaches");
+  public static final OptionKey<Boolean> NO_READ_IR_CACHES_KEY = new OptionKey<>(false);
+  private static final OptionDescriptor NO_READ_IR_CACHES_DESCRIPTOR =
+      OptionDescriptor.newBuilder(NO_READ_IR_CACHES_KEY, NO_READ_IR_CACHES).build();
 
   public static final OptionDescriptors OPTION_DESCRIPTORS =
       OptionDescriptors.create(
@@ -92,7 +97,8 @@ public class RuntimeOptions {
               LANGUAGE_HOME_OVERRIDE_DESCRIPTOR,
               INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_DESCRIPTOR,
               DISABLE_IR_CACHES_DESCRIPTOR,
-              WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESRIPTOR));
+              WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESCRIPTOR,
+              NO_READ_IR_CACHES_DESCRIPTOR));
 
   /**
    * Canonicalizes the option name by prefixing it with the language name.

--- a/engine/polyglot-api/src/test/scala/org/enso/polyglot/ApiTest.scala
+++ b/engine/polyglot-api/src/test/scala/org/enso/polyglot/ApiTest.scala
@@ -12,7 +12,7 @@ class ApiTest extends AnyFlatSpec with Matchers {
     Context
       .newBuilder(ID)
       .allowExperimentalOptions(true)
-      .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
+      .allowAllAccess(true)
       .option(
         RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
         Paths.get("../../distribution/component").toFile.getAbsolutePath

--- a/engine/polyglot-api/src/test/scala/org/enso/polyglot/ApiTest.scala
+++ b/engine/polyglot-api/src/test/scala/org/enso/polyglot/ApiTest.scala
@@ -12,6 +12,7 @@ class ApiTest extends AnyFlatSpec with Matchers {
     Context
       .newBuilder(ID)
       .allowExperimentalOptions(true)
+      .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
       .option(
         RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
         Paths.get("../../distribution/component").toFile.getAbsolutePath

--- a/engine/polyglot-api/src/test/scala/org/enso/polyglot/ModuleManagementTest.scala
+++ b/engine/polyglot-api/src/test/scala/org/enso/polyglot/ModuleManagementTest.scala
@@ -18,7 +18,6 @@ class ModuleManagementTest extends AnyFlatSpec with Matchers {
         .allowExperimentalOptions(true)
         .allowAllAccess(true)
         .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
-        .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
         .option(
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
           Paths.get("../../distribution/component").toFile.getAbsolutePath

--- a/engine/polyglot-api/src/test/scala/org/enso/polyglot/ModuleManagementTest.scala
+++ b/engine/polyglot-api/src/test/scala/org/enso/polyglot/ModuleManagementTest.scala
@@ -18,6 +18,7 @@ class ModuleManagementTest extends AnyFlatSpec with Matchers {
         .allowExperimentalOptions(true)
         .allowAllAccess(true)
         .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
+        .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
         .option(
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
           Paths.get("../../distribution/component").toFile.getAbsolutePath

--- a/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
@@ -23,6 +23,7 @@ class ContextFactory {
     * @param out the output stream for standard out
     * @param repl the Repl manager to use for this context
     * @param logLevel the log level for this context
+    * @param enableIrCaches whether or not IR caching should be enabled
     * @param strictErrors whether or not to use strict errors
     * @return configured Context instance
     */
@@ -33,6 +34,7 @@ class ContextFactory {
     repl: Repl,
     logLevel: LogLevel,
     logMasking: Boolean,
+    enableIrCaches: Boolean,
     strictErrors: Boolean = false
   ): PolyglotContext = {
     val context = Context
@@ -41,7 +43,8 @@ class ContextFactory {
       .allowAllAccess(true)
       .option(RuntimeOptions.PROJECT_ROOT, projectRoot)
       .option(RuntimeOptions.STRICT_ERRORS, strictErrors.toString)
-      .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
+      .option(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS, "true")
+      .option(RuntimeOptions.DISABLE_IR_CACHES, (!enableIrCaches).toString)
       .option(DebugServerInfo.ENABLE_OPTION, "true")
       .option(RuntimeOptions.LOG_MASKING, logMasking.toString)
       .option("js.foreign-object-prototype", "true")

--- a/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
@@ -24,6 +24,8 @@ class ContextFactory {
     * @param repl the Repl manager to use for this context
     * @param logLevel the log level for this context
     * @param enableIrCaches whether or not IR caching should be enabled
+    * @param enableIrCacheReading whether or not IR cache reading should be
+    *                             enabled
     * @param strictErrors whether or not to use strict errors
     * @return configured Context instance
     */
@@ -35,6 +37,7 @@ class ContextFactory {
     logLevel: LogLevel,
     logMasking: Boolean,
     enableIrCaches: Boolean,
+    enableIrCacheReading: Boolean,
     strictErrors: Boolean = false
   ): PolyglotContext = {
     val context = Context
@@ -45,6 +48,10 @@ class ContextFactory {
       .option(RuntimeOptions.STRICT_ERRORS, strictErrors.toString)
       .option(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS, "true")
       .option(RuntimeOptions.DISABLE_IR_CACHES, (!enableIrCaches).toString)
+      .option(
+        RuntimeOptions.NO_READ_IR_CACHES,
+        (!enableIrCacheReading).toString
+      )
       .option(DebugServerInfo.ENABLE_OPTION, "true")
       .option(RuntimeOptions.LOG_MASKING, logMasking.toString)
       .option("js.foreign-object-prototype", "true")

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
@@ -53,6 +53,7 @@ public class Context {
   private final ResourceManager resourceManager;
   private final boolean isInlineCachingDisabled;
   private final boolean isIrCachingDisabled;
+  private final boolean isIrCacheReadingDisabled;
   private final boolean shouldWaitForPendingSerializationJobs;
   private final Builtins builtins;
   private final String home;
@@ -90,6 +91,8 @@ public class Context {
     this.isInlineCachingDisabled =
         environment.getOptions().get(RuntimeOptions.DISABLE_INLINE_CACHES_KEY);
     this.isIrCachingDisabled = environment.getOptions().get(RuntimeOptions.DISABLE_IR_CACHES_KEY);
+    this.isIrCacheReadingDisabled =
+        environment.getOptions().get(RuntimeOptions.NO_READ_IR_CACHES_KEY);
     this.shouldWaitForPendingSerializationJobs =
         environment.getOptions().get(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS_KEY);
     this.compilerConfig = new CompilerConfig(false, true);
@@ -404,6 +407,11 @@ public class Context {
   /** @return whether IR caching should be disabled for this context. */
   public boolean isIrCachingDisabled() {
     return isIrCachingDisabled;
+  }
+
+  /** @return whether IR cache reading is disabled for this context */
+  public boolean isIrCacheReadingDisabled() {
+    return isIrCacheReadingDisabled;
   }
 
   /** @return the compiler configuration for this language */

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -89,6 +89,7 @@ public class Module implements TruffleObject {
   private final ModuleCache cache;
   private boolean wasLoadedFromCache;
   private boolean hasCrossModuleLinks;
+  private boolean isInteractive;
 
   /**
    * Creates a new module.
@@ -105,6 +106,7 @@ public class Module implements TruffleObject {
     this.cache = new ModuleCache(this);
     this.wasLoadedFromCache = false;
     this.hasCrossModuleLinks = false;
+    this.isInteractive = false;
   }
 
   /**
@@ -122,6 +124,7 @@ public class Module implements TruffleObject {
     this.cache = new ModuleCache(this);
     this.wasLoadedFromCache = false;
     this.hasCrossModuleLinks = false;
+    this.isInteractive = true;
   }
 
   /**
@@ -139,6 +142,7 @@ public class Module implements TruffleObject {
     this.cache = new ModuleCache(this);
     this.wasLoadedFromCache = false;
     this.hasCrossModuleLinks = false;
+    this.isInteractive = true;
   }
 
   /**
@@ -156,6 +160,7 @@ public class Module implements TruffleObject {
     this.cache = new ModuleCache(this);
     this.wasLoadedFromCache = false;
     this.hasCrossModuleLinks = false;
+    this.isInteractive = false;
   }
 
   /**
@@ -172,6 +177,7 @@ public class Module implements TruffleObject {
 
   /** Clears any literal source set for this module. */
   public void unsetLiteralSource() {
+    this.isInteractive = false;
     this.literalSource = null;
     this.cachedSource = null;
     this.compilationStage = CompilationStage.INITIAL;
@@ -200,6 +206,7 @@ public class Module implements TruffleObject {
     this.literalSource = source;
     this.compilationStage = CompilationStage.INITIAL;
     this.cachedSource = null;
+    this.isInteractive = true;
   }
 
   /**
@@ -212,6 +219,7 @@ public class Module implements TruffleObject {
     this.sourceFile = file;
     this.compilationStage = CompilationStage.INITIAL;
     this.cachedSource = null;
+    this.isInteractive = false;
   }
 
   /** @return the location of this module. */
@@ -348,7 +356,7 @@ public class Module implements TruffleObject {
 
   /** @return {@code true} if the module is interactive, {@code false} otherwise */
   public boolean isInteractive() {
-    return literalSource != null;
+    return isInteractive;
   }
 
   /**
@@ -429,6 +437,8 @@ public class Module implements TruffleObject {
       Types.extractArguments(args);
       module.cachedSource = null;
       module.literalSource = null;
+      module.isInteractive = false;
+      module.wasLoadedFromCache = false;
       try {
         module.compile(context);
       } catch (IOException ignored) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -348,7 +348,7 @@ public class Module implements TruffleObject {
 
   /** @return {@code true} if the module is interactive, {@code false} otherwise */
   public boolean isInteractive() {
-    return literalSource == null;
+    return literalSource != null;
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -186,6 +186,21 @@ public class Builtins {
     return this.module.getIr() != null;
   }
 
+  /** Initialize the source file for the builtins module. */
+  @CompilerDirectives.TruffleBoundary
+  public void initializeBuiltinsSource() {
+    try {
+      var builtinsModuleBytes =
+          Objects.requireNonNull(
+                  getClass().getClassLoader().getResourceAsStream(Builtins.SOURCE_NAME))
+              .readAllBytes();
+      String source = new String(builtinsModuleBytes, StandardCharsets.UTF_8);
+      module.setLiteralSource(source);
+    } catch (IOException e) {
+      throw new CompilerError("Fatal, unable to read Builtins source file.");
+    }
+  }
+
   /**
    * Initialize the IR for the builtins module from the builtins source file.
    *
@@ -195,15 +210,12 @@ public class Builtins {
   @CompilerDirectives.TruffleBoundary
   public void initializeBuiltinsIr(FreshNameSupply freshNameSupply, Passes passes) {
     try {
-      var builtinsModuleBytes =
-          Objects.requireNonNull(
-                  getClass().getClassLoader().getResourceAsStream(Builtins.SOURCE_NAME))
-              .readAllBytes();
-      String source = new String(builtinsModuleBytes, StandardCharsets.UTF_8);
-      module.setLiteralSource(source);
+      if (module.getSource() == null) {
+        initializeBuiltinsSource();
+      }
       BuiltinsIrBuilder.build(module, freshNameSupply, passes);
     } catch (IOException e) {
-      throw new CompilerError("Fatal, unable to read Builtins source file.");
+      e.printStackTrace();
     }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -47,6 +47,7 @@ class Compiler(
   private val stubsGenerator: RuntimeStubsGenerator =
     new RuntimeStubsGenerator()
   private val irCachingEnabled = !context.isIrCachingDisabled
+  private val irCacheReadingEnabled = !context.isIrCacheReadingDisabled
   private val serializationManager: SerializationManager =
     new SerializationManager(this)
   private val logger: TruffleLogger = context.getLogger(getClass)
@@ -62,7 +63,7 @@ class Compiler(
 
       builtins.initializeBuiltinsSource()
 
-      if (irCachingEnabled) {
+      if (irCachingEnabled && irCacheReadingEnabled) {
         serializationManager.deserialize(builtins.getModule) match {
           case Some(true) =>
             builtins.getModule.unsafeSetCompilationStage(
@@ -108,7 +109,7 @@ class Compiler(
     var requiredModules = runImportsAndExportsResolution(module)
 
     var hasInvalidModuleRelink = false
-    if (irCachingEnabled) {
+    if (irCachingEnabled && irCacheReadingEnabled) {
       requiredModules.foreach { m =>
         if (!m.hasCrossModuleLinks) {
           val flags =
@@ -229,7 +230,7 @@ class Compiler(
     module.ensureScopeExists()
     module.getScope.reset()
 
-    if (irCachingEnabled) {
+    if (irCachingEnabled && irCacheReadingEnabled) {
       serializationManager.deserialize(module) match {
         case Some(_) => return
         case _       =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -1,5 +1,6 @@
 package org.enso.compiler
 
+import com.oracle.truffle.api.TruffleLogger
 import com.oracle.truffle.api.source.Source
 import org.enso.compiler.codegen.{AstToIr, IrToTruffle, RuntimeStubsGenerator}
 import org.enso.compiler.context.{FreshNameSupply, InlineContext, ModuleContext}
@@ -23,6 +24,8 @@ import org.enso.syntax.text.Parser.IDMap
 import org.enso.syntax.text.{AST, Parser}
 
 import java.io.StringReader
+import java.util.logging.Level
+import scala.annotation.unused
 import scala.jdk.OptionConverters._
 
 /** This class encapsulates the static transformation processes that take place
@@ -46,12 +49,38 @@ class Compiler(
   private val irCachingEnabled = !context.isIrCachingDisabled
   private val serializationManager: SerializationManager =
     new SerializationManager(this)
+  private val logger: TruffleLogger = context.getLogger(getClass)
 
   /** Lazy-initializes the IR for the builtins module.
     */
   def initializeBuiltinsIr(): Unit = {
     if (!builtins.isIrInitialized) {
-      builtins.initializeBuiltinsIr(freshNameSupply, passes)
+      logger.log(
+        Compiler.defaultLogLevel,
+        "Initialising IR for [Standard.Builtins]."
+      )
+
+      builtins.initializeBuiltinsSource()
+
+      if (irCachingEnabled) {
+        serializationManager.deserialize(builtins.getModule) match {
+          case Some(true) =>
+            builtins.getModule.unsafeSetCompilationStage(
+              Module.CompilationStage.AFTER_CODEGEN
+            )
+          case _ =>
+            builtins.initializeBuiltinsIr(freshNameSupply, passes)
+            builtins.getModule.setHasCrossModuleLinks(true)
+
+        }
+      } else {
+        builtins.initializeBuiltinsIr(freshNameSupply, passes)
+        builtins.getModule.setHasCrossModuleLinks(true)
+      }
+
+      if (irCachingEnabled && !builtins.getModule.wasLoadedFromCache()) {
+        serializationManager.serialize(builtins.getModule)
+      }
     }
   }
 
@@ -75,10 +104,44 @@ class Compiler(
   def run(module: Module): Unit = {
     initializeBuiltinsIr()
     parseModule(module)
-    val importedModules = importResolver.mapImports(module)
-    val requiredModules =
-      try { new ExportsResolution().run(importedModules) }
-      catch { case e: ExportCycleException => reportCycle(e) }
+
+    var requiredModules = runImportsAndExportsResolution(module)
+
+    var hasInvalidModuleRelink = false
+    if (irCachingEnabled) {
+      requiredModules.foreach { m =>
+        if (!m.hasCrossModuleLinks) {
+          val flags =
+            m.getIr.preorder.map(_.passData.restoreFromSerialization(this))
+
+          if (!flags.contains(false)) {
+            logger.log(
+              Compiler.defaultLogLevel,
+              s"Restored links (late phase) for module [${m.getName}]."
+            )
+          } else {
+            logger.log(
+              Compiler.defaultLogLevel,
+              s"Failed to restore links (late phase) for module [${m.getName}]."
+            )
+            hasInvalidModuleRelink = true
+
+            uncachedParseModule(m, isGenDocs = false)
+          }
+        }
+      }
+    }
+
+    if (hasInvalidModuleRelink) {
+      logger.log(
+        Compiler.defaultLogLevel,
+        s"Some modules failed to relink. Re-running import and " +
+        s"export resolution."
+      )
+
+      requiredModules = runImportsAndExportsResolution(module)
+    }
+
     requiredModules.foreach { module =>
       if (
         !module.getCompilationStage.isAtLeast(
@@ -119,6 +182,11 @@ class Compiler(
           Module.CompilationStage.AFTER_CODEGEN
         )
       ) {
+        logger.log(
+          Compiler.defaultLogLevel,
+          s"Generating code for module [${module.getName}]."
+        )
+
         truffleCodegen(module.getIr, module.getSource, module.getScope)
         module.unsafeSetCompilationStage(Module.CompilationStage.AFTER_CODEGEN)
 
@@ -131,7 +199,8 @@ class Compiler(
   }
 
   /** Runs part of the compiler to generate docs from Enso code.
-    * @param module - the scope from which docs are generated.
+    *
+    * @param module the scope from which docs are generated
     */
   def generateDocs(module: Module): Module = {
     initializeBuiltinsIr()
@@ -139,33 +208,57 @@ class Compiler(
     module
   }
 
+  private def runImportsAndExportsResolution(module: Module): List[Module] = {
+    val importedModules = importResolver.mapImports(module)
+
+    val requiredModules =
+      try { new ExportsResolution().run(importedModules) }
+      catch { case e: ExportCycleException => reportCycle(e) }
+
+    requiredModules
+  }
+
   private def parseModule(
     module: Module,
     isGenDocs: Boolean = false
   ): Unit = {
+    logger.log(
+      Compiler.defaultLogLevel,
+      s"Parsing the module [${module.getName}]."
+    )
     module.ensureScopeExists()
     module.getScope.reset()
 
-    module.getCache.load(context) match {
-      case Some(ModuleCache.CachedModule(ir, stage)) if irCachingEnabled =>
-        module.unsafeSetIr(ir)
-        module.unsafeSetCompilationStage(stage)
-        throw new CompilerError(
-          "Caching should not yet be enabled in production."
-        )
-      case _ =>
-        val moduleContext = ModuleContext(
-          module           = module,
-          freshNameSupply  = Some(freshNameSupply),
-          compilerConfig   = config,
-          isGeneratingDocs = isGenDocs
-        )
-        val parsedAST        = parse(module.getSource)
-        val expr             = generateIR(parsedAST)
-        val discoveredModule = recognizeBindings(expr, moduleContext)
-        module.unsafeSetIr(discoveredModule)
-        module.unsafeSetCompilationStage(Module.CompilationStage.AFTER_PARSING)
+    if (irCachingEnabled) {
+      serializationManager.deserialize(module) match {
+        case Some(_) => return
+        case _       =>
+      }
     }
+
+    uncachedParseModule(module, isGenDocs)
+  }
+
+  private def uncachedParseModule(module: Module, isGenDocs: Boolean): Unit = {
+    logger.log(
+      Compiler.defaultLogLevel,
+      s"Loading module `${module.getName}` from source."
+    )
+    module.ensureScopeExists()
+    module.getScope.reset()
+
+    val moduleContext = ModuleContext(
+      module           = module,
+      freshNameSupply  = Some(freshNameSupply),
+      compilerConfig   = config,
+      isGeneratingDocs = isGenDocs
+    )
+    val parsedAST        = parse(module.getSource)
+    val expr             = generateIR(parsedAST)
+    val discoveredModule = recognizeBindings(expr, moduleContext)
+    module.unsafeSetIr(discoveredModule)
+    module.unsafeSetCompilationStage(Module.CompilationStage.AFTER_PARSING)
+    module.setHasCrossModuleLinks(true)
   }
 
   /** Gets a module definition by name.
@@ -361,9 +454,13 @@ class Compiler(
     modules: List[Module]
   ): Unit = {
     if (context.isStrictErrors) {
-      val diagnostics = modules.map { module =>
-        val errors = gatherDiagnostics(module)
-        (module, errors)
+      val diagnostics = modules.flatMap { module =>
+        if (module == builtins.getModule) {
+          List()
+        } else {
+          val errors = gatherDiagnostics(module)
+          List((module, errors))
+        }
       }
       if (reportDiagnostics(diagnostics)) {
         throw new CompilationAbortedException
@@ -389,7 +486,7 @@ class Compiler(
       .diagnostics
   }
 
-  private def hasErrors(module: Module): Boolean =
+  @unused private def hasErrors(module: Module): Boolean =
     gatherDiagnostics(module).exists {
       case _: IR.Error => true
       case _           => false
@@ -553,4 +650,28 @@ class Compiler(
   def shutdown(waitForPendingJobCompletion: Boolean): Unit = {
     serializationManager.shutdown(waitForPendingJobCompletion)
   }
+
+  /** Updates the metadata in a copy of the IR when updating that metadata
+    * requires global state.
+    *
+    * This is usually the case in the presence of structures that are shared
+    * throughout the IR, and need to maintain that sharing for correctness. This
+    * must be called with `copyOfIr` as the result of an `ir.duplicate` call.
+    *
+    * Additionally this method _must not_ alter the structure of the IR. It
+    * should only update its metadata.
+    *
+    * @param sourceIr the IR being copied
+    * @param copyOfIr a duplicate of `sourceIr`
+    * @return the result of updating metadata in `copyOfIr` globally using
+    *         information from `sourceIr`
+    */
+  def updateMetadata(sourceIr: IR.Module, copyOfIr: IR.Module): IR.Module = {
+    passManager.runMetadataUpdate(sourceIr, copyOfIr)
+  }
+}
+object Compiler {
+
+  /** The default logging level for the compiler. */
+  private val defaultLogLevel: Level = Level.FINE
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -110,23 +110,23 @@ class Compiler(
 
     var hasInvalidModuleRelink = false
     if (irCachingEnabled && irCacheReadingEnabled) {
-      requiredModules.foreach { m =>
-        if (!m.hasCrossModuleLinks) {
+      requiredModules.foreach { module =>
+        if (!module.hasCrossModuleLinks) {
           val flags =
-            m.getIr.preorder.map(_.passData.restoreFromSerialization(this))
+            module.getIr.preorder.map(_.passData.restoreFromSerialization(this))
 
           if (!flags.contains(false)) {
             logger.log(
               Compiler.defaultLogLevel,
-              s"Restored links (late phase) for module [${m.getName}]."
+              s"Restored links (late phase) for module [${module.getName}]."
             )
           } else {
             hasInvalidModuleRelink = true
             logger.log(
               Compiler.defaultLogLevel,
-              s"Failed to restore links (late phase) for module [${m.getName}]."
+              s"Failed to restore links (late phase) for module [${module.getName}]."
             )
-            uncachedParseModule(m, isGenDocs = false)
+            uncachedParseModule(module, isGenDocs = false)
           }
         }
       }

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -124,7 +124,8 @@ class Compiler(
             hasInvalidModuleRelink = true
             logger.log(
               Compiler.defaultLogLevel,
-              s"Failed to restore links (late phase) for module [${module.getName}]."
+              s"Failed to restore links (late phase) for module " +
+              s"[${module.getName}]."
             )
             uncachedParseModule(module, isGenDocs = false)
           }
@@ -229,7 +230,7 @@ class Compiler(
     module.ensureScopeExists()
     module.getScope.reset()
 
-    if (irCachingEnabled && irCacheReadingEnabled) {
+    if (irCachingEnabled && irCacheReadingEnabled && !module.isInteractive) {
       serializationManager.deserialize(module) match {
         case Some(_) => return
         case _       =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/Passes.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Passes.scala
@@ -90,6 +90,9 @@ class Passes(
     List(moduleDiscoveryPasses, functionBodyPasses)
   )
 
+  /** The ordered representation of all passes run by the compiler. */
+  val allPassOrdering: List[IRPass] = passOrdering.flatMap(_.passes)
+
   /** Configuration for the passes. */
   private val passConfig: PassConfiguration = PassConfiguration(
     ApplicationSaturation -->> ApplicationSaturation.Configuration(),

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -218,7 +218,8 @@ class IrToTruffle(
       val scopeInfo = methodDef
         .unsafeGetMetadata(
           AliasAnalysis,
-          "Missing scope information for method."
+          s"Missing scope information for method " +
+          s"`${methodDef.typeName.name}.${methodDef.methodName.name}`."
         )
         .unsafeAs[AliasAnalysis.Info.Scope.Root]
       val dataflowInfo = methodDef.unsafeGetMetadata(

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/ir/MetadataStorage.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/ir/MetadataStorage.scala
@@ -14,7 +14,8 @@ import org.enso.compiler.pass.IRPass
 class MetadataStorage(
   startingMeta: Seq[MetadataPair[_]] = Seq()
 ) extends Serializable {
-  private var metadata: Map[IRPass, Any] = Map(
+  // TODO [AA] Restore private
+  var metadata: Map[IRPass, Any] = Map(
     startingMeta.map(_.asPair.asInstanceOf[(IRPass, Any)]): _*
   )
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/ir/MetadataStorage.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/ir/MetadataStorage.scala
@@ -14,8 +14,7 @@ import org.enso.compiler.pass.IRPass
 class MetadataStorage(
   startingMeta: Seq[MetadataPair[_]] = Seq()
 ) extends Serializable {
-  // TODO [AA] Restore private
-  var metadata: Map[IRPass, Any] = Map(
+  private var metadata: Map[IRPass, Any] = Map(
     startingMeta.map(_.asPair.asInstanceOf[(IRPass, Any)]): _*
   )
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -418,9 +418,11 @@ object BindingsMap {
         * @return `this` with its resolution made concrete
         */
       def toConcrete(moduleMap: ModuleMap): Option[AllowedResolution] = {
-        resolution.flatMap(res =>
-          res.toConcrete(moduleMap).map(r => this.copy(resolution = Some(r)))
-        )
+        resolution match {
+          case None => Some(this)
+          case Some(res) =>
+            res.toConcrete(moduleMap).map(r => this.copy(resolution = Some(r)))
+        }
       }
     }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/IRPass.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/IRPass.scala
@@ -60,6 +60,24 @@ trait IRPass extends Serializable {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression
+
+  /** Updates the metadata in a copy of the IR when updating that metadata
+    * requires global state.
+    *
+    * This is usually the case in the presence of structures that are shared
+    * throughout the IR, and need to maintain that sharing for correctness. This
+    * must be called with `copyOfIr` as the result of an `ir.duplicate` call.
+    *
+    * Additionally this method _must not_ alter the structure of the IR. It
+    * should only update its metadata.
+    *
+    * @param sourceIr the IR being copied
+    * @param copyOfIr a duplicate of `sourceIr`
+    * @tparam T the concrete [[IR]] type
+    * @return the result of updating metadata in `copyOfIr` globally using
+    *         information from `sourceIr`
+    */
+  def updateMetadataInDuplicate[T <: IR](sourceIr: T, copyOfIr: T): T
 }
 object IRPass {
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/PassManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/PassManager.scala
@@ -172,6 +172,27 @@ class PassManager(
 
     ix - totalLength == indexOfPassInGroup
   }
+
+  /** Updates the metadata in a copy of the IR when updating that metadata
+    * requires global state.
+    *
+    * This is usually the case in the presence of structures that are shared
+    * throughout the IR, and need to maintain that sharing for correctness. This
+    * must be called with `copyOfIr` as the result of an `ir.duplicate` call.
+    *
+    * Additionally this method _must not_ alter the structure of the IR. It
+    * should only update its metadata.
+    *
+    * @param sourceIr the IR being copied
+    * @param copyOfIr a duplicate of `sourceIr`
+    * @return the result of updating metadata in `copyOfIr` globally using
+    *         information from `sourceIr`
+    */
+  def runMetadataUpdate(sourceIr: IR.Module, copyOfIr: IR.Module): IR.Module = {
+    allPasses.foldLeft(copyOfIr) { (module, pass) =>
+      pass.updateMetadataInDuplicate(sourceIr, module)
+    }
+  }
 }
 
 /** A representation of a group of passes.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AutomaticParallelism.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AutomaticParallelism.scala
@@ -4,7 +4,15 @@ import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.Module.Scope.Definition
 import org.enso.compiler.core.IR.Module.Scope.Definition.Method
-import org.enso.compiler.core.IR.{Application, CallArgument, Case, DefinitionArgument, Error, Name, Type}
+import org.enso.compiler.core.IR.{
+  Application,
+  CallArgument,
+  Case,
+  DefinitionArgument,
+  Error,
+  Name,
+  Type
+}
 import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.analyse.DataflowAnalysis.DependencyInfo
@@ -77,6 +85,12 @@ object AutomaticParallelism extends IRPass {
     ir: IR.Expression,
     @unused inlineContext: InlineContext
   ): IR.Expression = ir
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   // If I can do the limited form, then it is sufficient to have spawn/await on
   //  bindings combined with liberal inlining of the other parts of the
@@ -275,9 +289,10 @@ object AutomaticParallelism extends IRPass {
         )
         .newName()
     )
-    @unused val bindings = bindingNames.zip(app.arguments).map { case (bindName, arg) =>
-      makeInlinedBindingFor(bindName, arg, mutData, dataflow)
-    }
+    @unused val bindings =
+      bindingNames.zip(app.arguments).map { case (bindName, arg) =>
+        makeInlinedBindingFor(bindName, arg, mutData, dataflow)
+      }
 
     // Rewrite the application to use the bindings
     val newArgs = app.arguments.zip(bindingNames).map {
@@ -316,7 +331,7 @@ object AutomaticParallelism extends IRPass {
       case cse: IR.Case                         => cse
       case block: IR.Expression.Block           => block
       case binding: IR.Expression.Binding       => binding
-      case a => a
+      case a                                    => a
     }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
@@ -13,6 +13,8 @@ import org.enso.compiler.pass.desugar.{
 }
 import org.enso.compiler.pass.resolve.{MethodDefinitions, Patterns}
 
+import scala.annotation.unused
+
 /** Recognizes all defined bindings in the current module and constructs
   * a mapping data structure that can later be used for symbol resolution.
   */
@@ -101,4 +103,9 @@ case object BindingAnalysis extends IRPass {
     inlineContext: InlineContext
   ): IR.Expression = ir
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/CachePreferenceAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/CachePreferenceAnalysis.scala
@@ -1,23 +1,16 @@
 package org.enso.compiler.pass.analyse
 
 import org.enso.compiler.Compiler
-
-import java.util
-import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.Module.Scope.Definition.Method
 import org.enso.compiler.core.ir.MetadataStorage._
+import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.IRPass
-import org.enso.compiler.pass.desugar.{
-  ComplexType,
-  FunctionBinding,
-  GenerateMethodBodies,
-  LambdaShorthandToLambda,
-  OperatorToFunction,
-  SectionsToBinOp
-}
+import org.enso.compiler.pass.desugar._
 
+import java.util
+import scala.annotation.unused
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
@@ -74,6 +67,12 @@ case object CachePreferenceAnalysis extends IRPass {
     inlineContext: InlineContext
   ): IR.Expression =
     analyseExpression(ir, WeightInfo())
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   // === Pass Internals =======================================================
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
@@ -7,6 +7,8 @@ import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.optimise.LambdaConsolidate
 import org.enso.compiler.pass.resolve.OverloadsResolution
 
+import scala.annotation.unused
+
 /** This pass implements demand analysis for Enso.
   *
   * Demand analysis is the process of determining _when_ a suspended term needs
@@ -73,6 +75,12 @@ case object DemandAnalysis extends IRPass {
       expression,
       isInsideCallArgument = false
     )
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   /** Performs demand analysis on an arbitrary program expression.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/GatherDiagnostics.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/GatherDiagnostics.scala
@@ -6,6 +6,8 @@ import org.enso.compiler.core.IR
 import org.enso.compiler.core.ir.MetadataStorage._
 import org.enso.compiler.pass.IRPass
 
+import scala.annotation.unused
+
 /** A pass that traverses the given root IR and accumulates all the encountered
   * diagnostic nodes in the root.
   *
@@ -47,6 +49,12 @@ case object GatherDiagnostics extends IRPass {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression = ir.updateMetadata(this -->> gatherMetadata(ir))
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   /** Gathers diagnostics from all children of an IR node.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
@@ -10,6 +10,8 @@ import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.desugar._
 import org.enso.compiler.pass.resolve.ExpressionAnnotations
 
+import scala.annotation.unused
+
 /** This pass performs tail call analysis on the Enso IR.
   *
   * It is responsible for marking every single expression with whether it is in
@@ -73,6 +75,12 @@ case object TailCall extends IRPass {
         )
       )
     )
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   /** Performs tail call analysis on a top-level definition in a module.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/UndefinedVariables.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/UndefinedVariables.scala
@@ -5,6 +5,8 @@ import org.enso.compiler.core.IR
 import org.enso.compiler.core.ir.MetadataStorage._
 import org.enso.compiler.pass.IRPass
 
+import scala.annotation.unused
+
 /** Reports errors for local variables that are not linked to a definition
   *  after Alias Analysis.
   */
@@ -49,6 +51,12 @@ case object UndefinedVariables extends IRPass {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression = analyseExpression(ir)
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   private def analyseExpression(ir: IR.Expression): IR.Expression =
     ir.transformExpressions { case name: IR.Name.Literal =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/ComplexType.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/ComplexType.scala
@@ -93,6 +93,12 @@ case object ComplexType extends IRPass {
     @unused inlineContext: InlineContext
   ): IR.Expression = ir
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
+
   // === Pass Internals =======================================================
 
   /** Desugars a complex type definition into a series of top-level definitions.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
@@ -77,6 +77,12 @@ case object FunctionBinding extends IRPass {
     @unused inlineContext: InlineContext
   ): IR.Expression = desugarExpression(ir)
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
+
   // === Pass Internals =======================================================
 
   /** Performs desugaring on an arbitrary Enso expression.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
@@ -13,6 +13,8 @@ import org.enso.compiler.pass.analyse.{
 import org.enso.compiler.pass.lint.UnusedBindings
 import org.enso.compiler.pass.optimise.LambdaConsolidate
 
+import scala.annotation.unused
+
 /** This pass is responsible for ensuring that method bodies are in the correct
   * format.
   *
@@ -175,6 +177,12 @@ case object GenerateMethodBodies extends IRPass {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression = ir
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   /** Collects the argument list of a chain of function definitions.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
@@ -4,6 +4,8 @@ import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
 import org.enso.compiler.pass.IRPass
 
+import scala.annotation.unused
+
 /** Desugars shorthand syntaxes in import and export statements.
   */
 case object Imports extends IRPass {
@@ -103,6 +105,12 @@ case object Imports extends IRPass {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression = ir
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   private def computeRename(
     originalRename: Option[IR.Name.Literal],

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
@@ -21,6 +21,8 @@ import org.enso.compiler.pass.resolve.{
   OverloadsResolution
 }
 
+import scala.annotation.unused
+
 /** This pass translates `_` arguments at application sites to lambda functions.
   *
   * This pass has no configuration.
@@ -104,6 +106,12 @@ case object LambdaShorthandToLambda extends IRPass {
     desugarExpression(ir, freshNameSupply)
   }
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
+
   // === Pass Internals =======================================================
 
   /** Performs lambda shorthand desugaring on an arbitrary expression.
@@ -145,7 +153,7 @@ case object LambdaShorthandToLambda extends IRPass {
                 isMethod   = false,
                 None
               ),
-              ascribedType       = None,
+              ascribedType = None,
               defaultValue = None,
               suspended    = false,
               location     = None
@@ -268,7 +276,7 @@ case object LambdaShorthandToLambda extends IRPass {
         bindings.foldLeft(newVec: IR.Expression) { (body, bindingName) =>
           val defArg = IR.DefinitionArgument.Specified(
             bindingName,
-            ascribedType       = None,
+            ascribedType = None,
             defaultValue = None,
             suspended    = false,
             location     = None

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
@@ -144,6 +144,12 @@ case object NestedPatternMatch extends IRPass {
     }
   }
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
+
   // === Pass Internals =======================================================
 
   /** Desugars an arbitrary expression.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/OperatorToFunction.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/OperatorToFunction.scala
@@ -9,6 +9,8 @@ import org.enso.compiler.pass.analyse.{
   DemandAnalysis
 }
 
+import scala.annotation.unused
+
 /** This pass converts usages of operators to calls to standard functions.
   *
   * This pass requires the context to provide:
@@ -86,4 +88,10 @@ case object OperatorToFunction extends IRPass {
           diag
         )
     }
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/SectionsToBinOp.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/SectionsToBinOp.scala
@@ -8,6 +8,8 @@ import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.analyse._
 import org.enso.compiler.pass.lint.UnusedBindings
 
+import scala.annotation.unused
+
 /** This pass converts operator sections to applications of binary operators.
   *
   * This pass has no configuration.
@@ -50,7 +52,7 @@ case object SectionsToBinOp extends IRPass {
         new InlineContext(
           moduleContext.module,
           freshNameSupply = moduleContext.freshNameSupply,
-          compilerConfig = moduleContext.compilerConfig
+          compilerConfig  = moduleContext.compilerConfig
         )
       )
     )
@@ -77,6 +79,12 @@ case object SectionsToBinOp extends IRPass {
       desugarSections(sec, freshNameSupply)
     }
   }
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   /** Desugars operator sections to fully-saturated applications of operators.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/ShadowedPatternFields.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/ShadowedPatternFields.scala
@@ -76,6 +76,12 @@ case object ShadowedPatternFields extends IRPass {
     }
   }
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
+
   // === Pass Internals =======================================================
 
   /** Lints for shadowed pattern variables on an arbitrary expression.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
@@ -77,6 +77,12 @@ case object UnusedBindings extends IRPass {
     }
   } else ir
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
+
   // === Pass Internals =======================================================
 
   /** Lints a binding.
@@ -123,7 +129,7 @@ case object UnusedBindings extends IRPass {
     */
   def lintFunction(
     function: IR.Function,
-    @unused context: InlineContext
+    context: InlineContext
   ): IR.Function = {
     function match {
       case IR.Function.Lambda(_, _: IR.Foreign.Definition, _, _, _, _) =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/ApplicationSaturation.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/ApplicationSaturation.scala
@@ -12,6 +12,8 @@ import org.enso.interpreter.node.{ExpressionNode => RuntimeExpression}
 import org.enso.interpreter.runtime.callable.argument.CallArgument
 import org.enso.interpreter.runtime.scope.{LocalScope, ModuleScope}
 
+import scala.annotation.unused
+
 /** This optimisation pass recognises fully-saturated applications of known
   * functions and writes analysis data that allows optimisation of them to
   * specific nodes at codegen time.
@@ -178,6 +180,12 @@ case object ApplicationSaturation extends IRPass {
         }
     }
   }
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   /** Configuration for this pass
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
@@ -15,6 +15,8 @@ import org.enso.compiler.pass.desugar._
 import org.enso.compiler.pass.resolve.IgnoredBindings
 import org.enso.syntax.text.Location
 
+import scala.annotation.unused
+
 /** This pass consolidates chains of lambdas into multi-argument lambdas
   * internally.
   *
@@ -108,6 +110,12 @@ case object LambdaConsolidate extends IRPass {
       collapseFunction(fn, inlineContext, freshNameSupply)
     }
   }
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   /** Collapses chained lambdas for a function definition where possible.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/UnreachableMatchBranches.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/UnreachableMatchBranches.scala
@@ -89,6 +89,12 @@ case object UnreachableMatchBranches extends IRPass {
     }
   }
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
+
   // === Pass Internals =======================================================
 
   /** Optimizes an expression by removing unreachable branches in case

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/DocumentationComments.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/DocumentationComments.scala
@@ -9,6 +9,8 @@ import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.desugar.{ComplexType, GenerateMethodBodies}
 
+import scala.annotation.unused
+
 /** Associates doc comments with the commented entities as metadata.
   *
   * If the first module definition is a documentation comment, it is treated as
@@ -56,6 +58,12 @@ case object DocumentationComments extends IRPass {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression = resolveExpression(ir)
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   // === Pass Internals =======================================================
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/ExpressionAnnotations.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/ExpressionAnnotations.scala
@@ -8,6 +8,8 @@ import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.analyse.AliasAnalysis
 import org.enso.compiler.pass.resolve.ModuleAnnotations.Annotations
 
+import scala.annotation.unused
+
 case object ExpressionAnnotations extends IRPass {
   val tailCallName      = "@Tail_Call"
   val builtinMethodName = "@Builtin_Method"
@@ -57,6 +59,12 @@ case object ExpressionAnnotations extends IRPass {
   ): IR.Expression = {
     doExpression(ir)
   }
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   private def doExpression(
     ir: IR.Expression

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/GenerateDocumentation.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/GenerateDocumentation.scala
@@ -6,6 +6,8 @@ import org.enso.compiler.core.ir.MetadataStorage.ToPair
 import org.enso.compiler.pass.IRPass
 import org.enso.docs.generator.DocParserWrapper
 
+import scala.annotation.unused
+
 /** Generates documentation on resolved IR.
   */
 case object GenerateDocumentation extends IRPass {
@@ -53,6 +55,12 @@ case object GenerateDocumentation extends IRPass {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression = ir
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   // === Pass Internals =======================================================
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
@@ -20,6 +20,8 @@ import org.enso.compiler.pass.desugar.{
   NestedPatternMatch
 }
 
+import scala.annotation.unused
+
 /** This pass translates ignored bindings (of the form `_`) into fresh names
   * internally, as well as marks all bindings as whether or not they were
   * ignored.
@@ -93,6 +95,12 @@ case object IgnoredBindings extends IRPass {
       resolveExpression(ir, freshNameSupply)
     } else ir
   }
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   // === Pass Internals =======================================================
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/MethodDefinitions.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/MethodDefinitions.scala
@@ -13,6 +13,8 @@ import org.enso.compiler.pass.desugar.{
   GenerateMethodBodies
 }
 
+import scala.annotation.unused
+
 /** Resolves the correct `this` argument type for method definitions and stores
   * the resolution in the method's metadata.
   */
@@ -154,4 +156,9 @@ case object MethodDefinitions extends IRPass {
     inlineContext: InlineContext
   ): IR.Expression = ir
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/ModuleAnnotations.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/ModuleAnnotations.scala
@@ -104,6 +104,12 @@ case object ModuleAnnotations extends IRPass {
     @unused inlineContext: InlineContext
   ): IR.Expression = ir
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
+
   /** A container for annotations on an IR construct.
     *
     * @param annotations the initial annotations for the container
@@ -133,7 +139,7 @@ case object ModuleAnnotations extends IRPass {
     override def restoreFromSerialization(
       compiler: Compiler
     ): Option[IRPass.Metadata] = {
-      annotations.foreach{ ann =>
+      annotations.foreach { ann =>
         ann.preorder.foreach { ir =>
           if (!ir.passData.restoreFromSerialization(compiler)) {
             return None

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/ModuleThisToHere.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/ModuleThisToHere.scala
@@ -8,6 +8,8 @@ import org.enso.compiler.exception.CompilerError
 import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.analyse.AliasAnalysis
 
+import scala.annotation.unused
+
 /** Performs a substitution of `this` to `here` in methods defined on the
   * current module.
   *
@@ -89,4 +91,10 @@ case object ModuleThisToHere extends IRPass {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression = ir
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/OverloadsResolution.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/OverloadsResolution.scala
@@ -121,4 +121,10 @@ case object OverloadsResolution extends IRPass {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression = ir
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/Patterns.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/Patterns.scala
@@ -9,6 +9,8 @@ import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.analyse.{AliasAnalysis, BindingAnalysis}
 import org.enso.compiler.pass.desugar.{GenerateMethodBodies, NestedPatternMatch}
 
+import scala.annotation.unused
+
 /** Resolves constructors in pattern matches and validates their arity.
   */
 object Patterns extends IRPass {
@@ -59,6 +61,12 @@ object Patterns extends IRPass {
     )
     doExpression(ir, bindings)
   }
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   private def doExpression(
     expr: IR.Expression,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/SuspendedArguments.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/SuspendedArguments.scala
@@ -88,6 +88,12 @@ case object SuspendedArguments extends IRPass {
     @unused inlineContext: InlineContext
   ): IR.Expression = resolveExpression(ir)
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
+
   // === Pass Internals =======================================================
 
   /** Resolves suspended arguments for a module binding.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeFunctions.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeFunctions.scala
@@ -56,8 +56,8 @@ case object TypeFunctions extends IRPass {
     @unused moduleContext: ModuleContext
   ): IR.Module = {
     val new_bindings = ir.bindings.map {
-      case asc:IR.Type.Ascription => asc
-      case a => a.mapExpressions(resolveExpression)
+      case asc: IR.Type.Ascription => asc
+      case a                       => a.mapExpressions(resolveExpression)
     }
     ir.copy(bindings = new_bindings)
   }
@@ -77,6 +77,12 @@ case object TypeFunctions extends IRPass {
     ir.transformExpressions { case a =>
       resolveExpression(a)
     }
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   // === Pass Internals =======================================================
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeSignatures.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeSignatures.scala
@@ -65,6 +65,12 @@ case object TypeSignatures extends IRPass {
     @unused inlineContext: InlineContext
   ): IR.Expression = resolveExpression(ir)
 
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
+
   // === Pass Internals =======================================================
 
   /** Resolves type signatures in a module.
@@ -261,7 +267,7 @@ case object TypeSignatures extends IRPass {
     override def restoreFromSerialization(
       compiler: Compiler
     ): Option[Signature] = {
-      signature.preorder.foreach{node =>
+      signature.preorder.foreach { node =>
         if (!node.passData.restoreFromSerialization(compiler)) {
           return None
         }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/UppercaseNames.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/UppercaseNames.scala
@@ -14,6 +14,8 @@ import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.analyse.{AliasAnalysis, BindingAnalysis}
 import org.enso.interpreter.Constants
 
+import scala.annotation.unused
+
 /** Resolves and desugars referent name occurences in non-pattern contexts.
   *
   * 1. Attaches resolution metadata to encountered constructors, modules,
@@ -90,6 +92,12 @@ case object UppercaseNames extends IRPass {
     )
     processExpression(ir, scopeMap, freshNameSupply)
   }
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   private def processModuleDefinition(
     definition: IR.Module.Scope.Definition,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/VectorLiterals.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/VectorLiterals.scala
@@ -9,6 +9,8 @@ import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.analyse.BindingAnalysis
 import org.enso.interpreter.runtime.Module
 
+import scala.annotation.unused
+
 case object VectorLiterals extends IRPass {
 
   /** The type of the metadata object that the pass writes to the IR. */
@@ -67,6 +69,12 @@ case object VectorLiterals extends IRPass {
     val vec = vectorCons(bindings)
     doExpression(ir, vec)
   }
+
+  /** @inheritdoc */
+  override def updateMetadataInDuplicate[T <: IR](
+    @unused sourceIr: T,
+    copyOfIr: T
+  ): T = copyOfIr
 
   private def vectorCons(bindings: BindingsMap): IR.Expression = {
     val modules: List[Module] = bindings.resolvedImports.flatMap { imp =>

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/PassesTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/PassesTest.scala
@@ -30,6 +30,11 @@ class PassesTest extends CompilerTest {
       ir: IR.Expression,
       inlineContext: InlineContext
     ): IR.Expression = ir
+
+    override def updateMetadataInDuplicate[T <: IR](
+      sourceIr: T,
+      copyOfIr: T
+    ): T = copyOfIr
   }
 
   // === The Tests ============================================================

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/ir/MetadataStorageTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/ir/MetadataStorageTest.scala
@@ -31,6 +31,11 @@ class MetadataStorageTest extends CompilerTest {
       inlineContext: InlineContext
     ): IR.Expression = ir
 
+    override def updateMetadataInDuplicate[T <: IR](
+      sourceIr: T,
+      copyOfIr: T
+    ): T = copyOfIr
+
     sealed case class Metadata1() extends IRPass.Metadata {
       override val metadataName: String = "TestPass1.Metadata1"
 
@@ -62,6 +67,11 @@ class MetadataStorageTest extends CompilerTest {
       ir: IR.Expression,
       inlineContext: InlineContext
     ): IR.Expression = ir
+
+    override def updateMetadataInDuplicate[T <: IR](
+      sourceIr: T,
+      copyOfIr: T
+    ): T = copyOfIr
 
     sealed case class Metadata2() extends IRPass.Metadata {
       override val metadataName: String = "TestPass2.Metadata2"

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/PassConfigurationTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/PassConfigurationTest.scala
@@ -28,6 +28,11 @@ class PassConfigurationTest extends CompilerTest {
       inlineContext: InlineContext
     ): IR.Expression = ir
 
+    override def updateMetadataInDuplicate[T <: IR](
+      sourceIr: T,
+      copyOfIr: T
+    ): T = copyOfIr
+
     sealed case class Configuration1() extends IRPass.Configuration {
       override var shouldWriteToContext: Boolean = false
     }
@@ -49,6 +54,11 @@ class PassConfigurationTest extends CompilerTest {
       ir: IR.Expression,
       inlineContext: InlineContext
     ): IR.Expression = ir
+
+    override def updateMetadataInDuplicate[T <: IR](
+      sourceIr: T,
+      copyOfIr: T
+    ): T = copyOfIr
 
     sealed case class Configuration2() extends IRPass.Configuration {
       override var shouldWriteToContext: Boolean = true

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/AliasAnalysisTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/AliasAnalysisTest.scala
@@ -193,7 +193,7 @@ class AliasAnalysisTest extends CompilerTest {
     }
 
     "allow itself to be copied deeply" in {
-      val complexScopeCopy = complexScope.copy
+      val complexScopeCopy = complexScope.deepCopy()
 
       complexScopeCopy shouldEqual complexScope
     }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
@@ -28,6 +28,7 @@ trait PackageTest extends AnyFlatSpec with Matchers with ValueEquality {
         Paths.get("../../distribution/component").toFile.getAbsolutePath
       )
       .option(RuntimeOptions.STRICT_ERRORS, "true")
+      .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
       .out(output)
       .in(System.in)
       .option(RuntimeOptions.LOG_LEVEL, "WARNING")

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -64,6 +64,7 @@ class RuntimeErrorsTest
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
+        .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
         .option(RuntimeServerInfo.ENABLE_OPTION, "true")
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
@@ -58,6 +58,7 @@ class RuntimeInstrumentTest
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
+        .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
         .option(RuntimeServerInfo.ENABLE_OPTION, "true")
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -62,6 +62,7 @@ class RuntimeServerTest
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
+        .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
         .option(RuntimeServerInfo.ENABLE_OPTION, "true")
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeStdlibTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeStdlibTest.scala
@@ -60,6 +60,7 @@ class RuntimeStdlibTest
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeServerInfo.ENABLE_OPTION, "true")
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
+        .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -50,6 +50,7 @@ class RuntimeSuggestionUpdatesTest
         .option(RuntimeOptions.LOG_LEVEL, "WARNING")
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
+        .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
         .option(RuntimeServerInfo.ENABLE_OPTION, "true")
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualisationsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualisationsTest.scala
@@ -63,6 +63,7 @@ class RuntimeVisualisationsTest
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
         .option(RuntimeServerInfo.ENABLE_OPTION, "true")
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
+        .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
         .option(
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
           Paths.get("../../distribution/component").toFile.getAbsolutePath

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -45,44 +45,42 @@ import project.System.Process_Spec
 
 import project.Examples_Spec
 
-main = IO.println "DONE"
-
-# main = Test.Suite.run_main <|
-    # Any_Spec.spec
-    # Array_Spec.spec
-    # Case_Spec.spec
-    # Deep_Export_Spec.spec
-    # Error_Spec.spec
-    # Examples_Spec.spec
-    # File_Spec.spec
-    # Http_Header_Spec.spec
-    # Http_Request_Spec.spec
-    # Http_Spec.spec
-    # Import_Loop_Spec.spec
-    # Interval_Spec.spec
-    # Java_Interop_Spec.spec
-    # Js_Interop_Spec.spec
-    # Json_Spec.spec
-    # List_Spec.spec
-    # Locale_Spec.spec
-    # Map_Spec.spec
-    # Maybe_Spec.spec
-    # Meta_Spec.spec
-    # Names_Spec.spec
-    # Noise_Generator_Spec.spec
-    # Noise_Spec.spec
-    # Numbers_Spec.spec
-    # Ordering_Spec.spec
-    # Process_Spec.spec
-    # Python_Interop_Spec.spec
-    # R_Interop_Spec.spec
-    # Range_Spec.spec
-    # Default_Regex_Engine_Spec.spec
-    # Regex_Spec.spec
-    # Runtime_Spec.spec
-    # Span_Spec.spec
-    # Text_Spec.spec
-    # Time_Spec.spec
-    # Uri_Spec.spec
-    # Vector_Spec.spec
+Main = Test.Suite.run_main <|
+    Any_Spec.spec
+    Array_Spec.spec
+    Case_Spec.spec
+    Deep_Export_Spec.spec
+    Error_Spec.spec
+    Examples_Spec.spec
+    File_Spec.spec
+    Http_Header_Spec.spec
+    Http_Request_Spec.spec
+    Http_Spec.spec
+    Import_Loop_Spec.spec
+    Interval_Spec.spec
+    Java_Interop_Spec.spec
+    Js_Interop_Spec.spec
+    Json_Spec.spec
+    List_Spec.spec
+    Locale_Spec.spec
+    Map_Spec.spec
+    Maybe_Spec.spec
+    Meta_Spec.spec
+    Names_Spec.spec
+    Noise_Generator_Spec.spec
+    Noise_Spec.spec
+    Numbers_Spec.spec
+    Ordering_Spec.spec
+    Process_Spec.spec
+    Python_Interop_Spec.spec
+    R_Interop_Spec.spec
+    Range_Spec.spec
+    Default_Regex_Engine_Spec.spec
+    Regex_Spec.spec
+    Runtime_Spec.spec
+    Span_Spec.spec
+    Text_Spec.spec
+    Time_Spec.spec
+    Uri_Spec.spec
+    Vector_Spec.spec
 

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -45,42 +45,44 @@ import project.System.Process_Spec
 
 import project.Examples_Spec
 
-main = Test.Suite.run_main <|
-    Any_Spec.spec
-    Array_Spec.spec
-    Case_Spec.spec
-    Deep_Export_Spec.spec
-    Error_Spec.spec
-    Examples_Spec.spec
-    File_Spec.spec
-    Http_Header_Spec.spec
-    Http_Request_Spec.spec
-    Http_Spec.spec
-    Import_Loop_Spec.spec
-    Interval_Spec.spec
-    Java_Interop_Spec.spec
-    Js_Interop_Spec.spec
-    Json_Spec.spec
-    List_Spec.spec
-    Locale_Spec.spec
-    Map_Spec.spec
-    Maybe_Spec.spec
-    Meta_Spec.spec
-    Names_Spec.spec
-    Noise_Generator_Spec.spec
-    Noise_Spec.spec
-    Numbers_Spec.spec
-    Ordering_Spec.spec
-    Process_Spec.spec
-    Python_Interop_Spec.spec
-    R_Interop_Spec.spec
-    Range_Spec.spec
-    Default_Regex_Engine_Spec.spec
-    Regex_Spec.spec
-    Runtime_Spec.spec
-    Span_Spec.spec
-    Text_Spec.spec
-    Time_Spec.spec
-    Uri_Spec.spec
-    Vector_Spec.spec
+main = IO.println "DONE"
+
+# main = Test.Suite.run_main <|
+    # Any_Spec.spec
+    # Array_Spec.spec
+    # Case_Spec.spec
+    # Deep_Export_Spec.spec
+    # Error_Spec.spec
+    # Examples_Spec.spec
+    # File_Spec.spec
+    # Http_Header_Spec.spec
+    # Http_Request_Spec.spec
+    # Http_Spec.spec
+    # Import_Loop_Spec.spec
+    # Interval_Spec.spec
+    # Java_Interop_Spec.spec
+    # Js_Interop_Spec.spec
+    # Json_Spec.spec
+    # List_Spec.spec
+    # Locale_Spec.spec
+    # Map_Spec.spec
+    # Maybe_Spec.spec
+    # Meta_Spec.spec
+    # Names_Spec.spec
+    # Noise_Generator_Spec.spec
+    # Noise_Spec.spec
+    # Numbers_Spec.spec
+    # Ordering_Spec.spec
+    # Process_Spec.spec
+    # Python_Interop_Spec.spec
+    # R_Interop_Spec.spec
+    # Range_Spec.spec
+    # Default_Regex_Engine_Spec.spec
+    # Regex_Spec.spec
+    # Runtime_Spec.spec
+    # Span_Spec.spec
+    # Text_Spec.spec
+    # Time_Spec.spec
+    # Uri_Spec.spec
+    # Vector_Spec.spec
 


### PR DESCRIPTION
### Pull Request Description
The previous PR (#1991) enabled the writing of IR caches to disk. This PR implements the reading and usage of these caches to drastically speed up the interpreter boot. It cuts what is usually a ~30s boot on my machine to 3-4 seconds depending on load. Note that this speedup does not touch the boot of the Language Server which now dominates IDE project start.

Closes #1873.

### Important Notes
Currently the runtime has no means to pre-generate the IR caches. This means that they will be generated on first run and then re-used for subsequent runs.

Note that the deserialization process is currently the bottleneck due to technical considerations. The documentation contains some future work that can speed this up more. 

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
