### PR TITLE
Implement a `--compile` Command for the Engine Runner

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -241,6 +241,37 @@ jobs:
         run: |
           sleep 1
           sbt buildEngineDistribution
+
+      - name: Compile the Standard Libraries (Unix)
+        shell: bash
+        if: runner.os != 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
+
+      - name: Compile the Standard Libraries (Windows))
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
+
       - name: Prepare Project Manager Distribution
         working-directory: repo
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -243,6 +243,7 @@ jobs:
           sbt buildEngineDistribution
 
       - name: Compile the Standard Libraries (Unix)
+        working-directory: repo
         shell: bash
         if: runner.os != 'Windows'
         run: |
@@ -258,6 +259,7 @@ jobs:
           $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
 
       - name: Compile the Standard Libraries (Windows)
+        working-directory: repo
         shell: bash
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -246,31 +246,31 @@ jobs:
         shell: bash
         if: runner.os != 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
 
-      - name: Compile the Standard Libraries (Windows))
+      - name: Compile the Standard Libraries (Windows)
         shell: bash
         if: runner.os == 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
 
       - name: Prepare Project Manager Distribution
         working-directory: repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,31 +200,31 @@ jobs:
         shell: bash
         if: runner.os != 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
 
-      - name: Compile the Standard Libraries (Windows))
+      - name: Compile the Standard Libraries (Windows)
         shell: bash
         if: runner.os == 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
 
       - name: Prepare Project Manager Distribution
         working-directory: repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,37 @@ jobs:
         run: |
           sleep 1
           sbt buildEngineDistribution
+
+      - name: Compile the Standard Libraries (Unix)
+        shell: bash
+        if: runner.os != 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
+
+      - name: Compile the Standard Libraries (Windows))
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
+
       - name: Prepare Project Manager Distribution
         working-directory: repo
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,7 @@ jobs:
           sbt buildEngineDistribution
 
       - name: Compile the Standard Libraries (Unix)
+        working-directory: repo
         shell: bash
         if: runner.os != 'Windows'
         run: |
@@ -212,6 +213,7 @@ jobs:
           $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
 
       - name: Compile the Standard Libraries (Windows)
+        working-directory: repo
         shell: bash
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -156,22 +156,22 @@ jobs:
           sleep 1
           sbt --no-colors "runtime/clean; engine-runner/assembly"
 
-#      - name: Test Enso
-#        run: |
-#          sleep 1
-#          sbt --no-colors "set Global / parallelExecution := false; runtime/clean; compile; test"
-#      - name: Check Runtime Benchmark Compilation
-#        run: |
-#          sleep 1
-#          sbt --no-colors "runtime/clean; runtime/Benchmark/compile"
-#      - name: Check Language Server Benchmark Compilation
-#        run: |
-#          sleep 1
-#          sbt --no-colors language-server/Benchmark/compile
-#      - name: Check Searcher Benchmark Compilation
-#        run: |
-#          sleep 1
-#          sbt --no-colors searcher/Benchmark/compile
+      - name: Test Enso
+        run: |
+          sleep 1
+          sbt --no-colors "set Global / parallelExecution := false; runtime/clean; compile; test"
+      - name: Check Runtime Benchmark Compilation
+        run: |
+          sleep 1
+          sbt --no-colors "runtime/clean; runtime/Benchmark/compile"
+      - name: Check Language Server Benchmark Compilation
+        run: |
+          sleep 1
+          sbt --no-colors language-server/Benchmark/compile
+      - name: Check Searcher Benchmark Compilation
+        run: |
+          sleep 1
+          sbt --no-colors searcher/Benchmark/compile
 
       # Build Distribution
       - name: Build the Project Manager Native Image
@@ -179,15 +179,15 @@ jobs:
           sleep 1
           sbt --no-colors project-manager/assembly
           sbt --no-colors --mem 1536 "launcher/buildNativeImage"
-#      - name: Build the Parser JS Bundle
-#        # The builds are run on 3 platforms, but
-#        # Flatbuffer schemas are platform agnostic, so they just need to be
-#        # uploaded from one of the runners.
-#        if: runner.os == 'Linux'
-#        run: sbt --no-colors syntaxJS/fullOptJS
-#      - name: Build the docs from standard library sources.
-#        if: runner.os == 'Linux'
-#        run: sbt --no-colors docs-generator/run
+      - name: Build the Parser JS Bundle
+        # The builds are run on 3 platforms, but
+        # Flatbuffer schemas are platform agnostic, so they just need to be
+        # uploaded from one of the runners.
+        if: runner.os == 'Linux'
+        run: sbt --no-colors syntaxJS/fullOptJS
+      - name: Build the docs from standard library sources.
+        if: runner.os == 'Linux'
+        run: sbt --no-colors docs-generator/run
 
       # Prepare distributions
       # The version used in filenames is based on the version of the launcher.
@@ -275,16 +275,16 @@ jobs:
           postgresql user: ${{ env.ENSO_DATABASE_TEST_DB_USER }}
           postgresql password: ${{ env.ENSO_DATABASE_TEST_DB_PASSWORD }}
 
-#      - name: Test Engine Distribution Without Caches (Unix)
-#        shell: bash
-#        if: runner.os != 'Windows'
-#        run: |
-#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Tests
-#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Table_Tests
-#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Database_Tests
-#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Geo_Tests
-#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Visualization_Tests
-#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Image_Tests
+      - name: Test Engine Distribution Without Caches (Unix)
+        shell: bash
+        if: runner.os != 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Tests
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Table_Tests
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Database_Tests
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Image_Tests
 
       - name: Compile the Standard Libraries (Unix)
         shell: bash
@@ -301,53 +301,53 @@ jobs:
           $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
           $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
 
-#      - name: Test Engine Distribution With Caches (Unix)
-#        shell: bash
-#        if: runner.os != 'Windows'
-#        run: |
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Tests
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Table_Tests
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Database_Tests
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Geo_Tests
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Visualization_Tests
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Image_Tests
-#
-#      - name: Test Engine Distribution Without Caches (Windows)
-#        shell: bash
-#        if: runner.os == 'Windows'
-#        run: |
-#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Tests
-#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Table_Tests
-#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Database_Tests
-#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Geo_Tests
-#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Visualization_Tests
-#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Image_Tests
-#
-#      - name: Compile the Standard Libraries (Windows)
-#        shell: bash
-#        if: runner.os == 'Windows'
-#        run: |
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
-#
-#      - name: Test Engine Distribution With Caches (Windows)
-#        shell: bash
-#        if: runner.os == 'Windows'
-#        run: |
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Tests
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Table_Tests
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Database_Tests
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Geo_Tests
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Visualization_Tests
-#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Image_Tests
+      - name: Test Engine Distribution With Caches (Unix)
+        shell: bash
+        if: runner.os != 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Table_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Database_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Image_Tests
+
+      - name: Test Engine Distribution Without Caches (Windows)
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Table_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Database_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Image_Tests
+
+      - name: Compile the Standard Libraries (Windows)
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
+
+      - name: Test Engine Distribution With Caches (Windows)
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Table_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Database_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Image_Tests
 
       # Publish
       - name: Compress the built artifacts for upload

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -291,15 +291,15 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           $ENGINE_DIST_DIR/bin/enso --log-level=Debug --no-log-masking --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
 #          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
 #          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
 #          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
 #          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
 
 #      - name: Test Engine Distribution With Caches (Unix)
 #        shell: bash

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -22,7 +22,7 @@ jobs:
   test_and_publish:
     name: Build and Test
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 100
+    timeout-minutes: 120
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-18.04, windows-latest]
@@ -279,12 +279,27 @@ jobs:
         shell: bash
         if: runner.os != 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Tests
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Table_Tests
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Database_Tests
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Geo_Tests
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Visualization_Tests
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-read-ir-caches --run test/Image_Tests
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Tests
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Table_Tests
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Database_Tests
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Image_Tests
+
+      - name: Compile the Standard Libraries (Unix)
+        shell: bash
+        if: runner.os != 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
 
       - name: Test Engine Distribution With Caches (Unix)
         shell: bash
@@ -301,12 +316,27 @@ jobs:
         shell: bash
         if: runner.os == 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Table_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Database_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Geo_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Visualization_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-read-ir-caches --run test/Image_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Table_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Database_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Geo_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Visualization_Tests
+          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Image_Tests
+
+      - name: Compile the Standard Libraries (Windows)
+        shell: bash
+        if: runner.os == 'Windows'
+        run: |
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
 
       - name: Test Engine Distribution With Caches (Windows)
         shell: bash

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -156,22 +156,22 @@ jobs:
           sleep 1
           sbt --no-colors "runtime/clean; engine-runner/assembly"
 
-      - name: Test Enso
-        run: |
-          sleep 1
-          sbt --no-colors "set Global / parallelExecution := false; runtime/clean; compile; test"
-      - name: Check Runtime Benchmark Compilation
-        run: |
-          sleep 1
-          sbt --no-colors "runtime/clean; runtime/Benchmark/compile"
-      - name: Check Language Server Benchmark Compilation
-        run: |
-          sleep 1
-          sbt --no-colors language-server/Benchmark/compile
-      - name: Check Searcher Benchmark Compilation
-        run: |
-          sleep 1
-          sbt --no-colors searcher/Benchmark/compile
+#      - name: Test Enso
+#        run: |
+#          sleep 1
+#          sbt --no-colors "set Global / parallelExecution := false; runtime/clean; compile; test"
+#      - name: Check Runtime Benchmark Compilation
+#        run: |
+#          sleep 1
+#          sbt --no-colors "runtime/clean; runtime/Benchmark/compile"
+#      - name: Check Language Server Benchmark Compilation
+#        run: |
+#          sleep 1
+#          sbt --no-colors language-server/Benchmark/compile
+#      - name: Check Searcher Benchmark Compilation
+#        run: |
+#          sleep 1
+#          sbt --no-colors searcher/Benchmark/compile
 
       # Build Distribution
       - name: Build the Project Manager Native Image
@@ -179,15 +179,15 @@ jobs:
           sleep 1
           sbt --no-colors project-manager/assembly
           sbt --no-colors --mem 1536 "launcher/buildNativeImage"
-      - name: Build the Parser JS Bundle
-        # The builds are run on 3 platforms, but
-        # Flatbuffer schemas are platform agnostic, so they just need to be
-        # uploaded from one of the runners.
-        if: runner.os == 'Linux'
-        run: sbt --no-colors syntaxJS/fullOptJS
-      - name: Build the docs from standard library sources.
-        if: runner.os == 'Linux'
-        run: sbt --no-colors docs-generator/run
+#      - name: Build the Parser JS Bundle
+#        # The builds are run on 3 platforms, but
+#        # Flatbuffer schemas are platform agnostic, so they just need to be
+#        # uploaded from one of the runners.
+#        if: runner.os == 'Linux'
+#        run: sbt --no-colors syntaxJS/fullOptJS
+#      - name: Build the docs from standard library sources.
+#        if: runner.os == 'Linux'
+#        run: sbt --no-colors docs-generator/run
 
       # Prepare distributions
       # The version used in filenames is based on the version of the launcher.
@@ -275,79 +275,79 @@ jobs:
           postgresql user: ${{ env.ENSO_DATABASE_TEST_DB_USER }}
           postgresql password: ${{ env.ENSO_DATABASE_TEST_DB_PASSWORD }}
 
-      - name: Test Engine Distribution Without Caches (Unix)
-        shell: bash
-        if: runner.os != 'Windows'
-        run: |
-          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Tests
-          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Table_Tests
-          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Database_Tests
-          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Geo_Tests
-          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Visualization_Tests
-          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Image_Tests
+#      - name: Test Engine Distribution Without Caches (Unix)
+#        shell: bash
+#        if: runner.os != 'Windows'
+#        run: |
+#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Tests
+#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Table_Tests
+#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Database_Tests
+#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Geo_Tests
+#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Visualization_Tests
+#          $ENGINE_DIST_DIR/bin/enso --no-ir-caches --run test/Image_Tests
 
       - name: Compile the Standard Libraries (Unix)
         shell: bash
         if: runner.os != 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --log-level=Debug --no-log-masking --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
 
-      - name: Test Engine Distribution With Caches (Unix)
-        shell: bash
-        if: runner.os != 'Windows'
-        run: |
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Tests
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Table_Tests
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Database_Tests
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Geo_Tests
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Visualization_Tests
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Image_Tests
-
-      - name: Test Engine Distribution Without Caches (Windows)
-        shell: bash
-        if: runner.os == 'Windows'
-        run: |
-          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Table_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Database_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Geo_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Visualization_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Image_Tests
-
-      - name: Compile the Standard Libraries (Windows)
-        shell: bash
-        if: runner.os == 'Windows'
-        run: |
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
-
-      - name: Test Engine Distribution With Caches (Windows)
-        shell: bash
-        if: runner.os == 'Windows'
-        run: |
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Table_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Database_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Geo_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Visualization_Tests
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Image_Tests
+#      - name: Test Engine Distribution With Caches (Unix)
+#        shell: bash
+#        if: runner.os != 'Windows'
+#        run: |
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Tests
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Table_Tests
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Database_Tests
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Geo_Tests
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Visualization_Tests
+#          $ENGINE_DIST_DIR/bin/enso --ir-caches --run test/Image_Tests
+#
+#      - name: Test Engine Distribution Without Caches (Windows)
+#        shell: bash
+#        if: runner.os == 'Windows'
+#        run: |
+#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Tests
+#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Table_Tests
+#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Database_Tests
+#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Geo_Tests
+#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Visualization_Tests
+#          $ENGINE_DIST_DIR/bin/enso.bat --no-ir-caches --run test/Image_Tests
+#
+#      - name: Compile the Standard Libraries (Windows)
+#        shell: bash
+#        if: runner.os == 'Windows'
+#        run: |
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
+#
+#      - name: Test Engine Distribution With Caches (Windows)
+#        shell: bash
+#        if: runner.os == 'Windows'
+#        run: |
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Tests
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Table_Tests
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Database_Tests
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Geo_Tests
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Visualization_Tests
+#          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --run test/Image_Tests
 
       # Publish
       - name: Compress the built artifacts for upload

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -290,16 +290,16 @@ jobs:
         shell: bash
         if: runner.os != 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
-          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
 
       - name: Test Engine Distribution With Caches (Unix)
         shell: bash
@@ -327,16 +327,16 @@ jobs:
         shell: bash
         if: runner.os == 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test
-          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso.bat --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
 
       - name: Test Engine Distribution With Caches (Windows)
         shell: bash

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -290,16 +290,16 @@ jobs:
         shell: bash
         if: runner.os != 'Windows'
         run: |
-          $ENGINE_DIST_DIR/bin/enso --log-level=Debug --no-log-masking --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Base/$DIST_VERSION
           $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Test/$DIST_VERSION
           $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Visualization/$DIST_VERSION
           $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Searcher/$DIST_VERSION
           $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Table/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
-#          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Database/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Geo/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Google_Api/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Image/$DIST_VERSION
+          $ENGINE_DIST_DIR/bin/enso --ir-caches --no-compile-dependencies --no-global-cache --compile $ENGINE_DIST_DIR/lib/Standard/Examples/$DIST_VERSION
 
 #      - name: Test Engine Distribution With Caches (Unix)
 #        shell: bash

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Enso Next
 
+## Interpreter/Runtime
+
+- Added support for compiling Enso packages without execution
+  ([#1998](https://github.com/enso-org/enso/pull/1998)). This allows the
+  distribution of precompiled libraries which greatly improves language start-up
+  time.
+
 ## Enso 0.2.30 (2021-09-23)
 
 ## Interpreter/Runtime

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/MethodNames.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/MethodNames.java
@@ -8,6 +8,7 @@ public class MethodNames {
     public static final String LEAK_CONTEXT = "leak_context";
     public static final String REGISTER_MODULE = "register_module";
     public static final String UNREGISTER_MODULE = "unregister_module";
+    public static final String COMPILE_PACKAGES = "compile_packages";
   }
 
   public static class Module {

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/MethodNames.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/MethodNames.java
@@ -8,7 +8,7 @@ public class MethodNames {
     public static final String LEAK_CONTEXT = "leak_context";
     public static final String REGISTER_MODULE = "register_module";
     public static final String UNREGISTER_MODULE = "unregister_module";
-    public static final String COMPILE = "compile_packages";
+    public static final String COMPILE = "compile";
   }
 
   public static class Module {

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/MethodNames.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/MethodNames.java
@@ -8,7 +8,7 @@ public class MethodNames {
     public static final String LEAK_CONTEXT = "leak_context";
     public static final String REGISTER_MODULE = "register_module";
     public static final String UNREGISTER_MODULE = "unregister_module";
-    public static final String COMPILE_PACKAGES = "compile_packages";
+    public static final String COMPILE = "compile_packages";
   }
 
   public static class Module {

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -88,48 +88,6 @@ public class RuntimeOptions {
   private static final OptionDescriptor NO_READ_IR_CACHES_DESCRIPTOR =
       OptionDescriptor.newBuilder(NO_READ_IR_CACHES_KEY, NO_READ_IR_CACHES).build();
 
-  // TODO [AA] compile (takes a list) (use an OptionType here, and have a buildOptionString
-  //  function)
-  public static final String COMPILE = optionName("compile");
-  public static final OptionType<ArrayList<String>> COMPILE_TYPE =
-      new OptionType<>("Paths", Compile::fromOptionsString);
-  public static final OptionKey<ArrayList<String>> COMPILE_KEY =
-      new OptionKey<>(new ArrayList<>(), COMPILE_TYPE);
-  public static final OptionDescriptor COMPILE_DESCRIPTOR =
-      OptionDescriptor.newBuilder(COMPILE_KEY, COMPILE).build();
-
-  public static class Compile {
-    private static final String pathSeparator = File.pathSeparator;
-
-    /**
-     * Converts the options string to an {@link ArrayList} of paths.
-     *
-     * @param optionsString the string of the option
-     * @return the paths
-     */
-    public static ArrayList<String> fromOptionsString(String optionsString) {
-      var items = new ArrayList<>(Arrays.asList(optionsString.split(pathSeparator)));
-      return items.stream().filter(s -> !s.isEmpty())
-          .collect(Collectors.toCollection(ArrayList::new));
-    }
-
-    /**
-     * Convert an {@link ArrayList} of paths to an options string.
-     *
-     * @param paths the paths to consolidate
-     * @return the options string representing {@code paths}
-     */
-    public static String toOptionsString(List<String> paths) {
-      StringBuilder builder = new StringBuilder();
-      paths.forEach(
-          path -> {
-            builder.append(path);
-            builder.append(pathSeparator);
-          });
-      return builder.toString();
-    }
-  }
-
   public static final OptionDescriptors OPTION_DESCRIPTORS =
       OptionDescriptors.create(
           Arrays.asList(
@@ -145,8 +103,7 @@ public class RuntimeOptions {
               INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_DESCRIPTOR,
               DISABLE_IR_CACHES_DESCRIPTOR,
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESCRIPTOR,
-              NO_READ_IR_CACHES_DESCRIPTOR,
-              COMPILE_DESCRIPTOR));
+              NO_READ_IR_CACHES_DESCRIPTOR));
 
   /**
    * Canonicalizes the option name by prefixing it with the language name.

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -83,11 +83,6 @@ public class RuntimeOptions {
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_KEY, WAIT_FOR_PENDING_SERIALIZATION_JOBS)
           .build();
 
-  public static final String NO_READ_IR_CACHES = optionName("onlyGenerateIrCaches");
-  public static final OptionKey<Boolean> NO_READ_IR_CACHES_KEY = new OptionKey<>(false);
-  private static final OptionDescriptor NO_READ_IR_CACHES_DESCRIPTOR =
-      OptionDescriptor.newBuilder(NO_READ_IR_CACHES_KEY, NO_READ_IR_CACHES).build();
-
   public static final String USE_GLOBAL_IR_CACHE_LOCATION = optionName("useGlobalIrCacheLocation");
   public static final OptionKey<Boolean> USE_GLOBAL_IR_CACHE_LOCATION_KEY = new OptionKey<>(true);
   public static final OptionDescriptor USE_GLOBAL_IR_CACHE_LOCATION_DESCRIPTOR =
@@ -109,7 +104,6 @@ public class RuntimeOptions {
               INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_DESCRIPTOR,
               DISABLE_IR_CACHES_DESCRIPTOR,
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESCRIPTOR,
-              NO_READ_IR_CACHES_DESCRIPTOR,
               USE_GLOBAL_IR_CACHE_LOCATION_DESCRIPTOR));
 
   /**

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -88,6 +88,12 @@ public class RuntimeOptions {
   private static final OptionDescriptor NO_READ_IR_CACHES_DESCRIPTOR =
       OptionDescriptor.newBuilder(NO_READ_IR_CACHES_KEY, NO_READ_IR_CACHES).build();
 
+  public static final String USE_GLOBAL_IR_CACHE_LOCATION = optionName("useGlobalIrCacheLocation");
+  public static final OptionKey<Boolean> USE_GLOBAL_IR_CACHE_LOCATION_KEY = new OptionKey<>(true);
+  public static final OptionDescriptor USE_GLOBAL_IR_CACHE_LOCATION_DESCRIPTOR =
+      OptionDescriptor.newBuilder(USE_GLOBAL_IR_CACHE_LOCATION_KEY, USE_GLOBAL_IR_CACHE_LOCATION)
+          .build();
+
   public static final OptionDescriptors OPTION_DESCRIPTORS =
       OptionDescriptors.create(
           Arrays.asList(
@@ -103,7 +109,8 @@ public class RuntimeOptions {
               INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_DESCRIPTOR,
               DISABLE_IR_CACHES_DESCRIPTOR,
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESCRIPTOR,
-              NO_READ_IR_CACHES_DESCRIPTOR));
+              NO_READ_IR_CACHES_DESCRIPTOR,
+              USE_GLOBAL_IR_CACHE_LOCATION_DESCRIPTOR));
 
   /**
    * Canonicalizes the option name by prefixing it with the language name.

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -1,15 +1,10 @@
 package org.enso.polyglot;
 
-import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 import org.graalvm.options.OptionDescriptor;
 import org.graalvm.options.OptionDescriptors;
 import org.graalvm.options.OptionKey;
-import org.graalvm.options.OptionType;
 
 /** Class representing runtime options supported by the Enso engine. */
 public class RuntimeOptions {

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -1,10 +1,15 @@
 package org.enso.polyglot;
 
+import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import org.graalvm.options.OptionDescriptor;
 import org.graalvm.options.OptionDescriptors;
 import org.graalvm.options.OptionKey;
+import org.graalvm.options.OptionType;
 
 /** Class representing runtime options supported by the Enso engine. */
 public class RuntimeOptions {
@@ -83,6 +88,48 @@ public class RuntimeOptions {
   private static final OptionDescriptor NO_READ_IR_CACHES_DESCRIPTOR =
       OptionDescriptor.newBuilder(NO_READ_IR_CACHES_KEY, NO_READ_IR_CACHES).build();
 
+  // TODO [AA] compile (takes a list) (use an OptionType here, and have a buildOptionString
+  //  function)
+  public static final String COMPILE = optionName("compile");
+  public static final OptionType<ArrayList<String>> COMPILE_TYPE =
+      new OptionType<>("Paths", Compile::fromOptionsString);
+  public static final OptionKey<ArrayList<String>> COMPILE_KEY =
+      new OptionKey<>(new ArrayList<>(), COMPILE_TYPE);
+  public static final OptionDescriptor COMPILE_DESCRIPTOR =
+      OptionDescriptor.newBuilder(COMPILE_KEY, COMPILE).build();
+
+  public static class Compile {
+    private static final String pathSeparator = File.pathSeparator;
+
+    /**
+     * Converts the options string to an {@link ArrayList} of paths.
+     *
+     * @param optionsString the string of the option
+     * @return the paths
+     */
+    public static ArrayList<String> fromOptionsString(String optionsString) {
+      var items = new ArrayList<>(Arrays.asList(optionsString.split(pathSeparator)));
+      return items.stream().filter(s -> !s.isEmpty())
+          .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * Convert an {@link ArrayList} of paths to an options string.
+     *
+     * @param paths the paths to consolidate
+     * @return the options string representing {@code paths}
+     */
+    public static String toOptionsString(List<String> paths) {
+      StringBuilder builder = new StringBuilder();
+      paths.forEach(
+          path -> {
+            builder.append(path);
+            builder.append(pathSeparator);
+          });
+      return builder.toString();
+    }
+  }
+
   public static final OptionDescriptors OPTION_DESCRIPTORS =
       OptionDescriptors.create(
           Arrays.asList(
@@ -98,7 +145,8 @@ public class RuntimeOptions {
               INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_DESCRIPTOR,
               DISABLE_IR_CACHES_DESCRIPTOR,
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESCRIPTOR,
-              NO_READ_IR_CACHES_DESCRIPTOR));
+              NO_READ_IR_CACHES_DESCRIPTOR,
+              COMPILE_DESCRIPTOR));
 
   /**
    * Canonicalizes the option name by prefixing it with the language name.

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/TopScope.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/TopScope.scala
@@ -33,4 +33,8 @@ class TopScope(private val value: Value) {
   def unregisterModule(qualifiedName: String): Unit = {
     value.invokeMember(UNREGISTER_MODULE, qualifiedName): Unit
   }
+
+  def compile(packageRoots: List[String]): Unit = {
+    value.invokeMember(COMPILE_PACKAGES, packageRoots.toArray)
+  }
 }

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/TopScope.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/TopScope.scala
@@ -34,7 +34,7 @@ class TopScope(private val value: Value) {
     value.invokeMember(UNREGISTER_MODULE, qualifiedName): Unit
   }
 
-  def compile(packageRoots: List[String]): Unit = {
-    value.invokeMember(COMPILE_PACKAGES, packageRoots.toArray)
+  def compile(shouldCompileDependencies: Boolean): Unit = {
+    value.invokeMember(COMPILE, shouldCompileDependencies)
   }
 }

--- a/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
@@ -1,8 +1,5 @@
 package org.enso.runner
 
-import java.io.InputStream
-import java.io.OutputStream
-
 import org.enso.loggingservice.{JavaLoggingLogHandler, LogLevel}
 import org.enso.polyglot.debugger.{
   DebugServerInfo,
@@ -10,6 +7,8 @@ import org.enso.polyglot.debugger.{
 }
 import org.enso.polyglot.{PolyglotContext, RuntimeOptions}
 import org.graalvm.polyglot.Context
+
+import java.io.{InputStream, OutputStream}
 
 /** Utility class for creating Graal polyglot contexts.
   */

--- a/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
@@ -26,6 +26,8 @@ class ContextFactory {
     * @param enableIrCacheReading whether or not IR cache reading should be
     *                             enabled
     * @param strictErrors whether or not to use strict errors
+    * @param useGlobalIrCacheLocation whether or not to use the global IR cache
+    *                                 location
     * @return configured Context instance
     */
   def create(
@@ -37,7 +39,8 @@ class ContextFactory {
     logMasking: Boolean,
     enableIrCaches: Boolean,
     enableIrCacheReading: Boolean,
-    strictErrors: Boolean = false
+    strictErrors: Boolean             = false,
+    useGlobalIrCacheLocation: Boolean = true
   ): PolyglotContext = {
     val context = Context
       .newBuilder()
@@ -46,6 +49,10 @@ class ContextFactory {
       .option(RuntimeOptions.PROJECT_ROOT, projectRoot)
       .option(RuntimeOptions.STRICT_ERRORS, strictErrors.toString)
       .option(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS, "true")
+      .option(
+        RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION,
+        useGlobalIrCacheLocation.toString
+      )
       .option(RuntimeOptions.DISABLE_IR_CACHES, (!enableIrCaches).toString)
       .option(
         RuntimeOptions.NO_READ_IR_CACHES,

--- a/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
@@ -23,8 +23,6 @@ class ContextFactory {
     * @param repl the Repl manager to use for this context
     * @param logLevel the log level for this context
     * @param enableIrCaches whether or not IR caching should be enabled
-    * @param enableIrCacheReading whether or not IR cache reading should be
-    *                             enabled
     * @param strictErrors whether or not to use strict errors
     * @param useGlobalIrCacheLocation whether or not to use the global IR cache
     *                                 location
@@ -38,7 +36,6 @@ class ContextFactory {
     logLevel: LogLevel,
     logMasking: Boolean,
     enableIrCaches: Boolean,
-    enableIrCacheReading: Boolean,
     strictErrors: Boolean             = false,
     useGlobalIrCacheLocation: Boolean = true
   ): PolyglotContext = {
@@ -54,10 +51,6 @@ class ContextFactory {
         useGlobalIrCacheLocation.toString
       )
       .option(RuntimeOptions.DISABLE_IR_CACHES, (!enableIrCaches).toString)
-      .option(
-        RuntimeOptions.NO_READ_IR_CACHES,
-        (!enableIrCacheReading).toString
-      )
       .option(DebugServerInfo.ENABLE_OPTION, "true")
       .option(RuntimeOptions.LOG_MASKING, logMasking.toString)
       .option("js.foreign-object-prototype", "true")

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -11,7 +11,7 @@ import org.enso.languageserver.boot.LanguageServerConfig
 import org.enso.libraryupload.LibraryUploader.UploadFailedError
 import org.enso.loggingservice.LogLevel
 import org.enso.pkg.{Contact, PackageManager, Template}
-import org.enso.polyglot.{LanguageInfo, Module, PolyglotContext, RuntimeOptions}
+import org.enso.polyglot.{LanguageInfo, Module, PolyglotContext}
 import org.enso.version.VersionDescription
 import org.graalvm.polyglot.PolyglotException
 
@@ -376,6 +376,12 @@ object Main {
     exitSuccess()
   }
 
+  /** Handles the `--compile` CLI option.
+    *
+    * @param packagePaths the paths to the package roots to be compiled
+    * @param logLevel the logging level
+    * @param logMasking whether log masking is enabled or disabled
+    */
   private def compile(
     packagePaths: Array[String],
     logLevel: LogLevel,
@@ -391,9 +397,20 @@ object Main {
       exitFail()
     }
 
-    println(s"Valid Paths: $validPaths")
-    println(s"LogLevel: $logLevel")
-    println(s"LogMasking: $logMasking")
+    val context = new ContextFactory().create(
+      "",
+      System.in,
+      System.out,
+      Repl(TerminalIO()),
+      logLevel,
+      logMasking,
+      enableIrCaches       = true,
+      enableIrCacheReading = false
+    )
+    val topScope = context.getTopScope
+    topScope.compile(validPaths)
+
+    context.context.close()
     exitSuccess()
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
@@ -53,7 +53,6 @@ public class Context {
   private final ResourceManager resourceManager;
   private final boolean isInlineCachingDisabled;
   private final boolean isIrCachingDisabled;
-  private final boolean isIrCacheReadingDisabled;
   private final boolean shouldWaitForPendingSerializationJobs;
   private final Builtins builtins;
   private final String home;
@@ -91,8 +90,6 @@ public class Context {
     this.isInlineCachingDisabled =
         environment.getOptions().get(RuntimeOptions.DISABLE_INLINE_CACHES_KEY);
     this.isIrCachingDisabled = environment.getOptions().get(RuntimeOptions.DISABLE_IR_CACHES_KEY);
-    this.isIrCacheReadingDisabled =
-        environment.getOptions().get(RuntimeOptions.NO_READ_IR_CACHES_KEY);
     this.shouldWaitForPendingSerializationJobs =
         environment.getOptions().get(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS_KEY);
     this.compilerConfig = new CompilerConfig(false, true);
@@ -407,11 +404,6 @@ public class Context {
   /** @return whether IR caching should be disabled for this context. */
   public boolean isIrCachingDisabled() {
     return isIrCachingDisabled;
-  }
-
-  /** @return whether IR cache reading is disabled for this context */
-  public boolean isIrCacheReadingDisabled() {
-    return isIrCacheReadingDisabled;
   }
 
   /** @return the compiler configuration for this language */

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
@@ -13,11 +13,8 @@ import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
-import org.enso.compiler.Compiler;
 import org.enso.compiler.PackageRepository;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.Context;
@@ -109,7 +106,7 @@ public class TopLevelScope implements TruffleObject {
         MethodNames.TopScope.CREATE_MODULE,
         MethodNames.TopScope.REGISTER_MODULE,
         MethodNames.TopScope.UNREGISTER_MODULE,
-        MethodNames.TopScope.COMPILE_PACKAGES);
+        MethodNames.TopScope.COMPILE);
   }
 
   /** Handles member invocation through the polyglot API. */
@@ -158,14 +155,12 @@ public class TopLevelScope implements TruffleObject {
       return context.getEnvironment().asGuestValue(context);
     }
 
-    private static Object compilePackages(Object[] arguments, Context context)
+    private static Object compile(Object[] arguments, Context context)
         throws UnsupportedTypeException, ArityException {
+      boolean shouldCompileDependencies = Types.extractArguments(arguments, Boolean.class);
+      context.getCompiler().compile(shouldCompileDependencies);
 
-      String[] packageRoots = Types.extractHostArguments(arguments, String[].class, context);
-
-
-
-      return Boolean.TRUE;
+      return true;
     }
 
     @Specialization
@@ -186,8 +181,8 @@ public class TopLevelScope implements TruffleObject {
           return unregisterModule(scope, arguments, contextRef.get());
         case MethodNames.TopScope.LEAK_CONTEXT:
           return leakContext(contextRef.get());
-        case MethodNames.TopScope.COMPILE_PACKAGES:
-          return compilePackages(arguments, contextRef.get());
+        case MethodNames.TopScope.COMPILE:
+          return compile(arguments, contextRef.get());
         default:
           throw UnknownIdentifierException.create(member);
       }
@@ -206,7 +201,7 @@ public class TopLevelScope implements TruffleObject {
         || member.equals(MethodNames.TopScope.CREATE_MODULE)
         || member.equals(MethodNames.TopScope.REGISTER_MODULE)
         || member.equals(MethodNames.TopScope.UNREGISTER_MODULE)
-        || member.equals(MethodNames.TopScope.COMPILE_PACKAGES);
+        || member.equals(MethodNames.TopScope.COMPILE);
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
@@ -13,8 +13,11 @@ import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
+import org.enso.compiler.Compiler;
 import org.enso.compiler.PackageRepository;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.Context;
@@ -105,7 +108,8 @@ public class TopLevelScope implements TruffleObject {
         MethodNames.TopScope.GET_MODULE,
         MethodNames.TopScope.CREATE_MODULE,
         MethodNames.TopScope.REGISTER_MODULE,
-        MethodNames.TopScope.UNREGISTER_MODULE);
+        MethodNames.TopScope.UNREGISTER_MODULE,
+        MethodNames.TopScope.COMPILE_PACKAGES);
   }
 
   /** Handles member invocation through the polyglot API. */
@@ -154,6 +158,16 @@ public class TopLevelScope implements TruffleObject {
       return context.getEnvironment().asGuestValue(context);
     }
 
+    private static Object compilePackages(Object[] arguments, Context context)
+        throws UnsupportedTypeException, ArityException {
+
+      String[] packageRoots = Types.extractHostArguments(arguments, String[].class, context);
+
+
+
+      return Boolean.TRUE;
+    }
+
     @Specialization
     static Object doInvoke(
         TopLevelScope scope,
@@ -172,6 +186,8 @@ public class TopLevelScope implements TruffleObject {
           return unregisterModule(scope, arguments, contextRef.get());
         case MethodNames.TopScope.LEAK_CONTEXT:
           return leakContext(contextRef.get());
+        case MethodNames.TopScope.COMPILE_PACKAGES:
+          return compilePackages(arguments, contextRef.get());
         default:
           throw UnknownIdentifierException.create(member);
       }
@@ -189,7 +205,8 @@ public class TopLevelScope implements TruffleObject {
     return member.equals(MethodNames.TopScope.GET_MODULE)
         || member.equals(MethodNames.TopScope.CREATE_MODULE)
         || member.equals(MethodNames.TopScope.REGISTER_MODULE)
-        || member.equals(MethodNames.TopScope.UNREGISTER_MODULE);
+        || member.equals(MethodNames.TopScope.UNREGISTER_MODULE)
+        || member.equals(MethodNames.TopScope.COMPILE_PACKAGES);
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.runtime.type;
 import com.oracle.truffle.api.dsl.TypeSystem;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.Thunk;
 import org.enso.interpreter.runtime.callable.atom.Atom;
@@ -164,6 +165,7 @@ public class Types {
     if (arguments.length != 1) {
       throw ArityException.create(1, arguments.length);
     }
+
     if (!(cls.isInstance(arguments[0]))) {
       throw UnsupportedTypeException.create(
           arguments, "The argument must be a " + cls.getSimpleName() + ".");
@@ -198,6 +200,36 @@ public class Types {
           arguments, "The second argument must be a " + cls2.getSimpleName() + ".");
     }
     return new Pair<>((A) arguments[0], (B) arguments[1]);
+  }
+
+  /**
+   * Asserts that the arguments array has exactly one element of a given type and extracts it.
+   *
+   * @param arguments the arguments array
+   * @param cls the class of the only element
+   * @param context the language context
+   * @param <A> the type of the only element
+   * @return the only element of the array
+   * @throws ArityException if the array does not have exactly one element
+   * @throws UnsupportedTypeException if the only element is not an instance of {@code cls}
+   */
+  @SuppressWarnings("unchecked")
+  public static <A> A extractHostArguments(Object[] arguments, Class<A> cls, Context context)
+      throws ArityException, UnsupportedTypeException {
+    if (arguments.length != 1) {
+      throw ArityException.create(1, arguments.length);
+    }
+
+    Object hostObject = arguments[0];
+    if (context.getEnvironment().isHostObject(hostObject)) {
+      hostObject = context.getEnvironment().asHostObject(hostObject);
+    }
+
+    if (!(cls.isInstance(hostObject))) {
+      throw UnsupportedTypeException.create(
+          arguments, "The argument must be a " + cls.getSimpleName() + ".");
+    }
+    return (A) hostObject;
   }
 
   /** @return the language type hierarchy */

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
@@ -202,36 +202,6 @@ public class Types {
     return new Pair<>((A) arguments[0], (B) arguments[1]);
   }
 
-  /**
-   * Asserts that the arguments array has exactly one element of a given type and extracts it.
-   *
-   * @param arguments the arguments array
-   * @param cls the class of the only element
-   * @param context the language context
-   * @param <A> the type of the only element
-   * @return the only element of the array
-   * @throws ArityException if the array does not have exactly one element
-   * @throws UnsupportedTypeException if the only element is not an instance of {@code cls}
-   */
-  @SuppressWarnings("unchecked")
-  public static <A> A extractHostArguments(Object[] arguments, Class<A> cls, Context context)
-      throws ArityException, UnsupportedTypeException {
-    if (arguments.length != 1) {
-      throw ArityException.create(1, arguments.length);
-    }
-
-    Object hostObject = arguments[0];
-    if (context.getEnvironment().isHostObject(hostObject)) {
-      hostObject = context.getEnvironment().asHostObject(hostObject);
-    }
-
-    if (!(cls.isInstance(hostObject))) {
-      throw UnsupportedTypeException.create(
-          arguments, "The argument must be a " + cls.getSimpleName() + ".");
-    }
-    return (A) hostObject;
-  }
-
   /** @return the language type hierarchy */
   public static TypeGraph getTypeHierarchy() {
     return typeHierarchy;

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -108,7 +108,7 @@ class Compiler(
     *         executable functionality in the module corresponding to `source`.
     */
   def run(module: Module): Unit = {
-    runInternal(module, generateCode = true, shouldCompileDependencies = false)
+    runInternal(module, generateCode = true, shouldCompileDependencies = true)
   }
 
   /** Compiles the requested packages, writing the compiled IR to the library
@@ -144,8 +144,6 @@ class Compiler(
             runInternal(m, generateCode = false, shouldCompileDependencies)
         }
     }
-
-    // TODO [AA] Do this on CI prior to running the tests with enabled caches.
   }
 
   /** Runs part of the compiler to generate docs from Enso code.
@@ -260,6 +258,11 @@ class Compiler(
           if (shouldStoreCache && !hasErrors(module) && !module.isInteractive) {
             serializationManager.serialize(module, useGlobalCacheLocations)
           }
+        } else {
+          logger.log(
+            Compiler.defaultLogLevel,
+            s"Skipping serialization for [${module.getName}]."
+          )
         }
       }
     }

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -1,6 +1,7 @@
 package org.enso.compiler
 
-import com.oracle.truffle.api.TruffleLogger
+import org.enso.pkg.Package
+import com.oracle.truffle.api.{TruffleFile, TruffleLogger}
 import com.oracle.truffle.api.source.Source
 import org.enso.compiler.codegen.{AstToIr, IrToTruffle, RuntimeStubsGenerator}
 import org.enso.compiler.context.{FreshNameSupply, InlineContext, ModuleContext}
@@ -197,6 +198,26 @@ class Compiler(
         }
       }
     }
+  }
+
+  /** Precompiles the requested packages, writing the compiled IR to the
+    * library-local cache directories.
+    *
+    * @param libraries the libraries to precompile
+    */
+  def compile(libraries: List[Package[TruffleFile]]): Unit = {
+    // TODO [AA] Find a way to request packages and load them.
+    // TODO [AA] Handle missing packages gracefully
+    // TODO [AA] Provide a way to request use of local caches only.
+    // TODO [AA] Provide a means to check if a cache exists at a given location
+    //  for a module.
+    // TODO [AA] Enumerate all modules in the requested packages.
+    // TODO [AA] Compile and write the caches (without codegen) for the
+    //  libraries.
+    // TODO [AA] Factor out common code where possible.
+    // TODO [AA] Remove the option to disable cache reading.
+    // TODO [AA] Do this on CI prior to running the tests with enabled caches.
+    ???
   }
 
   /** Runs part of the compiler to generate docs from Enso code.

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -113,6 +113,9 @@ class Compiler(
 
   /** Compiles the requested packages, writing the compiled IR to the library
     * cache directories.
+    *
+    * @param shouldCompileDependencies whether compilation should also compile
+    *                                  the dependencies of the requested package
     */
   def compile(shouldCompileDependencies: Boolean): Unit = {
     val packageRepository = context.getPackageRepository

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -217,6 +217,7 @@ class Compiler(
     // TODO [AA] Factor out common code where possible.
     // TODO [AA] Remove the option to disable cache reading.
     // TODO [AA] Do this on CI prior to running the tests with enabled caches.
+    // TODO [AA] Only write things from requested packages.
     ???
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -45,8 +45,7 @@ class Compiler(
   private val importResolver: ImportResolver   = new ImportResolver(this)
   private val stubsGenerator: RuntimeStubsGenerator =
     new RuntimeStubsGenerator()
-  private val irCachingEnabled      = !context.isIrCachingDisabled
-  private val irCacheReadingEnabled = !context.isIrCacheReadingDisabled
+  private val irCachingEnabled = !context.isIrCachingDisabled
   private val useGlobalCacheLocations = context.getEnvironment.getOptions.get(
     RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION_KEY
   )
@@ -65,7 +64,7 @@ class Compiler(
 
       builtins.initializeBuiltinsSource()
 
-      if (irCachingEnabled && irCacheReadingEnabled) {
+      if (irCachingEnabled) {
         serializationManager.deserialize(builtins.getModule) match {
           case Some(true) =>
             // Ensure that builtins doesn't try and have codegen run on it.
@@ -146,7 +145,6 @@ class Compiler(
         }
     }
 
-    // TODO [AA] Remove the option to disable cache reading.
     // TODO [AA] Do this on CI prior to running the tests with enabled caches.
   }
 
@@ -171,7 +169,7 @@ class Compiler(
     var requiredModules = runImportsAndExportsResolution(module)
 
     var hasInvalidModuleRelink = false
-    if (irCachingEnabled && irCacheReadingEnabled) {
+    if (irCachingEnabled) {
       requiredModules.foreach { module =>
         if (!module.hasCrossModuleLinks) {
           val flags =
@@ -295,7 +293,7 @@ class Compiler(
     module.ensureScopeExists()
     module.getScope.reset()
 
-    if (irCachingEnabled && irCacheReadingEnabled && !module.isInteractive) {
+    if (irCachingEnabled && !module.isInteractive) {
       serializationManager.deserialize(module) match {
         case Some(_) => return
         case _       =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/ModuleCache.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/ModuleCache.scala
@@ -8,7 +8,7 @@ import io.circe.parser._
 import io.circe.syntax._
 import org.bouncycastle.jcajce.provider.digest.SHA3
 import org.bouncycastle.util.encoders.Hex
-import org.enso.compiler.ModuleCache.ToMaskedPath
+import org.enso.compiler.ModuleCache.{logLevel, ToMaskedPath}
 import org.enso.compiler.core.IR
 import org.enso.interpreter.runtime.builtin.Builtins
 import org.enso.interpreter.runtime.{Context, Module}
@@ -36,21 +36,28 @@ class ModuleCache(private val module: Module) {
     *
     * @param module the module representation to be saved
     * @param context the language context in which saving is taking place
-    * @param localOnly specifies that only the local, in-library cache
-    *                  directories should be usEd
+    * @param useGlobalCacheLocations
     * @return returns the location of the cache if successful, and [[None]] if
     *         it was unable to save
     */
   def save(
     module: ModuleCache.CachedModule,
     context: Context,
-    localOnly: Boolean
+    useGlobalCacheLocations: Boolean
   ): Option[TruffleFile] = this.synchronized {
     implicit val logger: TruffleLogger = context.getLogger(this.getClass)
     getIrCacheRoots(context) match {
       case Some(roots) =>
-        if (!localOnly && saveCacheTo(roots.globalCacheRoot, module)) {
-          return Some(roots.globalCacheRoot)
+        if (useGlobalCacheLocations) {
+          if (saveCacheTo(roots.globalCacheRoot, module)) {
+            return Some(roots.globalCacheRoot)
+          }
+        } else {
+          logger.log(
+            logLevel,
+            s"Skipping use of global cache locations for module " +
+            s"${this.module.getName}."
+          )
         }
 
         if (saveCacheTo(roots.localCacheRoot, module)) {

--- a/engine/runtime/src/main/scala/org/enso/compiler/ModuleCache.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/ModuleCache.scala
@@ -36,17 +36,20 @@ class ModuleCache(private val module: Module) {
     *
     * @param module the module representation to be saved
     * @param context the language context in which saving is taking place
+    * @param localOnly specifies that only the local, in-library cache
+    *                  directories should be usEd
     * @return returns the location of the cache if successful, and [[None]] if
     *         it was unable to save
     */
   def save(
     module: ModuleCache.CachedModule,
-    context: Context
+    context: Context,
+    localOnly: Boolean
   ): Option[TruffleFile] = this.synchronized {
     implicit val logger: TruffleLogger = context.getLogger(this.getClass)
     getIrCacheRoots(context) match {
       case Some(roots) =>
-        if (saveCacheTo(roots.globalCacheRoot, module)) {
+        if (!localOnly && saveCacheTo(roots.globalCacheRoot, module)) {
           return Some(roots.globalCacheRoot)
         }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/PackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/PackageRepository.scala
@@ -60,6 +60,10 @@ trait PackageRepository {
     pkg: Package[TruffleFile]
   ): Unit
 
+  /** @return the main project package, if it exists
+    */
+  def getMainProjectPackage: Option[Package[TruffleFile]]
+
   /** Register a single module, outside of any packages or part of an already
     * loaded package, that has been created manually during runtime.
     */
@@ -127,8 +131,9 @@ object PackageRepository {
 
     private val logger = Logger[Default]
 
-    implicit private val fs: TruffleFileSystem = new TruffleFileSystem
-    private val packageManager                 = new PackageManager[TruffleFile]
+    implicit private val fs: TruffleFileSystem               = new TruffleFileSystem
+    private val packageManager                               = new PackageManager[TruffleFile]
+    private var projectPackage: Option[Package[TruffleFile]] = None
 
     /** The mapping containing all loaded packages.
       *
@@ -165,12 +170,20 @@ object PackageRepository {
     override def registerMainProjectPackage(
       libraryName: LibraryName,
       pkg: Package[TruffleFile]
-    ): Unit = registerPackageInternal(
-      libraryName    = libraryName,
-      pkg            = pkg,
-      libraryVersion = LibraryVersion.Local,
-      isLibrary      = false
-    )
+    ): Unit = {
+      projectPackage = Some(pkg)
+      registerPackageInternal(
+        libraryName    = libraryName,
+        pkg            = pkg,
+        libraryVersion = LibraryVersion.Local,
+        isLibrary      = false
+      )
+    }
+
+    /** @inheritdoc */
+    override def getMainProjectPackage: Option[Package[TruffleFile]] = {
+      projectPackage
+    }
 
     private def registerPackageInternal(
       libraryName: LibraryName,

--- a/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
@@ -76,7 +76,7 @@ class SerializationManager(compiler: Compiler) {
     * @return `true` if `module` has been scheduled for serialization, `false`
     *         otherwise
     */
-  def serialize(module: Module): Boolean = {
+  def serialize(module: Module, useGlobalCacheLocations: Boolean): Boolean = {
     logger.log(
       debugLogLevel,
       s"Requesting serialization for module [${module.getName}]."
@@ -92,7 +92,8 @@ class SerializationManager(compiler: Compiler) {
       duplicatedIr,
       module.getCompilationStage,
       module.getName,
-      module.getSource
+      module.getSource,
+      useGlobalCacheLocations
     )
     if (compiler.context.getEnvironment.isCreateThreadAllowed) {
       isWaitingForSerialization.put(module.getName, task)
@@ -252,7 +253,8 @@ class SerializationManager(compiler: Compiler) {
     ir: IR.Module,
     stage: Module.CompilationStage,
     name: QualifiedName,
-    source: Source
+    source: Source,
+    useGlobalCaches: Boolean
   ): Runnable = { () =>
     startSerializing(name)
     logger.log(
@@ -267,7 +269,7 @@ class SerializationManager(compiler: Compiler) {
       cache.save(
         ModuleCache.CachedModule(ir, fixedStage, source),
         compiler.context,
-        localOnly = false
+        useGlobalCaches
       )
     } catch {
       case e: NotSerializableException =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
@@ -266,7 +266,8 @@ class SerializationManager(compiler: Compiler) {
         } else stage
       cache.save(
         ModuleCache.CachedModule(ir, fixedStage, source),
-        compiler.context
+        compiler.context,
+        localOnly = false
       )
     } catch {
       case e: NotSerializableException =>

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
@@ -23,7 +23,7 @@ case class SourceFile[F](qualifiedName: QualifiedName, file: F)
   *
   * @param root the root directory of this package
   * @param config the metadata contained in the package configuration
-  *  @param fileSystem the file system access module
+  * @param fileSystem the file system access module
   */
 case class Package[F](
   root: F,

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -45,7 +45,7 @@ import project.System.Process_Spec
 
 import project.Examples_Spec
 
-Main = Test.Suite.run_main <|
+main = Test.Suite.run_main <|
     Any_Spec.spec
     Array_Spec.spec
     Case_Spec.spec


### PR DESCRIPTION
### Pull Request Description
This PR implements the `--compile` command to the engine runner. This allows for compiling the requested library without generating truffle code or executing the library. It writes the compiled IR to the cache for later loading.

The CI pipeline 

### Important Notes
The changes to the release and nightly workflows have been tested on [enso-staging](https://github.com/enso-org/enso/actions/runs/1265974901).

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
