### PR TITLE
Enable Caches by Default for the Nightly Runner

### DIFF
--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -61,7 +61,7 @@ object Main {
   private lazy val logger = Logger[Main.type]
 
   private def isDevBuild: Boolean = {
-    Info.ensoVersion.matches("SNAPSHOT$")
+    Info.ensoVersion.matches(".+-SNAPSHOT$")
   }
 
   /** Builds the [[Options]] object representing the CLI syntax.

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -61,7 +61,7 @@ object Main {
   private lazy val logger = Logger[Main.type]
 
   private def isDevBuild: Boolean = {
-    Info.ensoVersion.contains("SNAPSHOT")
+    Info.ensoVersion.matches("SNAPSHOT$")
   }
 
   /** Builds the [[Options]] object representing the CLI syntax.


### PR DESCRIPTION
### Pull Request Description
Due to an insufficiently restrictive condition, the nightly runner _also_ had disabled caches. This fixes that so they're _on_ by default instead of off. This does not affect the language server, where the caches are always enabled.

### Important Notes
N/A

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/main/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/main/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
